### PR TITLE
build: set galacean global name

### DIFF
--- a/packages/galacean-engine/package.json
+++ b/packages/galacean-engine/package.json
@@ -10,13 +10,16 @@
     "b:types": "tsc"
   },
   "types": "types/index.d.ts",
-  "main": "dist/browser.min.js",
+  "main": "dist/main.js",
   "module": "dist/module.js",
-  "browser": "dist/browser.min.js",
+  "browser": "dist/browser.js",
   "files": [
     "dist/**/*",
     "types/**/*"
   ],
+  "umd": {
+    "name": "Galacean"
+  },
   "homepage": "https://oasisengine.cn/",
   "repository": {
     "url": "https://github.com/galacean/engine"

--- a/packages/physics-lite/package.json
+++ b/packages/physics-lite/package.json
@@ -14,6 +14,12 @@
   "scripts": {
     "b:types": "tsc"
   },
+  "umd": {
+    "name": "Galacean.PhysicsLite",
+    "globals": {
+      "@galacean/engine": "Galacean"
+    }
+  },
   "files": [
     "dist/**/*",
     "types/**/*"

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -15,7 +15,7 @@
     "b:types": "tsc"
   },
   "umd": {
-    "name": "Galacean.PhysicsX",
+    "name": "Galacean.PhysicsPhysX",
     "globals": {
       "@galacean/engine": "Galacean"
     }

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -14,6 +14,12 @@
   "scripts": {
     "b:types": "tsc"
   },
+  "umd": {
+    "name": "Galacean.PhysicsX",
+    "globals": {
+      "@galacean/engine": "Galacean"
+    }
+  },
   "files": [
     "dist/**/*",
     "libs/**/*",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,8 +9,6 @@ import miniProgramPlugin from "./rollup.miniprogram.plugin";
 import replace from "@rollup/plugin-replace";
 import { swc, defineRollupSwcOption, minify } from "rollup-plugin-swc3";
 
-const camelCase = require("camelcase");
-
 const { BUILD_TYPE, NODE_ENV } = process.env;
 
 const pkgsRoot = path.join(__dirname, "packages");
@@ -26,10 +24,7 @@ const pkgs = fs
     };
   });
 
-// "@galacean/engine" 、 "@galacean/engine-math" ...
-function toGlobalName(pkgName) {
-  return camelCase(pkgName);
-}
+// toGlobalName
 
 const extensions = [".js", ".jsx", ".ts", ".tsx"];
 const mainFields = NODE_ENV === "development" ? ["debug", "module", "main"] : undefined;
@@ -64,7 +59,6 @@ function config({ location, pkgJson }) {
   const input = path.join(location, "src", "index.ts");
   const dependencies = Object.assign({}, pkgJson.dependencies ?? {}, pkgJson.peerDependencies ?? {});
   const external = Object.keys(dependencies);
-  const name = pkgJson.name;
   commonPlugins.push(
     replace({
       preventAssignment: true,
@@ -74,6 +68,7 @@ function config({ location, pkgJson }) {
 
   return {
     umd: (compress) => {
+      const umdConfig = pkgJson.umd
       let file = path.join(location, "dist", "browser.js");
       const plugins = [...commonPlugins];
       if (compress) {
@@ -81,23 +76,18 @@ function config({ location, pkgJson }) {
         file = path.join(location, "dist", "browser.min.js");
       }
 
-      const globalName = toGlobalName(pkgJson.name);
-
-      const globals = {};
-      external.forEach((pkgName) => {
-        globals[pkgName] = toGlobalName(pkgName);
-      });
+      const umdExternal = Object.keys(umdConfig.globals ?? {})
 
       return {
         input,
-        external: name === "@galacean/engine" ? {} : external,
+        external: umdExternal,
         output: [
           {
             file,
-            name: globalName,
+            name: umdConfig.name,
             format: "umd",
             sourcemap: false,
-            globals
+            globals: umdConfig.globals
           }
         ],
         plugins
@@ -167,7 +157,7 @@ switch (BUILD_TYPE) {
 }
 
 function getUMD() {
-  const configs = pkgs.filter((pkg) => pkg.pkgJson.browser);
+  const configs = pkgs.filter((pkg) => pkg.pkgJson.umd);
   return configs
     .map((config) => makeRollupConfig({ ...config, type: "umd" }))
     .concat(


### PR DESCRIPTION
Related to #1458 ，目前引擎需要 umd 的包和 global name 分别是：
- `galacean-engine` 是 `Galacean`
- `physics-lite` 是 `Galacean.PhysicsLite`
- `physics-physx` 是 `Galacean.PhysicsPhysX` 

同时解决 #1313 问题