### PR TITLE
Fix: Optimize the update logic of the default size of the `Sprite`

### DIFF
--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -45,6 +45,7 @@ export class Sprite extends RefObject {
   set texture(value: Texture2D) {
     if (this._texture !== value) {
       this._texture = value;
+      this._width = this._height = undefined;
       this._dispatchSpriteChange(SpritePropertyDirtyFlag.texture);
     }
   }
@@ -132,6 +133,7 @@ export class Sprite extends RefObject {
     const x = MathUtil.clamp(value.x, 0, 1);
     const y = MathUtil.clamp(value.y, 0, 1);
     region.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
+    this._width = this._height = undefined;
     this._dispatchSpriteChange(SpritePropertyDirtyFlag.region);
   }
 


### PR DESCRIPTION
When replacing `textures` or modifying `regions`, the `sprite` size should be updated.

Before:
```
sprite.texture = oldTexture;
// sprite.region = oldRegion;
console.log('old width',  sprite.width);
sprite.texture = newTexture;
// sprite.region = newRegion;
console.log('new width',  sprite.width);
```
**The results obtained are equal.**

But we think that at this moment the developer wants to update the width and height of the sprite.