### PR TITLE
Support get `ModelMesh`  position data create by `glTF Loader` 

### DIFF
--- a/packages/loader/src/GLTFLoader.ts
+++ b/packages/loader/src/GLTFLoader.ts
@@ -37,6 +37,9 @@ export class GLTFLoader extends Loader<GLTFResource> {
  * GlTF loader params.
  */
 export interface GLTFParams {
-  /** Keep raw mesh data for glTF parser, default is false. */
+  /**
+   * @beta Now only contains vertex information, need to improve.
+   * Keep raw mesh data for glTF parser, default is false.
+   */
   keepMeshData: boolean;
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Just experimental feature, for internal validation only**
```ts
engine.resourceManager
  .load<GLTFResource>({
    url: "https://mdn.alipayobjects.com/chain_myent/afts/file/aaa.gltf",
    params: <GLTFParams>{ keepMeshData: true },
  })
  .then((gltfResource) => {
    const sss = defaultSceneRoot.getComponentsIncludeChildren( SkinnedMeshRenderer, [] );
    sss.forEach((s) => {
      console.log((<ModelMesh>s.mesh).getPositions());
 });
});

```