### PR TITLE
Unified shader property and macro name style

### DIFF
--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -17,9 +17,9 @@ import { Sprite } from "./Sprite";
  */
 export class SpriteMask extends Renderer implements ICustomClone {
   /** @internal */
-  static _textureProperty: ShaderProperty = ShaderProperty.getByName("u_maskTexture");
+  static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_MaskTexture");
   /** @internal */
-  static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("u_maskAlphaCutoff");
+  static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("galacean_MaskAlphaCutoff");
 
   /** The mask layers the sprite mask influence to. */
   @assignmentClone

--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -17,9 +17,9 @@ import { Sprite } from "./Sprite";
  */
 export class SpriteMask extends Renderer implements ICustomClone {
   /** @internal */
-  static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_MaskTexture");
+  static _textureProperty: ShaderProperty = ShaderProperty.getByName("renderer_MaskTexture");
   /** @internal */
-  static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("galacean_MaskAlphaCutoff");
+  static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("renderer_MaskAlphaCutoff");
 
   /** The mask layers the sprite mask influence to. */
   @assignmentClone

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -23,7 +23,7 @@ import { Sprite } from "./Sprite";
  */
 export class SpriteRenderer extends Renderer implements ICustomClone {
   /** @internal */
-  static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpriteTexture");
+  static _textureProperty: ShaderProperty = ShaderProperty.getByName("renderer_SpriteTexture");
 
   /** @internal */
   @ignoreClone

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -23,7 +23,7 @@ import { Sprite } from "./Sprite";
  */
 export class SpriteRenderer extends Renderer implements ICustomClone {
   /** @internal */
-  static _textureProperty: ShaderProperty = ShaderProperty.getByName("u_spriteTexture");
+  static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpriteTexture");
 
   /** @internal */
   @ignoreClone

--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -49,7 +49,7 @@ export class Background {
   set texture(value: Texture2D) {
     if (this._texture !== value) {
       this._texture = value;
-      this._engine._backgroundTextureMaterial.shaderData.setTexture("u_baseTexture", value);
+      this._engine._backgroundTextureMaterial.shaderData.setTexture("material_BaseTexture", value);
     }
   }
 

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -32,9 +32,9 @@ class MathTemp {
 @dependentComponents(Transform, DependentMode.CheckOnly)
 export class Camera extends Component {
   /** @internal */
-  private static _inverseViewMatrixProperty = ShaderProperty.getByName("u_viewInvMat");
+  private static _inverseViewMatrixProperty = ShaderProperty.getByName("galacean_ViewInvMat");
   /** @internal */
-  private static _cameraPositionProperty = ShaderProperty.getByName("u_cameraPos");
+  private static _cameraPositionProperty = ShaderProperty.getByName("galacean_CameraPos");
 
   /** Shader data. */
   readonly shaderData: ShaderData = new ShaderData(ShaderDataGroup.Camera);

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -32,9 +32,9 @@ class MathTemp {
 @dependentComponents(Transform, DependentMode.CheckOnly)
 export class Camera extends Component {
   /** @internal */
-  private static _inverseViewMatrixProperty = ShaderProperty.getByName("galacean_ViewInvMat");
+  private static _inverseViewMatrixProperty = ShaderProperty.getByName("camera_ViewInvMat");
   /** @internal */
-  private static _cameraPositionProperty = ShaderProperty.getByName("galacean_CameraPos");
+  private static _cameraPositionProperty = ShaderProperty.getByName("camera_Position");
 
   /** Shader data. */
   readonly shaderData: ShaderData = new ShaderData(ShaderDataGroup.Camera);

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -47,9 +47,9 @@ ShaderPool.init();
  */
 export class Engine extends EventDispatcher {
   /** @internal */
-  static _gammaMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_COLORSPACE_GAMMA");
+  static _gammaMacro: ShaderMacro = ShaderMacro.getByName("ENGINE_IS_COLORSPACE_GAMMA");
   /** @internal */
-  static _noDepthTextureMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_NO_DEPTH_TEXTURE");
+  static _noDepthTextureMacro: ShaderMacro = ShaderMacro.getByName("ENGINE_NO_DEPTH_TEXTURE");
   /** @internal Conversion of space units to pixel units for 2D. */
   static _pixelsPerUnit: number = 100;
 
@@ -250,7 +250,7 @@ export class Engine extends EventDispatcher {
     }
 
     const magentaMaterial = new Material(this, Shader.find("unlit"));
-    magentaMaterial.shaderData.setColor("u_baseColor", new Color(1.0, 0.0, 1.01, 1.0));
+    magentaMaterial.shaderData.setColor("material_BaseColor", new Color(1.0, 0.0, 1.01, 1.0));
     this._magentaMaterial = magentaMaterial;
 
     const backgroundTextureMaterial = new Material(this, Shader.find("background-texture"));

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -47,9 +47,9 @@ ShaderPool.init();
  */
 export class Engine extends EventDispatcher {
   /** @internal */
-  static _gammaMacro: ShaderMacro = ShaderMacro.getByName("OASIS_COLORSPACE_GAMMA");
+  static _gammaMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_COLORSPACE_GAMMA");
   /** @internal */
-  static _noDepthTextureMacro: ShaderMacro = ShaderMacro.getByName("OASIS_NO_DEPTH_TEXTURE");
+  static _noDepthTextureMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_NO_DEPTH_TEXTURE");
   /** @internal Conversion of space units to pixel units for 2D. */
   static _pixelsPerUnit: number = 100;
 

--- a/packages/core/src/RenderPipeline/RenderContext.ts
+++ b/packages/core/src/RenderPipeline/RenderContext.ts
@@ -8,11 +8,11 @@ import { VirtualCamera } from "../VirtualCamera";
  * Rendering context.
  */
 export class RenderContext {
-  static vpMatrixProperty = ShaderProperty.getByName("u_VPMat");
+  static vpMatrixProperty = ShaderProperty.getByName("galacean_VPMat");
   static pipelineStageKey: ShaderTagKey = ShaderTagKey.getByName("pipelineStage");
 
-  private static _viewMatrixProperty = ShaderProperty.getByName("u_viewMat");
-  private static _projectionMatrixProperty = ShaderProperty.getByName("u_projMat");
+  private static _viewMatrixProperty = ShaderProperty.getByName("galacean_ViewMat");
+  private static _projectionMatrixProperty = ShaderProperty.getByName("galacean_ProjMat");
 
   camera: Camera;
   virtualCamera: VirtualCamera;

--- a/packages/core/src/RenderPipeline/RenderContext.ts
+++ b/packages/core/src/RenderPipeline/RenderContext.ts
@@ -8,11 +8,11 @@ import { VirtualCamera } from "../VirtualCamera";
  * Rendering context.
  */
 export class RenderContext {
-  static vpMatrixProperty = ShaderProperty.getByName("galacean_VPMat");
+  static vpMatrixProperty = ShaderProperty.getByName("camera_VPMat");
   static pipelineStageKey: ShaderTagKey = ShaderTagKey.getByName("pipelineStage");
 
-  private static _viewMatrixProperty = ShaderProperty.getByName("galacean_ViewMat");
-  private static _projectionMatrixProperty = ShaderProperty.getByName("galacean_ProjMat");
+  private static _viewMatrixProperty = ShaderProperty.getByName("camera_ViewMat");
+  private static _projectionMatrixProperty = ShaderProperty.getByName("camera_ProjMat");
 
   camera: Camera;
   virtualCamera: VirtualCamera;

--- a/packages/core/src/RenderPipeline/SpriteBatcher.ts
+++ b/packages/core/src/RenderPipeline/SpriteBatcher.ts
@@ -14,7 +14,7 @@ import { SpriteRenderData } from "./SpriteRenderData";
  * @internal
  */
 export class SpriteBatcher extends Basic2DBatcher {
-  private static _textureProperty: ShaderProperty = ShaderProperty.getByName("u_spriteTexture");
+  private static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpriteTexture");
 
   createVertexElements(vertexElements: VertexElement[]): number {
     vertexElements[0] = new VertexElement("POSITION", 0, VertexElementFormat.Vector3, 0);

--- a/packages/core/src/RenderPipeline/SpriteBatcher.ts
+++ b/packages/core/src/RenderPipeline/SpriteBatcher.ts
@@ -14,7 +14,7 @@ import { SpriteRenderData } from "./SpriteRenderData";
  * @internal
  */
 export class SpriteBatcher extends Basic2DBatcher {
-  private static _textureProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpriteTexture");
+  private static _textureProperty: ShaderProperty = ShaderProperty.getByName("renderer_SpriteTexture");
 
   createVertexElements(vertexElements: VertexElement[]): number {
     vertexElements[0] = new VertexElement("POSITION", 0, VertexElementFormat.Vector3, 0);

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -20,14 +20,14 @@ import { Material } from "./material";
 export class Renderer extends Component {
   private static _tempVector0 = new Vector3();
 
-  private static _receiveShadowMacro = ShaderMacro.getByName("GALACEAN_RECEIVE_SHADOWS");
-  private static _localMatrixProperty = ShaderProperty.getByName("galacean_LocalMat");
-  private static _worldMatrixProperty = ShaderProperty.getByName("galacean_ModelMat");
-  private static _mvMatrixProperty = ShaderProperty.getByName("galacean_MVMat");
-  private static _mvpMatrixProperty = ShaderProperty.getByName("galacean_MVPMat");
-  private static _mvInvMatrixProperty = ShaderProperty.getByName("galacean_MVInvMat");
-  private static _normalMatrixProperty = ShaderProperty.getByName("galacean_NormalMat");
-  private static _rendererLayerProperty = ShaderProperty.getByName("galacean_RendererLayer");
+  private static _receiveShadowMacro = ShaderMacro.getByName("RENDERER_IS_RECEIVE_SHADOWS");
+  private static _localMatrixProperty = ShaderProperty.getByName("renderer_LocalMat");
+  private static _worldMatrixProperty = ShaderProperty.getByName("renderer_ModelMat");
+  private static _mvMatrixProperty = ShaderProperty.getByName("renderer_MVMat");
+  private static _mvpMatrixProperty = ShaderProperty.getByName("renderer_MVPMat");
+  private static _mvInvMatrixProperty = ShaderProperty.getByName("renderer_MVInvMat");
+  private static _normalMatrixProperty = ShaderProperty.getByName("renderer_NormalMat");
+  private static _rendererLayerProperty = ShaderProperty.getByName("renderer_Layer");
 
   /** ShaderData related to renderer. */
   @deepClone

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -20,13 +20,13 @@ import { Material } from "./material";
 export class Renderer extends Component {
   private static _tempVector0 = new Vector3();
 
-  private static _receiveShadowMacro = ShaderMacro.getByName("OASIS_RECEIVE_SHADOWS");
-  private static _localMatrixProperty = ShaderProperty.getByName("u_localMat");
-  private static _worldMatrixProperty = ShaderProperty.getByName("u_modelMat");
-  private static _mvMatrixProperty = ShaderProperty.getByName("u_MVMat");
-  private static _mvpMatrixProperty = ShaderProperty.getByName("u_MVPMat");
-  private static _mvInvMatrixProperty = ShaderProperty.getByName("u_MVInvMat");
-  private static _normalMatrixProperty = ShaderProperty.getByName("u_normalMat");
+  private static _receiveShadowMacro = ShaderMacro.getByName("GALACEAN_RECEIVE_SHADOWS");
+  private static _localMatrixProperty = ShaderProperty.getByName("galacean_LocalMat");
+  private static _worldMatrixProperty = ShaderProperty.getByName("galacean_ModelMat");
+  private static _mvMatrixProperty = ShaderProperty.getByName("galacean_MVMat");
+  private static _mvpMatrixProperty = ShaderProperty.getByName("galacean_MVPMat");
+  private static _mvInvMatrixProperty = ShaderProperty.getByName("galacean_MVInvMat");
+  private static _normalMatrixProperty = ShaderProperty.getByName("galacean_NormalMat");
   private static _rendererLayerProperty = ShaderProperty.getByName("galacean_RendererLayer");
 
   /** ShaderData related to renderer. */

--- a/packages/core/src/Scene.ts
+++ b/packages/core/src/Scene.ts
@@ -19,10 +19,10 @@ import { ShadowType } from "./shadow/enum/ShadowType";
  * Scene.
  */
 export class Scene extends EngineObject {
-  private static _fogColorProperty = ShaderProperty.getByName("galacean_FogColor");
-  private static _fogParamsProperty = ShaderProperty.getByName("galacean_FogParams");
-  private static _sunlightColorProperty = ShaderProperty.getByName("galacean_SunlightColor");
-  private static _sunlightDirectionProperty = ShaderProperty.getByName("galacean_SunlightDirection");
+  private static _fogColorProperty = ShaderProperty.getByName("scene_FogColor");
+  private static _fogParamsProperty = ShaderProperty.getByName("scene_FogParams");
+  private static _sunlightColorProperty = ShaderProperty.getByName("scene_SunlightColor");
+  private static _sunlightDirectionProperty = ShaderProperty.getByName("scene_SunlightDirection");
 
   /** Scene name. */
   name: string;

--- a/packages/core/src/Scene.ts
+++ b/packages/core/src/Scene.ts
@@ -72,7 +72,7 @@ export class Scene extends EngineObject {
 
   set shadowCascades(value: ShadowCascadesMode) {
     if (this._shadowCascades !== value) {
-      this.shaderData.enableMacro("CASCADED_COUNT", value.toString());
+      this.shaderData.enableMacro("SCENE_SHADOW_CASCADED_COUNT", value.toString());
       this._shadowCascades = value;
     }
   }
@@ -112,7 +112,7 @@ export class Scene extends EngineObject {
 
   set fogMode(value: FogMode) {
     if (this._fogMode !== value) {
-      this.shaderData.enableMacro("GALACEAN_FOG_MODE", value.toString());
+      this.shaderData.enableMacro("SCENE_FOG_MODE", value.toString());
       this._fogMode = value;
     }
   }
@@ -200,8 +200,8 @@ export class Scene extends EngineObject {
     this.ambientLight = new AmbientLight();
     engine.sceneManager._allScenes.push(this);
 
-    shaderData.enableMacro("GALACEAN_FOG_MODE", this._fogMode.toString());
-    shaderData.enableMacro("CASCADED_COUNT", this.shadowCascades.toString());
+    shaderData.enableMacro("SCENE_FOG_MODE", this._fogMode.toString());
+    shaderData.enableMacro("SCENE_SHADOW_CASCADED_COUNT", this.shadowCascades.toString());
     shaderData.setColor(Scene._fogColorProperty, this._fogColor);
     shaderData.setVector4(Scene._fogParamsProperty, this._fogParams);
 
@@ -397,9 +397,9 @@ export class Scene extends EngineObject {
     }
 
     if (this.castShadows && this._sunLight && this._sunLight.shadowType !== ShadowType.None) {
-      shaderData.enableMacro("SHADOW_TYPE", this._sunLight.shadowType.toString());
+      shaderData.enableMacro("SCENE_SHADOW_TYPE", this._sunLight.shadowType.toString());
     } else {
-      shaderData.disableMacro("SHADOW_TYPE");
+      shaderData.disableMacro("SCENE_SHADOW_TYPE");
     }
 
     // union scene and camera macro.

--- a/packages/core/src/base/Time.ts
+++ b/packages/core/src/base/Time.ts
@@ -6,8 +6,8 @@ import { ShaderProperty } from "../shader/ShaderProperty";
  * Provide time related information.
  */
 export class Time {
-  private static _elapsedTimeProperty = ShaderProperty.getByName("galacean_ElapsedTime");
-  private static _deltaTimeProperty = ShaderProperty.getByName("galacean_DeltaTime");
+  private static _elapsedTimeProperty = ShaderProperty.getByName("scene_ElapsedTime");
+  private static _deltaTimeProperty = ShaderProperty.getByName("scene_DeltaTime");
 
   private _frameCount: number = 0;
   private _deltaTime: number = 0;

--- a/packages/core/src/lighting/AmbientLight.ts
+++ b/packages/core/src/lighting/AmbientLight.ts
@@ -10,18 +10,18 @@ import { DiffuseMode } from "./enums/DiffuseMode";
  * Ambient light.
  */
 export class AmbientLight {
-  private static _shMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_USE_SH");
-  private static _specularMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_USE_SPECULAR_ENV");
-  private static _decodeRGBMMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_DECODE_ENV_RGBM");
+  private static _shMacro: ShaderMacro = ShaderMacro.getByName("SCENE_USE_SH");
+  private static _specularMacro: ShaderMacro = ShaderMacro.getByName("SCENE_USE_SPECULAR_ENV");
+  private static _decodeRGBMMacro: ShaderMacro = ShaderMacro.getByName("SCENE_IS_DECODE_ENV_RGBM");
 
-  private static _diffuseColorProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.diffuse");
-  private static _diffuseSHProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvSH");
-  private static _diffuseIntensityProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.diffuseIntensity");
-  private static _specularTextureProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvSpecularSampler");
+  private static _diffuseColorProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvMapLight.diffuse");
+  private static _diffuseSHProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvSH");
+  private static _diffuseIntensityProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvMapLight.diffuseIntensity");
+  private static _specularTextureProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvSpecularSampler");
   private static _specularIntensityProperty: ShaderProperty = ShaderProperty.getByName(
-    "galacean_EnvMapLight.specularIntensity"
+    "scene_EnvMapLight.specularIntensity"
   );
-  private static _mipLevelProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.mipMapLevel");
+  private static _mipLevelProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvMapLight.mipMapLevel");
 
   private _diffuseSphericalHarmonics: SphericalHarmonics3;
   private _diffuseSolidColor: Color = new Color(0.212, 0.227, 0.259);

--- a/packages/core/src/lighting/AmbientLight.ts
+++ b/packages/core/src/lighting/AmbientLight.ts
@@ -10,18 +10,18 @@ import { DiffuseMode } from "./enums/DiffuseMode";
  * Ambient light.
  */
 export class AmbientLight {
-  private static _shMacro: ShaderMacro = ShaderMacro.getByName("O3_USE_SH");
-  private static _specularMacro: ShaderMacro = ShaderMacro.getByName("O3_USE_SPECULAR_ENV");
-  private static _decodeRGBMMacro: ShaderMacro = ShaderMacro.getByName("O3_DECODE_ENV_RGBM");
+  private static _shMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_USE_SH");
+  private static _specularMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_USE_SPECULAR_ENV");
+  private static _decodeRGBMMacro: ShaderMacro = ShaderMacro.getByName("GALACEAN_DECODE_ENV_RGBM");
 
-  private static _diffuseColorProperty: ShaderProperty = ShaderProperty.getByName("u_envMapLight.diffuse");
-  private static _diffuseSHProperty: ShaderProperty = ShaderProperty.getByName("u_env_sh");
-  private static _diffuseIntensityProperty: ShaderProperty = ShaderProperty.getByName("u_envMapLight.diffuseIntensity");
-  private static _specularTextureProperty: ShaderProperty = ShaderProperty.getByName("u_env_specularSampler");
+  private static _diffuseColorProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.diffuse");
+  private static _diffuseSHProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvSH");
+  private static _diffuseIntensityProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.diffuseIntensity");
+  private static _specularTextureProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvSpecularSampler");
   private static _specularIntensityProperty: ShaderProperty = ShaderProperty.getByName(
-    "u_envMapLight.specularIntensity"
+    "galacean_EnvMapLight.specularIntensity"
   );
-  private static _mipLevelProperty: ShaderProperty = ShaderProperty.getByName("u_envMapLight.mipMapLevel");
+  private static _mipLevelProperty: ShaderProperty = ShaderProperty.getByName("galacean_EnvMapLight.mipMapLevel");
 
   private _diffuseSphericalHarmonics: SphericalHarmonics3;
   private _diffuseSolidColor: Color = new Color(0.212, 0.227, 0.259);

--- a/packages/core/src/lighting/DirectLight.ts
+++ b/packages/core/src/lighting/DirectLight.ts
@@ -7,9 +7,9 @@ import { Light } from "./Light";
  * Directional light.
  */
 export class DirectLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("u_directLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("u_directLightColor");
-  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("u_directLightDirection");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightColor");
+  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightDirection");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/lighting/DirectLight.ts
+++ b/packages/core/src/lighting/DirectLight.ts
@@ -7,9 +7,9 @@ import { Light } from "./Light";
  * Directional light.
  */
 export class DirectLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightColor");
-  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("galacean_DirectLightDirection");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("scene_DirectLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("scene_DirectLightColor");
+  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("scene_DirectLightDirection");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/lighting/LightManager.ts
+++ b/packages/core/src/lighting/LightManager.ts
@@ -126,23 +126,23 @@ export class LightManager {
 
     if (directLightCount) {
       DirectLight._updateShaderData(shaderData);
-      shaderData.enableMacro("O3_DIRECT_LIGHT_COUNT", directLightCount.toString());
+      shaderData.enableMacro("SCENE_DIRECT_LIGHT_COUNT", directLightCount.toString());
     } else {
-      shaderData.disableMacro("O3_DIRECT_LIGHT_COUNT");
+      shaderData.disableMacro("SCENE_DIRECT_LIGHT_COUNT");
     }
 
     if (pointLightCount) {
       PointLight._updateShaderData(shaderData);
-      shaderData.enableMacro("O3_POINT_LIGHT_COUNT", pointLightCount.toString());
+      shaderData.enableMacro("SCENE_POINT_LIGHT_COUNT", pointLightCount.toString());
     } else {
-      shaderData.disableMacro("O3_POINT_LIGHT_COUNT");
+      shaderData.disableMacro("SCENE_POINT_LIGHT_COUNT");
     }
 
     if (spotLightCount) {
       SpotLight._updateShaderData(shaderData);
-      shaderData.enableMacro("O3_SPOT_LIGHT_COUNT", spotLightCount.toString());
+      shaderData.enableMacro("SCENE_SPOT_LIGHT_COUNT", spotLightCount.toString());
     } else {
-      shaderData.disableMacro("O3_SPOT_LIGHT_COUNT");
+      shaderData.disableMacro("SCENE_SPOT_LIGHT_COUNT");
     }
   }
 }

--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -7,10 +7,10 @@ import { Light } from "./Light";
  * Point light.
  */
 export class PointLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("u_pointLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("u_pointLightColor");
-  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("u_pointLightPosition");
-  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("u_pointLightDistance");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightColor");
+  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightPosition");
+  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightDistance");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -7,10 +7,10 @@ import { Light } from "./Light";
  * Point light.
  */
 export class PointLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightColor");
-  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightPosition");
-  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("galacean_PointLightDistance");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("scene_PointLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("scene_PointLightColor");
+  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("scene_PointLightPosition");
+  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("scene_PointLightDistance");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/lighting/SpotLight.ts
+++ b/packages/core/src/lighting/SpotLight.ts
@@ -7,13 +7,13 @@ import { Light } from "./Light";
  * Spot light.
  */
 export class SpotLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightColor");
-  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightPosition");
-  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightDirection");
-  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightDistance");
-  private static _angleCosProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightAngleCos");
-  private static _penumbraCosProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightPenumbraCos");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightColor");
+  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightPosition");
+  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightDirection");
+  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightDistance");
+  private static _angleCosProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightAngleCos");
+  private static _penumbraCosProperty: ShaderProperty = ShaderProperty.getByName("scene_SpotLightPenumbraCos");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/lighting/SpotLight.ts
+++ b/packages/core/src/lighting/SpotLight.ts
@@ -7,13 +7,13 @@ import { Light } from "./Light";
  * Spot light.
  */
 export class SpotLight extends Light {
-  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightCullingMask");
-  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightColor");
-  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightPosition");
-  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightDirection");
-  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightDistance");
-  private static _angleCosProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightAngleCos");
-  private static _penumbraCosProperty: ShaderProperty = ShaderProperty.getByName("u_spotLightPenumbraCos");
+  private static _cullingMaskProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightCullingMask");
+  private static _colorProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightColor");
+  private static _positionProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightPosition");
+  private static _directionProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightDirection");
+  private static _distanceProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightDistance");
+  private static _angleCosProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightAngleCos");
+  private static _penumbraCosProperty: ShaderProperty = ShaderProperty.getByName("galacean_SpotLightPenumbraCos");
 
   private static _combinedData = {
     cullingMask: new Int32Array(Light._maxLight * 2),

--- a/packages/core/src/material/BaseMaterial.ts
+++ b/packages/core/src/material/BaseMaterial.ts
@@ -8,20 +8,22 @@ import { RenderFace } from "./enums/RenderFace";
 import { Material } from "./Material";
 
 export class BaseMaterial extends Material {
-  protected static _baseColorProp: ShaderProperty = ShaderProperty.getByName("u_baseColor");
-  protected static _baseTextureProp: ShaderProperty = ShaderProperty.getByName("u_baseTexture");
-  protected static _baseTextureMacro: ShaderMacro = ShaderMacro.getByName("BASETEXTURE");
-  protected static _tilingOffsetProp: ShaderProperty = ShaderProperty.getByName("u_tilingOffset");
-  protected static _normalTextureProp: ShaderProperty = ShaderProperty.getByName("u_normalTexture");
-  protected static _normalIntensityProp: ShaderProperty = ShaderProperty.getByName("u_normalIntensity");
-  protected static _normalTextureMacro: ShaderMacro = ShaderMacro.getByName("NORMALTEXTURE");
-  protected static _emissiveColorProp: ShaderProperty = ShaderProperty.getByName("u_emissiveColor");
-  protected static _emissiveTextureProp: ShaderProperty = ShaderProperty.getByName("u_emissiveTexture");
-  protected static _emissiveTextureMacro: ShaderMacro = ShaderMacro.getByName("EMISSIVETEXTURE");
-  protected static _transparentMacro: ShaderMacro = ShaderMacro.getByName("OASIS_TRANSPARENT");
+  protected static _baseTextureMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_HAS_BASETEXTURE");
+  protected static _normalTextureMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_HAS_NORMALTEXTURE");
+  protected static _emissiveTextureMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_HAS_EMISSIVETEXTURE");
+  protected static _transparentMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_IS_TRANSPARENT");
 
-  private static _alphaCutoffProp = ShaderProperty.getByName("u_alphaCutoff");
-  private static _alphaCutoffMacro: ShaderMacro = ShaderMacro.getByName("ALPHA_CUTOFF");
+  protected static _baseColorProp: ShaderProperty = ShaderProperty.getByName("material_BaseColor");
+  protected static _baseTextureProp: ShaderProperty = ShaderProperty.getByName("material_BaseTexture");
+  protected static _tilingOffsetProp: ShaderProperty = ShaderProperty.getByName("material_TilingOffset");
+  protected static _normalTextureProp: ShaderProperty = ShaderProperty.getByName("material_NormalTexture");
+  protected static _normalIntensityProp: ShaderProperty = ShaderProperty.getByName("material_NormalIntensity");
+  protected static _emissiveColorProp: ShaderProperty = ShaderProperty.getByName("material_EmissiveColor");
+  protected static _emissiveTextureProp: ShaderProperty = ShaderProperty.getByName("material_EmissiveTexture");
+
+
+  private static _alphaCutoffProp:ShaderProperty = ShaderProperty.getByName("material_AlphaCutoff");
+  private static _alphaCutoffMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_IS_ALPHA_CUTOFF");
 
   private _renderFace: RenderFace = RenderFace.Front;
   private _isTransparent: boolean = false;

--- a/packages/core/src/material/BlinnPhongMaterial.ts
+++ b/packages/core/src/material/BlinnPhongMaterial.ts
@@ -67,9 +67,9 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set specularTexture(value: Texture2D) {
     this.shaderData.setTexture(BlinnPhongMaterial._specularTextureProp, value);
     if (value) {
-      this.shaderData.enableMacro("MATERIAL_SPECULAR_TEXTURE");
+      this.shaderData.enableMacro("MATERIAL_HAS_SPECULAR_TEXTURE");
     } else {
-      this.shaderData.disableMacro("MATERIAL_SPECULAR_TEXTURE");
+      this.shaderData.disableMacro("MATERIAL_HAS_SPECULAR_TEXTURE");
     }
   }
 

--- a/packages/core/src/material/BlinnPhongMaterial.ts
+++ b/packages/core/src/material/BlinnPhongMaterial.ts
@@ -9,9 +9,9 @@ import { BaseMaterial } from "./BaseMaterial";
  * Blinn-phong Material.
  */
 export class BlinnPhongMaterial extends BaseMaterial {
-  private static _specularColorProp = ShaderProperty.getByName("u_specularColor");
-  private static _shininessProp = ShaderProperty.getByName("u_shininess");
-  private static _specularTextureProp = ShaderProperty.getByName("u_specularTexture");
+  private static _specularColorProp = ShaderProperty.getByName("material_SpecularColor");
+  private static _shininessProp = ShaderProperty.getByName("material_Shininess");
+  private static _specularTextureProp = ShaderProperty.getByName("material_SpecularTexture");
 
   /**
    * Base color.
@@ -164,8 +164,8 @@ export class BlinnPhongMaterial extends BaseMaterial {
 
     const shaderData = this.shaderData;
 
-    shaderData.enableMacro("O3_NEED_WORLDPOS");
-    shaderData.enableMacro("O3_NEED_TILINGOFFSET");
+    shaderData.enableMacro("MATERIAL_NEED_WORLDPOS");
+    shaderData.enableMacro("MATERIAL_NEED_TILINGOFFSET");
 
     shaderData.setColor(BlinnPhongMaterial._baseColorProp, new Color(1, 1, 1, 1));
     shaderData.setColor(BlinnPhongMaterial._specularColorProp, new Color(1, 1, 1, 1));

--- a/packages/core/src/material/BlinnPhongMaterial.ts
+++ b/packages/core/src/material/BlinnPhongMaterial.ts
@@ -67,9 +67,9 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set specularTexture(value: Texture2D) {
     this.shaderData.setTexture(BlinnPhongMaterial._specularTextureProp, value);
     if (value) {
-      this.shaderData.enableMacro("O3_SPECULAR_TEXTURE");
+      this.shaderData.enableMacro("MATERIAL_SPECULAR_TEXTURE");
     } else {
-      this.shaderData.disableMacro("O3_SPECULAR_TEXTURE");
+      this.shaderData.disableMacro("MATERIAL_SPECULAR_TEXTURE");
     }
   }
 

--- a/packages/core/src/material/PBRBaseMaterial.ts
+++ b/packages/core/src/material/PBRBaseMaterial.ts
@@ -10,15 +10,15 @@ import { TextureCoordinate } from "./enums/TextureCoordinate";
  * PBR (Physically-Based Rendering) Material.
  */
 export abstract class PBRBaseMaterial extends BaseMaterial {
-  private static _occlusionTextureIntensityProp = ShaderProperty.getByName("u_occlusionIntensity");
-  private static _occlusionTextureCoordProp = ShaderProperty.getByName("u_occlusionTextureCoord");
-  private static _occlusionTextureProp = ShaderProperty.getByName("u_occlusionTexture");
+  private static _occlusionTextureIntensityProp = ShaderProperty.getByName("material_OcclusionIntensity");
+  private static _occlusionTextureCoordProp = ShaderProperty.getByName("material_OcclusionTextureCoord");
+  private static _occlusionTextureProp = ShaderProperty.getByName("material_OcclusionTexture");
 
-  private static _clearCoatProp = ShaderProperty.getByName("u_clearCoat");
-  private static _clearCoatTextureProp = ShaderProperty.getByName("u_clearCoatTexture");
-  private static _clearCoatRoughnessProp = ShaderProperty.getByName("u_clearCoatRoughness");
-  private static _clearCoatRoughnessTextureProp = ShaderProperty.getByName("u_clearCoatRoughnessTexture");
-  private static _clearCoatNormalTextureProp = ShaderProperty.getByName("u_clearCoatNormalTexture");
+  private static _clearCoatProp = ShaderProperty.getByName("material_ClearCoat");
+  private static _clearCoatTextureProp = ShaderProperty.getByName("material_ClearCoatTexture");
+  private static _clearCoatRoughnessProp = ShaderProperty.getByName("material_ClearCoatRoughness");
+  private static _clearCoatRoughnessTextureProp = ShaderProperty.getByName("material_ClearCoatRoughnessTexture");
+  private static _clearCoatNormalTextureProp = ShaderProperty.getByName("material_ClearCoatNormalTexture");
 
   /**
    * Base color.
@@ -253,8 +253,8 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
 
     const shaderData = this.shaderData;
 
-    shaderData.enableMacro("O3_NEED_WORLDPOS");
-    shaderData.enableMacro("O3_NEED_TILINGOFFSET");
+    shaderData.enableMacro("MATERIAL_NEED_WORLDPOS");
+    shaderData.enableMacro("MATERIAL_NEED_TILINGOFFSET");
 
     shaderData.setColor(PBRBaseMaterial._baseColorProp, new Color(1, 1, 1, 1));
     shaderData.setColor(PBRBaseMaterial._emissiveColorProp, new Color(0, 0, 0, 1));

--- a/packages/core/src/material/PBRMaterial.ts
+++ b/packages/core/src/material/PBRMaterial.ts
@@ -45,9 +45,9 @@ export class PBRMaterial extends PBRBaseMaterial {
   set roughnessMetallicTexture(value: Texture2D) {
     this.shaderData.setTexture(PBRMaterial._roughnessMetallicTextureProp, value);
     if (value) {
-      this.shaderData.enableMacro("ROUGHNESSMETALLICTEXTURE");
+      this.shaderData.enableMacro("MATERIAL_ROUGHNESSMETALLICTEXTURE");
     } else {
-      this.shaderData.disableMacro("ROUGHNESSMETALLICTEXTURE");
+      this.shaderData.disableMacro("MATERIAL_ROUGHNESSMETALLICTEXTURE");
     }
   }
 

--- a/packages/core/src/material/PBRMaterial.ts
+++ b/packages/core/src/material/PBRMaterial.ts
@@ -8,9 +8,9 @@ import { PBRBaseMaterial } from "./PBRBaseMaterial";
  * PBR (Metallic-Roughness Workflow) Material.
  */
 export class PBRMaterial extends PBRBaseMaterial {
-  private static _metallicProp = ShaderProperty.getByName("u_metal");
-  private static _roughnessProp = ShaderProperty.getByName("u_roughness");
-  private static _roughnessMetallicTextureProp = ShaderProperty.getByName("u_roughnessMetallicTexture");
+  private static _metallicProp = ShaderProperty.getByName("material_Metal");
+  private static _roughnessProp = ShaderProperty.getByName("material_Roughness");
+  private static _roughnessMetallicTextureProp = ShaderProperty.getByName("material_RoughnessMetallicTexture");
 
   /**
    * Metallic, default 1.0.

--- a/packages/core/src/material/PBRSpecularMaterial.ts
+++ b/packages/core/src/material/PBRSpecularMaterial.ts
@@ -10,10 +10,10 @@ import { PBRBaseMaterial } from "./PBRBaseMaterial";
  * PBR (Specular-Glossiness Workflow) Material.
  */
 export class PBRSpecularMaterial extends PBRBaseMaterial {
-  private static _specularColorProp = ShaderProperty.getByName("u_PBRSpecularColor");
-  private static _glossinessProp = ShaderProperty.getByName("u_glossiness");
-  private static _specularGlossinessTextureProp = ShaderProperty.getByName("u_specularGlossinessTexture");
-  private static _specularGlossinessTextureMacro: ShaderMacro = ShaderMacro.getByName("SPECULARGLOSSINESSTEXTURE");
+  private static _specularColorProp = ShaderProperty.getByName("material_PBRSpecularColor");
+  private static _glossinessProp = ShaderProperty.getByName("material_Glossiness");
+  private static _specularGlossinessTextureProp = ShaderProperty.getByName("material_SpecularGlossinessTexture");
+  private static _specularGlossinessTextureMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_HAS_SPECULARGLOSSINESSTEXTURE");
 
   /**
    * Specular color.

--- a/packages/core/src/material/UnlitMaterial.ts
+++ b/packages/core/src/material/UnlitMaterial.ts
@@ -61,8 +61,8 @@ export class UnlitMaterial extends BaseMaterial {
 
     const shaderData = this.shaderData;
 
-    shaderData.enableMacro("OMIT_NORMAL");
-    shaderData.enableMacro("O3_NEED_TILINGOFFSET");
+    shaderData.enableMacro("MATERIAL_OMIT_NORMAL");
+    shaderData.enableMacro("MATERIAL_NEED_TILINGOFFSET");
 
     shaderData.setColor(UnlitMaterial._baseColorProp, new Color(1, 1, 1, 1));
     shaderData.setVector4(UnlitMaterial._tilingOffsetProp, new Vector4(1, 1, 0, 0));

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -19,14 +19,14 @@ import { SkinnedMeshRenderer } from "./SkinnedMeshRenderer";
  * @internal
  */
 export class BlendShapeManager {
-  private static _blendShapeMacro = ShaderMacro.getByName("OASIS_BLENDSHAPE");
-  private static _blendShapeTextureMacro = ShaderMacro.getByName("OASIS_BLENDSHAPE_TEXTURE");
-  private static _blendShapeNormalMacro = ShaderMacro.getByName("OASIS_BLENDSHAPE_NORMAL");
-  private static _blendShapeTangentMacro = ShaderMacro.getByName("OASIS_BLENDSHAPE_TANGENT");
+  private static _blendShapeMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE");
+  private static _blendShapeTextureMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_TEXTURE");
+  private static _blendShapeNormalMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_NORMAL");
+  private static _blendShapeTangentMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_TANGENT");
 
-  private static _blendShapeWeightsProperty = ShaderProperty.getByName("u_blendShapeWeights");
-  private static _blendShapeTextureProperty = ShaderProperty.getByName("u_blendShapeTexture");
-  private static _blendShapeTextureInfoProperty = ShaderProperty.getByName("u_blendShapeTextureInfo");
+  private static _blendShapeWeightsProperty = ShaderProperty.getByName("galacean_BlendShapeWeights");
+  private static _blendShapeTextureProperty = ShaderProperty.getByName("galacean_BlendShapeTexture");
+  private static _blendShapeTextureInfoProperty = ShaderProperty.getByName("galacean_BlendShapeTextureInfo");
 
   /** @internal */
   _blendShapeCount: number = 0;

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -19,14 +19,14 @@ import { SkinnedMeshRenderer } from "./SkinnedMeshRenderer";
  * @internal
  */
 export class BlendShapeManager {
-  private static _blendShapeMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE");
-  private static _blendShapeTextureMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_TEXTURE");
-  private static _blendShapeNormalMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_NORMAL");
-  private static _blendShapeTangentMacro = ShaderMacro.getByName("GALACEAN_BLENDSHAPE_TANGENT");
+  private static _blendShapeMacro = ShaderMacro.getByName("RENDERER_HAS_BLENDSHAPE");
+  private static _blendShapeTextureMacro = ShaderMacro.getByName("RENDERER_BLENDSHAPE_USE_TEXTURE");
+  private static _blendShapeNormalMacro = ShaderMacro.getByName("RENDERER_BLENDSHAPE_HAS_NORMAL");
+  private static _blendShapeTangentMacro = ShaderMacro.getByName("RENDERER_BLENDSHAPE_HAS_TANGENT");
 
-  private static _blendShapeWeightsProperty = ShaderProperty.getByName("galacean_BlendShapeWeights");
-  private static _blendShapeTextureProperty = ShaderProperty.getByName("galacean_BlendShapeTexture");
-  private static _blendShapeTextureInfoProperty = ShaderProperty.getByName("galacean_BlendShapeTextureInfo");
+  private static _blendShapeWeightsProperty = ShaderProperty.getByName("renderer_BlendShapeWeights");
+  private static _blendShapeTextureProperty = ShaderProperty.getByName("renderer_BlendShapeTexture");
+  private static _blendShapeTextureInfoProperty = ShaderProperty.getByName("renderer_BlendShapeTextureInfo");
 
   /** @internal */
   _blendShapeCount: number = 0;

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -110,7 +110,7 @@ export class BlendShapeManager {
         shaderData.setTexture(BlendShapeManager._blendShapeTextureProperty, this._vertexTexture);
         shaderData.setVector3(BlendShapeManager._blendShapeTextureInfoProperty, this._dataTextureInfo);
         shaderData.setFloatArray(BlendShapeManager._blendShapeWeightsProperty, skinnedMeshRenderer.blendShapeWeights);
-        shaderData.enableMacro("GALACEAN_BLENDSHAPE_COUNT", blendShapeCount.toString());
+        shaderData.enableMacro("RENDERER_BLENDSHAPE_COUNT", blendShapeCount.toString());
         this._uniformOccupiesCount = blendShapeCount + 1;
       } else {
         const maxBlendCount = this._getVertexBufferModeSupportCount();
@@ -129,7 +129,7 @@ export class BlendShapeManager {
           this._modelMesh._enableVAO = true;
         }
         shaderData.disableMacro(BlendShapeManager._blendShapeTextureMacro);
-        shaderData.disableMacro("GALACEAN_BLENDSHAPE_COUNT");
+        shaderData.disableMacro("RENDERER_BLENDSHAPE_COUNT");
         this._uniformOccupiesCount = blendShapeCount;
       }
 
@@ -145,7 +145,7 @@ export class BlendShapeManager {
       }
     } else {
       shaderData.disableMacro(BlendShapeManager._blendShapeMacro);
-      shaderData.disableMacro("GALACEAN_BLENDSHAPE_COUNT");
+      shaderData.disableMacro("RENDERER_BLENDSHAPE_COUNT");
     }
   }
 

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -12,11 +12,11 @@ import { ShaderMacro } from "../shader/ShaderMacro";
  * MeshRenderer Component.
  */
 export class MeshRenderer extends Renderer implements ICustomClone {
-  private static _uvMacro = ShaderMacro.getByName("O3_HAS_UV");
-  private static _uv1Macro = ShaderMacro.getByName("O3_HAS_UV1");
-  private static _normalMacro = ShaderMacro.getByName("O3_HAS_NORMAL");
-  private static _tangentMacro = ShaderMacro.getByName("O3_HAS_TANGENT");
-  private static _vertexColorMacro = ShaderMacro.getByName("O3_HAS_VERTEXCOLOR");
+  private static _uvMacro = ShaderMacro.getByName("GALACEAN_HAS_UV");
+  private static _uv1Macro = ShaderMacro.getByName("GALACEAN_HAS_UV1");
+  private static _normalMacro = ShaderMacro.getByName("GALACEAN_HAS_NORMAL");
+  private static _tangentMacro = ShaderMacro.getByName("GALACEAN_HAS_TANGENT");
+  private static _vertexColorMacro = ShaderMacro.getByName("GALACEAN_HAS_VERTEXCOLOR");
 
   /** @internal */
   @ignoreClone

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -12,11 +12,11 @@ import { ShaderMacro } from "../shader/ShaderMacro";
  * MeshRenderer Component.
  */
 export class MeshRenderer extends Renderer implements ICustomClone {
-  private static _uvMacro = ShaderMacro.getByName("GALACEAN_HAS_UV");
-  private static _uv1Macro = ShaderMacro.getByName("GALACEAN_HAS_UV1");
-  private static _normalMacro = ShaderMacro.getByName("GALACEAN_HAS_NORMAL");
-  private static _tangentMacro = ShaderMacro.getByName("GALACEAN_HAS_TANGENT");
-  private static _vertexColorMacro = ShaderMacro.getByName("GALACEAN_HAS_VERTEXCOLOR");
+  private static _uvMacro = ShaderMacro.getByName("RENDERER_HAS_UV");
+  private static _uv1Macro = ShaderMacro.getByName("RENDERER_HAS_UV1");
+  private static _normalMacro = ShaderMacro.getByName("RENDERER_HAS_NORMAL");
+  private static _tangentMacro = ShaderMacro.getByName("RENDERER_HAS_TANGENT");
+  private static _vertexColorMacro = ShaderMacro.getByName("RENDERER_HAS_VERTEXCOLOR");
 
   /** @internal */
   @ignoreClone

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -17,9 +17,9 @@ import { Skin } from "./Skin";
  * SkinnedMeshRenderer.
  */
 export class SkinnedMeshRenderer extends MeshRenderer {
-  private static _jointCountProperty = ShaderProperty.getByName("galacean_JointCount");
-  private static _jointSamplerProperty = ShaderProperty.getByName("galacean_JointSampler");
-  private static _jointMatrixProperty = ShaderProperty.getByName("galacean_JointMatrix");
+  private static _jointCountProperty = ShaderProperty.getByName("renderer_JointCount");
+  private static _jointSamplerProperty = ShaderProperty.getByName("renderer_JointSampler");
+  private static _jointMatrixProperty = ShaderProperty.getByName("renderer_JointMatrix");
 
   @ignoreClone
   private _hasInitSkin: boolean = false;
@@ -193,8 +193,8 @@ export class SkinnedMeshRenderer extends MeshRenderer {
               this._jointTexture = new Texture2D(engine, 4, jointCount, TextureFormat.R32G32B32A32, false);
               this._jointTexture.filterMode = TextureFilterMode.Point;
             }
-            shaderData.disableMacro("O3_JOINTS_NUM");
-            shaderData.enableMacro("O3_USE_JOINT_TEXTURE");
+            shaderData.disableMacro("RENDERER_JOINTS_NUM");
+            shaderData.enableMacro("RENDERER_USE_JOINT_TEXTURE");
             shaderData.setTexture(SkinnedMeshRenderer._jointSamplerProperty, this._jointTexture);
           } else {
             Logger.error(
@@ -204,8 +204,8 @@ export class SkinnedMeshRenderer extends MeshRenderer {
           }
         } else {
           this._jointTexture?.destroy();
-          shaderData.disableMacro("O3_USE_JOINT_TEXTURE");
-          shaderData.enableMacro("O3_JOINTS_NUM", remainUniformJointCount.toString());
+          shaderData.disableMacro("RENDERER_USE_JOINT_TEXTURE");
+          shaderData.enableMacro("RENDERER_JOINTS_NUM", remainUniformJointCount.toString());
           shaderData.setFloatArray(SkinnedMeshRenderer._jointMatrixProperty, this._jointMatrices);
         }
         jointDataCreateCache.set(jointCount, bsUniformOccupiesCount);
@@ -254,7 +254,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 
     const { _skin: skin, shaderData } = this;
     if (!skin) {
-      shaderData.disableMacro("O3_HAS_SKIN");
+      shaderData.disableMacro("RENDERER_HAS_SKIN");
       return;
     }
 
@@ -297,10 +297,10 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 
     this._rootBone = rootBone;
     if (jointCount) {
-      shaderData.enableMacro("O3_HAS_SKIN");
+      shaderData.enableMacro("RENDERER_HAS_SKIN");
       shaderData.setInt(SkinnedMeshRenderer._jointCountProperty, jointCount);
     } else {
-      shaderData.disableMacro("O3_HAS_SKIN");
+      shaderData.disableMacro("RENDERER_HAS_SKIN");
     }
   }
 

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -17,9 +17,9 @@ import { Skin } from "./Skin";
  * SkinnedMeshRenderer.
  */
 export class SkinnedMeshRenderer extends MeshRenderer {
-  private static _jointCountProperty = ShaderProperty.getByName("u_jointCount");
-  private static _jointSamplerProperty = ShaderProperty.getByName("u_jointSampler");
-  private static _jointMatrixProperty = ShaderProperty.getByName("u_jointMatrix");
+  private static _jointCountProperty = ShaderProperty.getByName("galacean_JointCount");
+  private static _jointSamplerProperty = ShaderProperty.getByName("galacean_JointSampler");
+  private static _jointMatrixProperty = ShaderProperty.getByName("galacean_JointMatrix");
 
   @ignoreClone
   private _hasInitSkin: boolean = false;

--- a/packages/core/src/shaderlib/FogFragment.glsl
+++ b/packages/core/src/shaderlib/FogFragment.glsl
@@ -1,4 +1,4 @@
-#if GALACEAN_FOG_MODE != 0
+#if SCENE_FOG_MODE != 0
     float fogIntensity = ComputeFogIntensity(length(v_positionVS));
     gl_FragColor.rgb = mix(galacean_FogColor.rgb, gl_FragColor.rgb, fogIntensity);
 #endif

--- a/packages/core/src/shaderlib/FogFragment.glsl
+++ b/packages/core/src/shaderlib/FogFragment.glsl
@@ -1,4 +1,4 @@
 #if SCENE_FOG_MODE != 0
     float fogIntensity = ComputeFogIntensity(length(v_positionVS));
-    gl_FragColor.rgb = mix(galacean_FogColor.rgb, gl_FragColor.rgb, fogIntensity);
+    gl_FragColor.rgb = mix(scene_FogColor.rgb, gl_FragColor.rgb, fogIntensity);
 #endif

--- a/packages/core/src/shaderlib/FogFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/FogFragmentDeclaration.glsl
@@ -1,17 +1,17 @@
-#if GALACEAN_FOG_MODE != 0
+#if SCENE_FOG_MODE != 0
     varying vec3 v_positionVS;
 
     uniform vec4 galacean_FogColor;
     uniform vec4 galacean_FogParams;// (-1/(end-start), end/(end-start), density/ln(2),density/sprt(ln(2)));
 
     float ComputeFogIntensity(float fogDepth){
-        #if GALACEAN_FOG_MODE == 1
+        #if SCENE_FOG_MODE == 1
             // (end-z) / (end-start) = z * (-1/(end-start)) + (end/(end-start))
             return clamp(fogDepth * galacean_FogParams.x + galacean_FogParams.y, 0.0, 1.0);
-        #elif GALACEAN_FOG_MODE == 2
+        #elif SCENE_FOG_MODE == 2
             // exp(-z * density) = exp2((-z * density)/ln(2)) = exp2(-z * density/ln(2))
             return  clamp(exp2(-fogDepth * galacean_FogParams.z), 0.0, 1.0);
-        #elif GALACEAN_FOG_MODE == 3
+        #elif SCENE_FOG_MODE == 3
             // exp(-(z * density)^2) = exp2(-(z * density)^2/ln(2)) = exp2(-(z * density/sprt(ln(2)))^2)
             float factor = fogDepth * galacean_FogParams.w;
             return  clamp(exp2(-factor * factor), 0.0, 1.0);

--- a/packages/core/src/shaderlib/FogFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/FogFragmentDeclaration.glsl
@@ -1,19 +1,19 @@
 #if SCENE_FOG_MODE != 0
     varying vec3 v_positionVS;
 
-    uniform vec4 galacean_FogColor;
-    uniform vec4 galacean_FogParams;// (-1/(end-start), end/(end-start), density/ln(2),density/sprt(ln(2)));
+    uniform vec4 scene_FogColor;
+    uniform vec4 scene_FogParams;// (-1/(end-start), end/(end-start), density/ln(2),density/sprt(ln(2)));
 
     float ComputeFogIntensity(float fogDepth){
         #if SCENE_FOG_MODE == 1
             // (end-z) / (end-start) = z * (-1/(end-start)) + (end/(end-start))
-            return clamp(fogDepth * galacean_FogParams.x + galacean_FogParams.y, 0.0, 1.0);
+            return clamp(fogDepth * scene_FogParams.x + scene_FogParams.y, 0.0, 1.0);
         #elif SCENE_FOG_MODE == 2
             // exp(-z * density) = exp2((-z * density)/ln(2)) = exp2(-z * density/ln(2))
-            return  clamp(exp2(-fogDepth * galacean_FogParams.z), 0.0, 1.0);
+            return  clamp(exp2(-fogDepth * scene_FogParams.z), 0.0, 1.0);
         #elif SCENE_FOG_MODE == 3
             // exp(-(z * density)^2) = exp2(-(z * density)^2/ln(2)) = exp2(-(z * density/sprt(ln(2)))^2)
-            float factor = fogDepth * galacean_FogParams.w;
+            float factor = fogDepth * scene_FogParams.w;
             return  clamp(exp2(-factor * factor), 0.0, 1.0);
         #endif
     }

--- a/packages/core/src/shaderlib/FogVertex.glsl
+++ b/packages/core/src/shaderlib/FogVertex.glsl
@@ -1,4 +1,4 @@
-#if GALACEAN_FOG_MODE != 0
+#if SCENE_FOG_MODE != 0
     vec4 positionVS = renderer_MVMat * position;
     v_positionVS = positionVS.xyz / positionVS.w;
 #endif

--- a/packages/core/src/shaderlib/FogVertex.glsl
+++ b/packages/core/src/shaderlib/FogVertex.glsl
@@ -1,4 +1,4 @@
 #if GALACEAN_FOG_MODE != 0
-    vec4 positionVS = u_MVMat * position;
+    vec4 positionVS = galacean_MVMat * position;
     v_positionVS = positionVS.xyz / positionVS.w;
 #endif

--- a/packages/core/src/shaderlib/FogVertex.glsl
+++ b/packages/core/src/shaderlib/FogVertex.glsl
@@ -1,4 +1,4 @@
 #if GALACEAN_FOG_MODE != 0
-    vec4 positionVS = galacean_MVMat * position;
+    vec4 positionVS = renderer_MVMat * position;
     v_positionVS = positionVS.xyz / positionVS.w;
 #endif

--- a/packages/core/src/shaderlib/FogVertexDeclaration.glsl
+++ b/packages/core/src/shaderlib/FogVertexDeclaration.glsl
@@ -1,3 +1,3 @@
-#if GALACEAN_FOG_MODE != 0
+#if SCENE_FOG_MODE != 0
     varying vec3 v_positionVS;
 #endif

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -1,41 +1,41 @@
     vec4 ambient = vec4(0.0);
-    vec4 emission = u_emissiveColor;
-    vec4 diffuse = u_baseColor;
-    vec4 specular = u_specularColor;
+    vec4 emission = material_EmissiveColor;
+    vec4 diffuse = material_BaseColor;
+    vec4 specular = material_SpecularColor;
 
     
 
-    #ifdef EMISSIVETEXTURE
-        vec4 emissiveTextureColor = texture2D(u_emissiveTexture, v_uv);
-        #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifdef MATERIAL_HAS_EMISSIVETEXTURE
+        vec4 emissiveTextureColor = texture2D(material_EmissiveTexture, v_uv);
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
             emissiveTextureColor = gammaToLinear(emissiveTextureColor);
         #endif
         emission *= emissiveTextureColor;
 
     #endif
 
-    #ifdef BASETEXTURE
-        vec4 diffuseTextureColor = texture2D(u_baseTexture, v_uv);
-        #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifdef MATERIAL_HAS_BASETEXTURE
+        vec4 diffuseTextureColor = texture2D(material_BaseTexture, v_uv);
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
             diffuseTextureColor = gammaToLinear(diffuseTextureColor);
         #endif
         diffuse *= diffuseTextureColor;
 
     #endif
 
-     #ifdef GALACEAN_HAS_VERTEXCOLOR
+     #ifdef RENDERER_HAS_VERTEXCOLOR
 
         diffuse *= v_color;
 
     #endif
 
     #ifdef O3_SPECULAR_TEXTURE
-        vec4 specularTextureColor = texture2D(u_specularTexture, v_uv);
-        #ifndef GALACEAN_COLORSPACE_GAMMA
+        vec4 specularTextureColor = texture2D(material_SpecularTexture, v_uv);
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
             specularTextureColor = gammaToLinear(specularTextureColor);
         #endif
         specular *= specularTextureColor;
 
     #endif
 
-    ambient = vec4(galacean_EnvMapLight.diffuse * galacean_EnvMapLight.diffuseIntensity, 1.0) * diffuse;
+    ambient = vec4(scene_EnvMapLight.diffuse * scene_EnvMapLight.diffuseIntensity, 1.0) * diffuse;

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -29,7 +29,7 @@
 
     #endif
 
-    #ifdef O3_SPECULAR_TEXTURE
+    #ifdef MATERIAL_SPECULAR_TEXTURE
         vec4 specularTextureColor = texture2D(material_SpecularTexture, v_uv);
         #ifndef ENGINE_IS_COLORSPACE_GAMMA
             specularTextureColor = gammaToLinear(specularTextureColor);

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -29,7 +29,7 @@
 
     #endif
 
-    #ifdef MATERIAL_SPECULAR_TEXTURE
+    #ifdef MATERIAL_HAS_SPECULAR_TEXTURE
         vec4 specularTextureColor = texture2D(material_SpecularTexture, v_uv);
         #ifndef ENGINE_IS_COLORSPACE_GAMMA
             specularTextureColor = gammaToLinear(specularTextureColor);

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -23,7 +23,7 @@
 
     #endif
 
-     #ifdef O3_HAS_VERTEXCOLOR
+     #ifdef GALACEAN_HAS_VERTEXCOLOR
 
         diffuse *= v_color;
 
@@ -38,4 +38,4 @@
 
     #endif
 
-    ambient = vec4(u_envMapLight.diffuse * u_envMapLight.diffuseIntensity, 1.0) * diffuse;
+    ambient = vec4(galacean_EnvMapLight.diffuse * galacean_EnvMapLight.diffuseIntensity, 1.0) * diffuse;

--- a/packages/core/src/shaderlib/begin_normal_vert.glsl
+++ b/packages/core/src/shaderlib/begin_normal_vert.glsl
@@ -1,9 +1,9 @@
 #ifndef OMIT_NORMAL
-    #ifdef O3_HAS_NORMAL
+    #ifdef GALACEAN_HAS_NORMAL
         vec3 normal = vec3( NORMAL );
     #endif
 
-    #ifdef O3_HAS_TANGENT
+    #ifdef GALACEAN_HAS_TANGENT
         vec4 tangent = vec4( TANGENT );
     #endif
 #endif

--- a/packages/core/src/shaderlib/begin_normal_vert.glsl
+++ b/packages/core/src/shaderlib/begin_normal_vert.glsl
@@ -1,9 +1,9 @@
-#ifndef OMIT_NORMAL
-    #ifdef GALACEAN_HAS_NORMAL
+#ifndef MATERIAL_OMIT_NORMAL
+    #ifdef RENDERER_HAS_NORMAL
         vec3 normal = vec3( NORMAL );
     #endif
 
-    #ifdef GALACEAN_HAS_TANGENT
+    #ifdef RENDERER_HAS_TANGENT
         vec4 tangent = vec4( TANGENT );
     #endif
 #endif

--- a/packages/core/src/shaderlib/begin_viewdir_frag.glsl
+++ b/packages/core/src/shaderlib/begin_viewdir_frag.glsl
@@ -1,3 +1,3 @@
 #ifdef O3_NEED_WORLDPOS
-    vec3 V =  normalize( u_cameraPos - v_pos );
+    vec3 V =  normalize( galacean_CameraPos - v_pos );
 #endif

--- a/packages/core/src/shaderlib/begin_viewdir_frag.glsl
+++ b/packages/core/src/shaderlib/begin_viewdir_frag.glsl
@@ -1,3 +1,3 @@
-#ifdef O3_NEED_WORLDPOS
-    vec3 V =  normalize( galacean_CameraPos - v_pos );
+#ifdef MATERIAL_NEED_WORLDPOS
+    vec3 V =  normalize( camera_Position - v_pos );
 #endif

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -2,7 +2,7 @@
 	#ifdef RENDERER_BLENDSHAPE_USE_TEXTURE
 		uniform mediump sampler2DArray renderer_BlendShapeTexture;
 		uniform ivec3 renderer_BlendShapeTextureInfo;
-		uniform float renderer_BlendShapeWeights[GALACEAN_BLENDSHAPE_COUNT];
+		uniform float renderer_BlendShapeWeights[RENDERER_BLENDSHAPE_COUNT];
 	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -1,8 +1,8 @@
 #ifdef GALACEAN_BLENDSHAPE
 	#ifdef GALACEAN_BLENDSHAPE_TEXTURE
-		uniform mediump sampler2DArray u_blendShapeTexture;
-		uniform ivec3 u_blendShapeTextureInfo;
-		uniform float u_blendShapeWeights[GALACEAN_BLENDSHAPE_COUNT];
+		uniform mediump sampler2DArray galacean_BlendShapeTexture;
+		uniform ivec3 galacean_BlendShapeTextureInfo;
+		uniform float galacean_BlendShapeWeights[GALACEAN_BLENDSHAPE_COUNT];
 	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;
@@ -11,7 +11,7 @@
 			attribute vec3 NORMAL_BS1;
 			attribute vec3 TANGENT_BS0;
 			attribute vec3 TANGENT_BS1;
-			uniform float u_blendShapeWeights[2];
+			uniform float galacean_BlendShapeWeights[2];
 		#else
 			#if defined( GALACEAN_BLENDSHAPE_NORMAL ) || defined( GALACEAN_BLENDSHAPE_TANGENT )
 				attribute vec3 POSITION_BS2;
@@ -30,7 +30,7 @@
 					attribute vec3 TANGENT_BS3;
 				#endif
 
-				uniform float u_blendShapeWeights[4];
+				uniform float galacean_BlendShapeWeights[4];
 			#else
 				attribute vec3 POSITION_BS2;
 				attribute vec3 POSITION_BS3;
@@ -38,7 +38,7 @@
 				attribute vec3 POSITION_BS5;
 				attribute vec3 POSITION_BS6;
 				attribute vec3 POSITION_BS7;
-				uniform float u_blendShapeWeights[8];
+				uniform float galacean_BlendShapeWeights[8];
 			#endif
 		#endif
 	#endif
@@ -46,10 +46,10 @@
 	#ifdef GALACEAN_BLENDSHAPE_TEXTURE
 		vec3 getBlendShapeVertexElement(int blendShapeIndex, int vertexElementIndex)
 		{			
-			int y = vertexElementIndex / u_blendShapeTextureInfo.y;
-			int x = vertexElementIndex - y * u_blendShapeTextureInfo.y;
+			int y = vertexElementIndex / galacean_BlendShapeTextureInfo.y;
+			int x = vertexElementIndex - y * galacean_BlendShapeTextureInfo.y;
 			ivec3 uv = ivec3(x, y , blendShapeIndex);
-			return texelFetch(u_blendShapeTexture, uv, 0).xyz;
+			return texelFetch(galacean_BlendShapeTexture, uv, 0).xyz;
 		}
 	#endif
 #endif

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -1,36 +1,36 @@
-#ifdef GALACEAN_BLENDSHAPE
-	#ifdef GALACEAN_BLENDSHAPE_TEXTURE
-		uniform mediump sampler2DArray galacean_BlendShapeTexture;
-		uniform ivec3 galacean_BlendShapeTextureInfo;
-		uniform float galacean_BlendShapeWeights[GALACEAN_BLENDSHAPE_COUNT];
+#ifdef RENDERER_HAS_BLENDSHAPE
+	#ifdef RENDERER_BLENDSHAPE_USE_TEXTURE
+		uniform mediump sampler2DArray renderer_BlendShapeTexture;
+		uniform ivec3 renderer_BlendShapeTextureInfo;
+		uniform float renderer_BlendShapeWeights[GALACEAN_BLENDSHAPE_COUNT];
 	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;
-		#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( GALACEAN_BLENDSHAPE_TANGENT )
+		#if defined( RENDERER_BLENDSHAPE_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_TANGENT )
 			attribute vec3 NORMAL_BS0;
 			attribute vec3 NORMAL_BS1;
 			attribute vec3 TANGENT_BS0;
 			attribute vec3 TANGENT_BS1;
-			uniform float galacean_BlendShapeWeights[2];
+			uniform float renderer_BlendShapeWeights[2];
 		#else
-			#if defined( GALACEAN_BLENDSHAPE_NORMAL ) || defined( GALACEAN_BLENDSHAPE_TANGENT )
+			#if defined( RENDERER_BLENDSHAPE_HAS_NORMAL ) || defined( RENDERER_BLENDSHAPE_HAS_TANGENT )
 				attribute vec3 POSITION_BS2;
 				attribute vec3 POSITION_BS3;
-				#ifdef GALACEAN_BLENDSHAPE_NORMAL
+				#ifdef RENDERER_BLENDSHAPE_HAS_NORMAL
 					attribute vec3 NORMAL_BS0;
 					attribute vec3 NORMAL_BS1;
 					attribute vec3 NORMAL_BS2;
 					attribute vec3 NORMAL_BS3;
 				#endif
 
-				#ifdef GALACEAN_BLENDSHAPE_TANGENT
+				#ifdef RENDERER_BLENDSHAPE_HAS_TANGENT
 					attribute vec3 TANGENT_BS0;
 					attribute vec3 TANGENT_BS1;
 					attribute vec3 TANGENT_BS2;
 					attribute vec3 TANGENT_BS3;
 				#endif
 
-				uniform float galacean_BlendShapeWeights[4];
+				uniform float renderer_BlendShapeWeights[4];
 			#else
 				attribute vec3 POSITION_BS2;
 				attribute vec3 POSITION_BS3;
@@ -38,18 +38,18 @@
 				attribute vec3 POSITION_BS5;
 				attribute vec3 POSITION_BS6;
 				attribute vec3 POSITION_BS7;
-				uniform float galacean_BlendShapeWeights[8];
+				uniform float renderer_BlendShapeWeights[8];
 			#endif
 		#endif
 	#endif
 
-	#ifdef GALACEAN_BLENDSHAPE_TEXTURE
+	#ifdef RENDERER_BLENDSHAPE_USE_TEXTURE
 		vec3 getBlendShapeVertexElement(int blendShapeIndex, int vertexElementIndex)
 		{			
-			int y = vertexElementIndex / galacean_BlendShapeTextureInfo.y;
-			int x = vertexElementIndex - y * galacean_BlendShapeTextureInfo.y;
+			int y = vertexElementIndex / renderer_BlendShapeTextureInfo.y;
+			int x = vertexElementIndex - y * renderer_BlendShapeTextureInfo.y;
 			ivec3 uv = ivec3(x, y , blendShapeIndex);
-			return texelFetch(galacean_BlendShapeTexture, uv, 0).xyz;
+			return texelFetch(renderer_BlendShapeTexture, uv, 0).xyz;
 		}
 	#endif
 #endif

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,7 +1,7 @@
 #ifdef RENDERER_HAS_BLENDSHAPE
 	#ifdef RENDERER_BLENDSHAPE_USE_TEXTURE	
 		int vertexOffset = gl_VertexID * renderer_BlendShapeTextureInfo.x;
-		for(int i = 0; i < GALACEAN_BLENDSHAPE_COUNT; i++){
+		for(int i = 0; i < RENDERER_BLENDSHAPE_COUNT; i++){
 			int vertexElementOffset = vertexOffset;
 			float weight = renderer_BlendShapeWeights[i];
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
@@ -12,7 +12,7 @@
 					normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 
-				#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+				#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
 					vertexElementOffset += 1;
 					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
@@ -28,7 +28,7 @@
 					normal += NORMAL_BS0 * renderer_BlendShapeWeights[0];
 					normal += NORMAL_BS1 * renderer_BlendShapeWeights[1];
 				#endif
-				#if defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+				#if defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
 					tangent.xyz += TANGENT_BS0 * renderer_BlendShapeWeights[0];
 					tangent.xyz += TANGENT_BS1 * renderer_BlendShapeWeights[1];
 				#endif				
@@ -46,7 +46,7 @@
 						normal += NORMAL_BS3 * renderer_BlendShapeWeights[3];
 					#endif
 
-					#if defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+					#if defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
 						tangent.xyz += TANGENT_BS0 * renderer_BlendShapeWeights[0];
 						tangent.xyz += TANGENT_BS1 * renderer_BlendShapeWeights[1];
 						tangent.xyz += TANGENT_BS2 * renderer_BlendShapeWeights[2];

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,65 +1,65 @@
-#ifdef GALACEAN_BLENDSHAPE
-	#ifdef GALACEAN_BLENDSHAPE_TEXTURE	
-		int vertexOffset = gl_VertexID * galacean_BlendShapeTextureInfo.x;
+#ifdef RENDERER_HAS_BLENDSHAPE
+	#ifdef RENDERER_BLENDSHAPE_USE_TEXTURE	
+		int vertexOffset = gl_VertexID * renderer_BlendShapeTextureInfo.x;
 		for(int i = 0; i < GALACEAN_BLENDSHAPE_COUNT; i++){
 			int vertexElementOffset = vertexOffset;
-			float weight = galacean_BlendShapeWeights[i];
+			float weight = renderer_BlendShapeWeights[i];
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 			
-			#ifndef OMIT_NORMAL
-				#if defined( GALACEAN_HAS_NORMAL ) && defined( GALACEAN_BLENDSHAPE_NORMAL )
+			#ifndef MATERIAL_OMIT_NORMAL
+				#if defined( RENDERER_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_NORMAL )
 					vertexElementOffset += 1;
 					normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 
-				#if defined( GALACEAN_HAS_TANGENT ) && defined(GALACEAN_BLENDSHAPE_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+				#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
 					vertexElementOffset += 1;
 					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 			#endif
 		}
 	#else
-		position.xyz += POSITION_BS0 * galacean_BlendShapeWeights[0];
-		position.xyz += POSITION_BS1 * galacean_BlendShapeWeights[1];
+		position.xyz += POSITION_BS0 * renderer_BlendShapeWeights[0];
+		position.xyz += POSITION_BS1 * renderer_BlendShapeWeights[1];
 
-		#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( GALACEAN_BLENDSHAPE_TANGENT )
-			#ifndef OMIT_NORMAL
-				#ifdef GALACEAN_HAS_NORMAL
-					normal += NORMAL_BS0 * galacean_BlendShapeWeights[0];
-					normal += NORMAL_BS1 * galacean_BlendShapeWeights[1];
+		#if defined( RENDERER_BLENDSHAPE_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_TANGENT )
+			#ifndef MATERIAL_OMIT_NORMAL
+				#ifdef RENDERER_HAS_NORMAL
+					normal += NORMAL_BS0 * renderer_BlendShapeWeights[0];
+					normal += NORMAL_BS1 * renderer_BlendShapeWeights[1];
 				#endif
-				#if defined( GALACEAN_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-					tangent.xyz += TANGENT_BS0 * galacean_BlendShapeWeights[0];
-					tangent.xyz += TANGENT_BS1 * galacean_BlendShapeWeights[1];
+				#if defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+					tangent.xyz += TANGENT_BS0 * renderer_BlendShapeWeights[0];
+					tangent.xyz += TANGENT_BS1 * renderer_BlendShapeWeights[1];
 				#endif				
 			#endif
 		#else
-			#if defined( GALACEAN_BLENDSHAPE_NORMAL ) || defined( GALACEAN_BLENDSHAPE_TANGENT )
-				#ifndef OMIT_NORMAL
-					position.xyz += POSITION_BS2 * galacean_BlendShapeWeights[2];
-					position.xyz += POSITION_BS3 * galacean_BlendShapeWeights[3];
+			#if defined( RENDERER_BLENDSHAPE_HAS_NORMAL ) || defined( RENDERER_BLENDSHAPE_HAS_TANGENT )
+				#ifndef MATERIAL_OMIT_NORMAL
+					position.xyz += POSITION_BS2 * renderer_BlendShapeWeights[2];
+					position.xyz += POSITION_BS3 * renderer_BlendShapeWeights[3];
 
-					#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( GALACEAN_HAS_NORMAL )
-						normal += NORMAL_BS0 * galacean_BlendShapeWeights[0];
-						normal += NORMAL_BS1 * galacean_BlendShapeWeights[1];
-						normal += NORMAL_BS2 * galacean_BlendShapeWeights[2];
-						normal += NORMAL_BS3 * galacean_BlendShapeWeights[3];
+					#if defined( RENDERER_BLENDSHAPE_HAS_NORMAL ) && defined( RENDERER_HAS_NORMAL )
+						normal += NORMAL_BS0 * renderer_BlendShapeWeights[0];
+						normal += NORMAL_BS1 * renderer_BlendShapeWeights[1];
+						normal += NORMAL_BS2 * renderer_BlendShapeWeights[2];
+						normal += NORMAL_BS3 * renderer_BlendShapeWeights[3];
 					#endif
 
-					#if defined(GALACEAN_BLENDSHAPE_TANGENT) && defined( GALACEAN_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-						tangent.xyz += TANGENT_BS0 * galacean_BlendShapeWeights[0];
-						tangent.xyz += TANGENT_BS1 * galacean_BlendShapeWeights[1];
-						tangent.xyz += TANGENT_BS2 * galacean_BlendShapeWeights[2];
-						tangent.xyz += TANGENT_BS3 * galacean_BlendShapeWeights[3];
+					#if defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && defined( RENDERER_HAS_TANGENT ) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+						tangent.xyz += TANGENT_BS0 * renderer_BlendShapeWeights[0];
+						tangent.xyz += TANGENT_BS1 * renderer_BlendShapeWeights[1];
+						tangent.xyz += TANGENT_BS2 * renderer_BlendShapeWeights[2];
+						tangent.xyz += TANGENT_BS3 * renderer_BlendShapeWeights[3];
 					#endif
 				#endif
 			#else
-				position.xyz += POSITION_BS2 * galacean_BlendShapeWeights[2];
-				position.xyz += POSITION_BS3 * galacean_BlendShapeWeights[3];
-				position.xyz += POSITION_BS4 * galacean_BlendShapeWeights[4];
-				position.xyz += POSITION_BS5 * galacean_BlendShapeWeights[5];
-				position.xyz += POSITION_BS6 * galacean_BlendShapeWeights[6];
-				position.xyz += POSITION_BS7 * galacean_BlendShapeWeights[7];
+				position.xyz += POSITION_BS2 * renderer_BlendShapeWeights[2];
+				position.xyz += POSITION_BS3 * renderer_BlendShapeWeights[3];
+				position.xyz += POSITION_BS4 * renderer_BlendShapeWeights[4];
+				position.xyz += POSITION_BS5 * renderer_BlendShapeWeights[5];
+				position.xyz += POSITION_BS6 * renderer_BlendShapeWeights[6];
+				position.xyz += POSITION_BS7 * renderer_BlendShapeWeights[7];
 			#endif
 		#endif
 	#endif

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,65 +1,65 @@
 #ifdef GALACEAN_BLENDSHAPE
 	#ifdef GALACEAN_BLENDSHAPE_TEXTURE	
-		int vertexOffset = gl_VertexID * u_blendShapeTextureInfo.x;
+		int vertexOffset = gl_VertexID * galacean_BlendShapeTextureInfo.x;
 		for(int i = 0; i < GALACEAN_BLENDSHAPE_COUNT; i++){
 			int vertexElementOffset = vertexOffset;
-			float weight = u_blendShapeWeights[i];
+			float weight = galacean_BlendShapeWeights[i];
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 			
 			#ifndef OMIT_NORMAL
-				#if defined( O3_HAS_NORMAL ) && defined( GALACEAN_BLENDSHAPE_NORMAL )
+				#if defined( GALACEAN_HAS_NORMAL ) && defined( GALACEAN_BLENDSHAPE_NORMAL )
 					vertexElementOffset += 1;
 					normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 
-				#if defined( O3_HAS_TANGENT ) && defined(GALACEAN_BLENDSHAPE_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+				#if defined( GALACEAN_HAS_TANGENT ) && defined(GALACEAN_BLENDSHAPE_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
 					vertexElementOffset += 1;
 					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 			#endif
 		}
 	#else
-		position.xyz += POSITION_BS0 * u_blendShapeWeights[0];
-		position.xyz += POSITION_BS1 * u_blendShapeWeights[1];
+		position.xyz += POSITION_BS0 * galacean_BlendShapeWeights[0];
+		position.xyz += POSITION_BS1 * galacean_BlendShapeWeights[1];
 
 		#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( GALACEAN_BLENDSHAPE_TANGENT )
 			#ifndef OMIT_NORMAL
-				#ifdef O3_HAS_NORMAL
-					normal += NORMAL_BS0 * u_blendShapeWeights[0];
-					normal += NORMAL_BS1 * u_blendShapeWeights[1];
+				#ifdef GALACEAN_HAS_NORMAL
+					normal += NORMAL_BS0 * galacean_BlendShapeWeights[0];
+					normal += NORMAL_BS1 * galacean_BlendShapeWeights[1];
 				#endif
-				#if defined( O3_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-					tangent.xyz += TANGENT_BS0 * u_blendShapeWeights[0];
-					tangent.xyz += TANGENT_BS1 * u_blendShapeWeights[1];
+				#if defined( GALACEAN_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+					tangent.xyz += TANGENT_BS0 * galacean_BlendShapeWeights[0];
+					tangent.xyz += TANGENT_BS1 * galacean_BlendShapeWeights[1];
 				#endif				
 			#endif
 		#else
 			#if defined( GALACEAN_BLENDSHAPE_NORMAL ) || defined( GALACEAN_BLENDSHAPE_TANGENT )
 				#ifndef OMIT_NORMAL
-					position.xyz += POSITION_BS2 * u_blendShapeWeights[2];
-					position.xyz += POSITION_BS3 * u_blendShapeWeights[3];
+					position.xyz += POSITION_BS2 * galacean_BlendShapeWeights[2];
+					position.xyz += POSITION_BS3 * galacean_BlendShapeWeights[3];
 
-					#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( O3_HAS_NORMAL )
-						normal += NORMAL_BS0 * u_blendShapeWeights[0];
-						normal += NORMAL_BS1 * u_blendShapeWeights[1];
-						normal += NORMAL_BS2 * u_blendShapeWeights[2];
-						normal += NORMAL_BS3 * u_blendShapeWeights[3];
+					#if defined( GALACEAN_BLENDSHAPE_NORMAL ) && defined( GALACEAN_HAS_NORMAL )
+						normal += NORMAL_BS0 * galacean_BlendShapeWeights[0];
+						normal += NORMAL_BS1 * galacean_BlendShapeWeights[1];
+						normal += NORMAL_BS2 * galacean_BlendShapeWeights[2];
+						normal += NORMAL_BS3 * galacean_BlendShapeWeights[3];
 					#endif
 
-					#if defined(GALACEAN_BLENDSHAPE_TANGENT) && defined( O3_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-						tangent.xyz += TANGENT_BS0 * u_blendShapeWeights[0];
-						tangent.xyz += TANGENT_BS1 * u_blendShapeWeights[1];
-						tangent.xyz += TANGENT_BS2 * u_blendShapeWeights[2];
-						tangent.xyz += TANGENT_BS3 * u_blendShapeWeights[3];
+					#if defined(GALACEAN_BLENDSHAPE_TANGENT) && defined( GALACEAN_HAS_TANGENT ) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+						tangent.xyz += TANGENT_BS0 * galacean_BlendShapeWeights[0];
+						tangent.xyz += TANGENT_BS1 * galacean_BlendShapeWeights[1];
+						tangent.xyz += TANGENT_BS2 * galacean_BlendShapeWeights[2];
+						tangent.xyz += TANGENT_BS3 * galacean_BlendShapeWeights[3];
 					#endif
 				#endif
 			#else
-				position.xyz += POSITION_BS2 * u_blendShapeWeights[2];
-				position.xyz += POSITION_BS3 * u_blendShapeWeights[3];
-				position.xyz += POSITION_BS4 * u_blendShapeWeights[4];
-				position.xyz += POSITION_BS5 * u_blendShapeWeights[5];
-				position.xyz += POSITION_BS6 * u_blendShapeWeights[6];
-				position.xyz += POSITION_BS7 * u_blendShapeWeights[7];
+				position.xyz += POSITION_BS2 * galacean_BlendShapeWeights[2];
+				position.xyz += POSITION_BS3 * galacean_BlendShapeWeights[3];
+				position.xyz += POSITION_BS4 * galacean_BlendShapeWeights[4];
+				position.xyz += POSITION_BS5 * galacean_BlendShapeWeights[5];
+				position.xyz += POSITION_BS6 * galacean_BlendShapeWeights[6];
+				position.xyz += POSITION_BS7 * galacean_BlendShapeWeights[7];
 			#endif
 		#endif
 	#endif

--- a/packages/core/src/shaderlib/camera_declare.glsl
+++ b/packages/core/src/shaderlib/camera_declare.glsl
@@ -1,1 +1,1 @@
-uniform vec3 u_cameraPos;
+uniform vec3 galacean_CameraPos;

--- a/packages/core/src/shaderlib/camera_declare.glsl
+++ b/packages/core/src/shaderlib/camera_declare.glsl
@@ -1,1 +1,1 @@
-uniform vec3 galacean_CameraPos;
+uniform vec3 camera_Position;

--- a/packages/core/src/shaderlib/color_share.glsl
+++ b/packages/core/src/shaderlib/color_share.glsl
@@ -1,4 +1,4 @@
-#ifdef O3_HAS_VERTEXCOLOR
+#ifdef GALACEAN_HAS_VERTEXCOLOR
 
 varying vec4 v_color;
 

--- a/packages/core/src/shaderlib/color_share.glsl
+++ b/packages/core/src/shaderlib/color_share.glsl
@@ -1,4 +1,4 @@
-#ifdef GALACEAN_HAS_VERTEXCOLOR
+#ifdef RENDERER_HAS_VERTEXCOLOR
 
 varying vec4 v_color;
 

--- a/packages/core/src/shaderlib/color_vert.glsl
+++ b/packages/core/src/shaderlib/color_vert.glsl
@@ -1,4 +1,4 @@
-    #ifdef O3_HAS_VERTEXCOLOR
+    #ifdef GALACEAN_HAS_VERTEXCOLOR
 
     v_color = COLOR_0;
 

--- a/packages/core/src/shaderlib/color_vert.glsl
+++ b/packages/core/src/shaderlib/color_vert.glsl
@@ -1,4 +1,4 @@
-    #ifdef GALACEAN_HAS_VERTEXCOLOR
+    #ifdef RENDERER_HAS_VERTEXCOLOR
 
     v_color = COLOR_0;
 

--- a/packages/core/src/shaderlib/common_vert.glsl
+++ b/packages/core/src/shaderlib/common_vert.glsl
@@ -1,10 +1,10 @@
 attribute vec3 POSITION;
 
-#ifdef O3_HAS_UV
+#ifdef GALACEAN_HAS_UV
     attribute vec2 TEXCOORD_0;
 #endif
 
-#ifdef O3_HAS_UV1
+#ifdef GALACEAN_HAS_UV1
     attribute vec2 TEXCOORD_1;
 #endif
 
@@ -13,13 +13,13 @@ attribute vec3 POSITION;
     attribute vec4 WEIGHTS_0;
 
     #ifdef O3_USE_JOINT_TEXTURE
-        uniform sampler2D u_jointSampler;
-        uniform float u_jointCount;
+        uniform sampler2D galacean_JointSampler;
+        uniform float galacean_JointCount;
 
         mat4 getJointMatrix(sampler2D smp, float index)
         {
-            float base = index / u_jointCount;
-            float hf = 0.5 / u_jointCount;
+            float base = index / galacean_JointCount;
+            float hf = 0.5 / galacean_JointCount;
             float v = base + hf;
 
             vec4 m0 = texture2D(smp, vec2(0.125, v ));
@@ -32,11 +32,11 @@ attribute vec3 POSITION;
         }
 
     #else
-        uniform mat4 u_jointMatrix[ O3_JOINTS_NUM ];
+        uniform mat4 galacean_JointMatrix[ O3_JOINTS_NUM ];
     #endif
 #endif
 
-#ifdef O3_HAS_VERTEXCOLOR
+#ifdef GALACEAN_HAS_VERTEXCOLOR
     attribute vec4 COLOR_0;
 #endif
 
@@ -48,11 +48,11 @@ uniform vec4 u_tilingOffset;
 
 
 #ifndef OMIT_NORMAL
-    #ifdef O3_HAS_NORMAL
+    #ifdef GALACEAN_HAS_NORMAL
         attribute vec3 NORMAL;
     #endif
 
-    #ifdef O3_HAS_TANGENT
+    #ifdef GALACEAN_HAS_TANGENT
         attribute vec4 TANGENT;
     #endif
 #endif

--- a/packages/core/src/shaderlib/common_vert.glsl
+++ b/packages/core/src/shaderlib/common_vert.glsl
@@ -1,25 +1,25 @@
 attribute vec3 POSITION;
 
-#ifdef GALACEAN_HAS_UV
+#ifdef RENDERER_HAS_UV
     attribute vec2 TEXCOORD_0;
 #endif
 
-#ifdef GALACEAN_HAS_UV1
+#ifdef RENDERER_HAS_UV1
     attribute vec2 TEXCOORD_1;
 #endif
 
-#ifdef O3_HAS_SKIN
+#ifdef RENDERER_HAS_SKIN
     attribute vec4 JOINTS_0;
     attribute vec4 WEIGHTS_0;
 
-    #ifdef O3_USE_JOINT_TEXTURE
-        uniform sampler2D galacean_JointSampler;
-        uniform float galacean_JointCount;
+    #ifdef RENDERER_USE_JOINT_TEXTURE
+        uniform sampler2D renderer_JointSampler;
+        uniform float renderer_JointCount;
 
         mat4 getJointMatrix(sampler2D smp, float index)
         {
-            float base = index / galacean_JointCount;
-            float hf = 0.5 / galacean_JointCount;
+            float base = index / renderer_JointCount;
+            float hf = 0.5 / renderer_JointCount;
             float v = base + hf;
 
             vec4 m0 = texture2D(smp, vec2(0.125, v ));
@@ -32,11 +32,11 @@ attribute vec3 POSITION;
         }
 
     #else
-        uniform mat4 galacean_JointMatrix[ O3_JOINTS_NUM ];
+        uniform mat4 renderer_JointMatrix[ RENDERER_JOINTS_NUM ];
     #endif
 #endif
 
-#ifdef GALACEAN_HAS_VERTEXCOLOR
+#ifdef RENDERER_HAS_VERTEXCOLOR
     attribute vec4 COLOR_0;
 #endif
 
@@ -44,15 +44,15 @@ attribute vec3 POSITION;
 #include <transform_declare>
 #include <camera_declare>
 
-uniform vec4 u_tilingOffset;
+uniform vec4 material_TilingOffset;
 
 
-#ifndef OMIT_NORMAL
-    #ifdef GALACEAN_HAS_NORMAL
+#ifndef MATERIAL_OMIT_NORMAL
+    #ifdef RENDERER_HAS_NORMAL
         attribute vec3 NORMAL;
     #endif
 
-    #ifdef GALACEAN_HAS_TANGENT
+    #ifdef RENDERER_HAS_TANGENT
         attribute vec4 TANGENT;
     #endif
 #endif

--- a/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
@@ -27,7 +27,7 @@ varying vec3 v_SkyColor;
 	varying vec3 v_SunColor;
 #endif
 
-#if defined(OASIS_COLORSPACE_GAMMA)
+#if defined(GALACEAN_COLORSPACE_GAMMA)
 	#define LINEAR_2_OUTPUT(color) sqrt(color)
 #endif
 
@@ -77,13 +77,13 @@ void main() {
 			col += v_SunColor * calcSunAttenuation(-oasis_SunlightDirection, -ray);
 	#endif
 
-    #ifdef OASIS_COLORSPACE_GAMMA
+    #ifdef GALACEAN_COLORSPACE_GAMMA
 		col = LINEAR_2_OUTPUT(col); // linear space convert to gamma space
 	#endif
 
 	gl_FragColor = vec4(col,1.0);
 
-	#ifndef OASIS_COLORSPACE_GAMMA
+	#ifndef GALACEAN_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
@@ -7,34 +7,34 @@ const float MIE_G = -0.990;
 const float MIE_G2 = 0.9801;
 const float SKY_GROUND_THRESHOLD = 0.02;
 
-uniform float u_SunSize;
-uniform float u_SunSizeConvergence;
+uniform float material_SunSize;
+uniform float material_SunSizeConvergence;
 uniform vec4 oasis_SunlightColor;
 uniform vec3 oasis_SunlightDirection;
 
 varying vec3 v_GroundColor;
 varying vec3 v_SkyColor;
 
-#ifdef SUN_HIGH_QUALITY
+#ifdef MATERIAL_SUN_HIGH_QUALITY
 	varying vec3 v_Vertex;
-#elif defined(SUN_SIMPLE)
+#elif defined(MATERIAL_SUN_SIMPLE)
 	varying vec3 v_RayDir;
 #else
 	varying float v_SkyGroundFactor;
 #endif
 
-#if defined(SUN_HIGH_QUALITY)||defined(SUN_SIMPLE)
+#if defined(MATERIAL_SUN_HIGH_QUALITY)||defined(MATERIAL_SUN_SIMPLE)
 	varying vec3 v_SunColor;
 #endif
 
-#if defined(GALACEAN_COLORSPACE_GAMMA)
+#if defined(ENGINE_IS_COLORSPACE_GAMMA)
 	#define LINEAR_2_OUTPUT(color) sqrt(color)
 #endif
 
 // Calculates the Mie phase function
 float getMiePhase(float eyeCos, float eyeCos2) {
 	float temp = 1.0 + MIE_G2 - 2.0 * MIE_G * eyeCos;
-	temp = pow(temp, pow(u_SunSize,0.65) * 10.0);
+	temp = pow(temp, pow(material_SunSize,0.65) * 10.0);
 	temp = max(temp,1.0e-4); // prevent division by zero, esp. in half precision
 	temp = 1.5 * ((1.0 - MIE_G2) / (2.0 + MIE_G2)) * (1.0 + eyeCos2) / temp;
 	return temp;
@@ -42,13 +42,13 @@ float getMiePhase(float eyeCos, float eyeCos2) {
 
 // Calculates the sun shape
 float calcSunAttenuation(vec3 lightPos, vec3 ray) {
-	#ifdef SUN_HIGH_QUALITY
-		float focusedEyeCos = pow(clamp(dot(lightPos, ray),0.0,1.0), u_SunSizeConvergence);
+	#ifdef MATERIAL_SUN_HIGH_QUALITY
+		float focusedEyeCos = pow(clamp(dot(lightPos, ray),0.0,1.0), material_SunSizeConvergence);
 		return getMiePhase(-focusedEyeCos, focusedEyeCos * focusedEyeCos);
-	#else //SUN_SIMPLE
+	#else //MATERIAL_SUN_SIMPLE
 		vec3 delta = lightPos - ray;
 		float dist = length(delta);
-		float spot = 1.0 - smoothstep(0.0, u_SunSize, dist);
+		float spot = 1.0 - smoothstep(0.0, material_SunSize, dist);
 		return spot * spot;
 	#endif
 }
@@ -59,10 +59,10 @@ void main() {
 	// if y < 0 [eyeRay.y > 0] - sky
 	vec3 col = vec3(0.0, 0.0, 0.0);
 
-	#ifdef SUN_HIGH_QUALITY
+	#ifdef MATERIAL_SUN_HIGH_QUALITY
 		vec3 ray = normalize(v_Vertex);
 		float y = ray.y / SKY_GROUND_THRESHOLD;
-	#elif defined(SUN_SIMPLE) 
+	#elif defined(MATERIAL_SUN_SIMPLE) 
 		vec3 ray = v_RayDir;
 		float y = ray.y / SKY_GROUND_THRESHOLD;	
 	#else
@@ -72,18 +72,18 @@ void main() {
 	// if we did precalculate color in vprog: just do lerp between them
 	col = mix(v_SkyColor, v_GroundColor, clamp(y,0.0,1.0));
 
-	#if defined(SUN_HIGH_QUALITY)||defined(SUN_SIMPLE)
+	#if defined(MATERIAL_SUN_HIGH_QUALITY)||defined(MATERIAL_SUN_SIMPLE)
 		if (y < 0.0)
 			col += v_SunColor * calcSunAttenuation(-oasis_SunlightDirection, -ray);
 	#endif
 
-    #ifdef GALACEAN_COLORSPACE_GAMMA
+    #ifdef ENGINE_IS_COLORSPACE_GAMMA
 		col = LINEAR_2_OUTPUT(col); // linear space convert to gamma space
 	#endif
 
 	gl_FragColor = vec4(col,1.0);
 
-	#ifndef GALACEAN_COLORSPACE_GAMMA
+	#ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.fs.glsl
@@ -9,8 +9,8 @@ const float SKY_GROUND_THRESHOLD = 0.02;
 
 uniform float material_SunSize;
 uniform float material_SunSizeConvergence;
-uniform vec4 oasis_SunlightColor;
-uniform vec3 oasis_SunlightDirection;
+uniform vec4 scene_SunlightColor;
+uniform vec3 scene_SunlightDirection;
 
 varying vec3 v_GroundColor;
 varying vec3 v_SkyColor;
@@ -74,7 +74,7 @@ void main() {
 
 	#if defined(MATERIAL_SUN_HIGH_QUALITY)||defined(MATERIAL_SUN_SIMPLE)
 		if (y < 0.0)
-			col += v_SunColor * calcSunAttenuation(-oasis_SunlightDirection, -ray);
+			col += v_SunColor * calcSunAttenuation(-scene_SunlightDirection, -ray);
 	#endif
 
     #ifdef ENGINE_IS_COLORSPACE_GAMMA

--- a/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
@@ -2,7 +2,7 @@
 // The original implementation can be found at unity build-in shader(DefaultResourcesExtra/Skybox-Procedural.shader)
 
 #define OUTER_RADIUS 1.025
-#define RAYLEIGH (mix(0.0, 0.0025, pow(u_AtmosphereThickness,2.5)))	// Rayleigh constant
+#define RAYLEIGH (mix(0.0, 0.0025, pow(material_AtmosphereThickness,2.5)))	// Rayleigh constant
 #define MIE 0.0010	// Mie constant
 #define SUN_BRIGHTNESS 20.0	// Sun brightness
 #define MAX_SCATTER 50.0 // Maximum scattering value, to prevent math overflows on Adrenos
@@ -31,30 +31,30 @@ const vec3 c_VariableRangeForScatteringWavelength = vec3(0.15, 0.15, 0.15);
 
 attribute vec4 POSITION;
 
-uniform mat4 galacean_VPMat;
-uniform vec3 u_SkyTint;
-uniform vec3 u_GroundTint;
-uniform float u_Exposure;
-uniform float u_AtmosphereThickness;
+uniform mat4 camera_VPMat;
+uniform vec3 material_SkyTint;
+uniform vec3 material_GroundTint;
+uniform float material_Exposure;
+uniform float material_AtmosphereThickness;
 uniform vec4 oasis_SunlightColor;
 uniform vec3 oasis_SunlightDirection;
 
 varying vec3 v_GroundColor;
 varying vec3 v_SkyColor;
 
-#ifdef SUN_HIGH_QUALITY
+#ifdef MATERIAL_SUN_HIGH_QUALITY
 	varying vec3 v_Vertex;
-#elif defined(SUN_SIMPLE)
+#elif defined(MATERIAL_SUN_SIMPLE)
 	varying vec3 v_RayDir;
 #else
 	varying float v_SkyGroundFactor;
 #endif
 
-#if defined(SUN_HIGH_QUALITY)||defined(SUN_SIMPLE)
+#if defined(MATERIAL_SUN_HIGH_QUALITY)||defined(MATERIAL_SUN_SIMPLE)
 	varying vec3 v_SunColor;
 #endif
 
-#if defined(GALACEAN_COLORSPACE_GAMMA)
+#if defined(ENGINE_IS_COLORSPACE_GAMMA)
 	#define COLOR_2_GAMMA(color) color
 	#define COLOR_2_LINEAR(color) color*color
 #else
@@ -77,9 +77,9 @@ float scaleAngle(float inCos)
 }
 
 void main () {
-	gl_Position = galacean_VPMat*vec4(POSITION.xyz,1.0);
+	gl_Position = camera_VPMat*vec4(POSITION.xyz,1.0);
 
- 	vec3 skyTintInGammaSpace = COLOR_2_GAMMA(u_SkyTint);
+ 	vec3 skyTintInGammaSpace = COLOR_2_GAMMA(material_SkyTint);
 	vec3 scatteringWavelength = mix(c_DefaultScatteringWavelength-c_VariableRangeForScatteringWavelength,c_DefaultScatteringWavelength+c_VariableRangeForScatteringWavelength,vec3(1.0) - skyTintInGammaSpace); // using Tint in sRGB+ gamma allows for more visually linear interpolation and to keep (0.5) at (128, gray in sRGB) point
 	vec3 invWavelength = 1.0 / pow(scatteringWavelength, vec3(4.0));
 
@@ -176,9 +176,9 @@ void main () {
 		cOut = clamp(attenuate, 0.0, 1.0);
 	}
 
-	#ifdef SUN_HIGH_QUALITY
+	#ifdef MATERIAL_SUN_HIGH_QUALITY
 		v_Vertex = -POSITION.xyz;
-	#elif defined(SUN_SIMPLE) 
+	#elif defined(MATERIAL_SUN_SIMPLE) 
 		v_RayDir = -eyeRay;
 	#else
 		v_SkyGroundFactor = -eyeRay.y / SKY_GROUND_THRESHOLD;
@@ -188,8 +188,8 @@ void main () {
 	// 1. in case of linear: multiply by _Exposure in here (even in case of lerp it will be common multiplier, so we can skip mul in fshader)
 	// 2. in case of gamma: do sqrt right away instead of doing that in fshader
 	
-	v_GroundColor = u_Exposure * (cIn + COLOR_2_LINEAR(u_GroundTint) * cOut);
-	v_SkyColor    = u_Exposure * (cIn * getRayleighPhase(-oasis_SunlightDirection, -eyeRay));
+	v_GroundColor = material_Exposure * (cIn + COLOR_2_LINEAR(material_GroundTint) * cOut);
+	v_SkyColor    = material_Exposure * (cIn * getRayleighPhase(-oasis_SunlightDirection, -eyeRay));
 
 	
 	// The sun should have a stable intensity in its course in the sky. Moreover it should match the highlight of a purely specular material.
@@ -197,9 +197,9 @@ void main () {
 	// Finally we want the sun to be always bright even in LDR thus the normalization of the lightColor for low intensity.
 	float lightColorIntensity = clamp(length(oasis_SunlightColor.xyz), 0.25, 1.0);
 
-	#ifdef SUN_HIGH_QUALITY 
+	#ifdef MATERIAL_SUN_HIGH_QUALITY 
 		v_SunColor = HDSundiskIntensityFactor * clamp(cOut,0.0,1.0) * oasis_SunlightColor.xyz / lightColorIntensity;
-	#elif defined(SUN_SIMPLE) 
+	#elif defined(MATERIAL_SUN_SIMPLE) 
 		v_SunColor = simpleSundiskIntensityFactor * clamp(cOut * sunScale,0.0,1.0) * oasis_SunlightColor.xyz / lightColorIntensity;
 	#endif
 }

--- a/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
@@ -36,8 +36,8 @@ uniform vec3 material_SkyTint;
 uniform vec3 material_GroundTint;
 uniform float material_Exposure;
 uniform float material_AtmosphereThickness;
-uniform vec4 oasis_SunlightColor;
-uniform vec3 oasis_SunlightDirection;
+uniform vec4 scene_SunlightColor;
+uniform vec3 scene_SunlightDirection;
 
 varying vec3 v_GroundColor;
 varying vec3 v_SkyColor;
@@ -115,7 +115,7 @@ void main () {
 		{
 			float height = length(samplePoint);
 			float depth = exp(scaleOverScaleDepth * (innerRadius - height));
-			float lightAngle = dot(-oasis_SunlightDirection, samplePoint) / height;
+			float lightAngle = dot(-scene_SunlightDirection, samplePoint) / height;
 			float cameraAngle = dot(eyeRay, samplePoint) / height;
 			float scatter = (startOffset + depth*(scaleAngle(lightAngle) - scaleAngle(cameraAngle)));
 			vec3 attenuate = exp(-clamp(scatter, 0.0, MAX_SCATTER) * (invWavelength * kr4PI + km4PI));
@@ -126,7 +126,7 @@ void main () {
 		{
 			float height = length(samplePoint);
 			float depth = exp(scaleOverScaleDepth * (innerRadius - height));
-			float lightAngle = dot(-oasis_SunlightDirection, samplePoint) / height;
+			float lightAngle = dot(-scene_SunlightDirection, samplePoint) / height;
 			float cameraAngle = dot(eyeRay, samplePoint) / height;
 			float scatter = (startOffset + depth*(scaleAngle(lightAngle) - scaleAngle(cameraAngle)));
 			vec3 attenuate = exp(-clamp(scatter, 0.0, MAX_SCATTER) * (invWavelength * kr4PI + km4PI));
@@ -146,7 +146,7 @@ void main () {
 		// Calculate the ray's starting position, then calculate its scattering offset
 		float depth = exp((-cameraHeight) * (1.0/scaleDepth));
 		float cameraAngle = dot(-eyeRay, pos);
-		float lightAngle = dot(-oasis_SunlightDirection, pos);
+		float lightAngle = dot(-scene_SunlightDirection, pos);
 		float cameraScale = scaleAngle(cameraAngle);
 		float lightScale = scaleAngle(lightAngle);
 		float cameraOffset = depth*cameraScale;
@@ -189,17 +189,17 @@ void main () {
 	// 2. in case of gamma: do sqrt right away instead of doing that in fshader
 	
 	v_GroundColor = material_Exposure * (cIn + COLOR_2_LINEAR(material_GroundTint) * cOut);
-	v_SkyColor    = material_Exposure * (cIn * getRayleighPhase(-oasis_SunlightDirection, -eyeRay));
+	v_SkyColor    = material_Exposure * (cIn * getRayleighPhase(-scene_SunlightDirection, -eyeRay));
 
 	
 	// The sun should have a stable intensity in its course in the sky. Moreover it should match the highlight of a purely specular material.
 	// This matching was done using the standard shader BRDF1 on the 5/31/2017
 	// Finally we want the sun to be always bright even in LDR thus the normalization of the lightColor for low intensity.
-	float lightColorIntensity = clamp(length(oasis_SunlightColor.xyz), 0.25, 1.0);
+	float lightColorIntensity = clamp(length(scene_SunlightColor.xyz), 0.25, 1.0);
 
 	#ifdef MATERIAL_SUN_HIGH_QUALITY 
-		v_SunColor = HDSundiskIntensityFactor * clamp(cOut,0.0,1.0) * oasis_SunlightColor.xyz / lightColorIntensity;
+		v_SunColor = HDSundiskIntensityFactor * clamp(cOut,0.0,1.0) * scene_SunlightColor.xyz / lightColorIntensity;
 	#elif defined(MATERIAL_SUN_SIMPLE) 
-		v_SunColor = simpleSundiskIntensityFactor * clamp(cOut * sunScale,0.0,1.0) * oasis_SunlightColor.xyz / lightColorIntensity;
+		v_SunColor = simpleSundiskIntensityFactor * clamp(cOut * sunScale,0.0,1.0) * scene_SunlightColor.xyz / lightColorIntensity;
 	#endif
 }

--- a/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
+++ b/packages/core/src/shaderlib/extra/SkyProcedural.vs.glsl
@@ -31,7 +31,7 @@ const vec3 c_VariableRangeForScatteringWavelength = vec3(0.15, 0.15, 0.15);
 
 attribute vec4 POSITION;
 
-uniform mat4 u_VPMat;
+uniform mat4 galacean_VPMat;
 uniform vec3 u_SkyTint;
 uniform vec3 u_GroundTint;
 uniform float u_Exposure;
@@ -54,7 +54,7 @@ varying vec3 v_SkyColor;
 	varying vec3 v_SunColor;
 #endif
 
-#if defined(OASIS_COLORSPACE_GAMMA)
+#if defined(GALACEAN_COLORSPACE_GAMMA)
 	#define COLOR_2_GAMMA(color) color
 	#define COLOR_2_LINEAR(color) color*color
 #else
@@ -77,7 +77,7 @@ float scaleAngle(float inCos)
 }
 
 void main () {
-	gl_Position = u_VPMat*vec4(POSITION.xyz,1.0);
+	gl_Position = galacean_VPMat*vec4(POSITION.xyz,1.0);
 
  	vec3 skyTintInGammaSpace = COLOR_2_GAMMA(u_SkyTint);
 	vec3 scatteringWavelength = mix(c_DefaultScatteringWavelength-c_VariableRangeForScatteringWavelength,c_DefaultScatteringWavelength+c_VariableRangeForScatteringWavelength,vec3(1.0) - skyTintInGammaSpace); // using Tint in sRGB+ gamma allows for more visually linear interpolation and to keep (0.5) at (128, gray in sRGB) point

--- a/packages/core/src/shaderlib/extra/background-texture.fs.glsl
+++ b/packages/core/src/shaderlib/extra/background-texture.fs.glsl
@@ -1,7 +1,7 @@
-uniform sampler2D u_baseTexture;
+uniform sampler2D material_BaseTexture;
 
 varying vec2 v_uv;
 
 void main() {
-  gl_FragColor = texture2D(u_baseTexture, v_uv);
+  gl_FragColor = texture2D(material_BaseTexture, v_uv);
 }

--- a/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
+++ b/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
@@ -21,7 +21,7 @@ void main() {
 
     gl_FragColor = emission + ambient + diffuse + specular;
 
-    #ifdef OASIS_TRANSPARENT
+    #ifdef MATERIAL_IS_TRANSPARENT
         gl_FragColor.a = diffuse.a;
     #else
         gl_FragColor.a = 1.0;
@@ -29,7 +29,7 @@ void main() {
 
     #include <FogFragment>
 
-    #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/particle.vs.glsl
+++ b/packages/core/src/shaderlib/extra/particle.vs.glsl
@@ -11,17 +11,17 @@ attribute vec2 a_normalizedUv;
 
 uniform float u_time;
 uniform bool u_once;
-uniform mat4 u_MVPMat;
+uniform mat4 galacean_MVPMat;
 
 varying vec4 v_color;
 varying float v_lifeLeft;
 varying vec2 v_uv;
 
 #ifdef is2d
-  uniform mat4 u_viewInvMat;
-  uniform mat4 u_projMat;
-  uniform mat4 u_viewMat;
-  uniform mat4 u_modelMat;
+  uniform mat4 galacean_ViewInvMat;
+  uniform mat4 galacean_ProjMat;
+  uniform mat4 galacean_ViewMat;
+  uniform mat4 galacean_ModelMat;
 #endif
 
 mat2 rotation2d(float angle) {
@@ -72,13 +72,13 @@ void main() {
 
     vec2 rotatedPoint = rotation2d(angle) * vec2(a_normalizedUv.x, a_normalizedUv.y * a_uv.z);
 
-    vec3 basisX = u_viewInvMat[0].xyz;
-    vec3 basisZ = u_viewInvMat[1].xyz;
+    vec3 basisX = galacean_ViewInvMat[0].xyz;
+    vec3 basisZ = galacean_ViewInvMat[1].xyz;
 
     vec3 localPosition = vec3(basisX * rotatedPoint.x + 
                 basisZ * rotatedPoint.y) * scale + position;
 
-    gl_Position = u_projMat * u_viewMat * vec4(localPosition + u_modelMat[3].xyz, 1.);
+    gl_Position = galacean_ProjMat * galacean_ViewMat * vec4(localPosition + galacean_ModelMat[3].xyz, 1.);
   #else
     #ifdef rotateToVelocity
       float s = sin(angle);
@@ -117,6 +117,6 @@ void main() {
 
     rotatedPoint = localMatrix * rotatedPoint;
 
-    gl_Position = u_MVPMat * rotatedPoint;
+    gl_Position = galacean_MVPMat * rotatedPoint;
   #endif
 }

--- a/packages/core/src/shaderlib/extra/particle.vs.glsl
+++ b/packages/core/src/shaderlib/extra/particle.vs.glsl
@@ -11,17 +11,17 @@ attribute vec2 a_normalizedUv;
 
 uniform float u_time;
 uniform bool u_once;
-uniform mat4 galacean_MVPMat;
+uniform mat4 renderer_MVPMat;
 
 varying vec4 v_color;
 varying float v_lifeLeft;
 varying vec2 v_uv;
 
 #ifdef is2d
-  uniform mat4 galacean_ViewInvMat;
-  uniform mat4 galacean_ProjMat;
-  uniform mat4 galacean_ViewMat;
-  uniform mat4 galacean_ModelMat;
+  uniform mat4 camera_ViewInvMat;
+  uniform mat4 camera_ProjMat;
+  uniform mat4 camera_ViewMat;
+  uniform mat4 renderer_ModelMat;
 #endif
 
 mat2 rotation2d(float angle) {
@@ -72,13 +72,13 @@ void main() {
 
     vec2 rotatedPoint = rotation2d(angle) * vec2(a_normalizedUv.x, a_normalizedUv.y * a_uv.z);
 
-    vec3 basisX = galacean_ViewInvMat[0].xyz;
-    vec3 basisZ = galacean_ViewInvMat[1].xyz;
+    vec3 basisX = camera_ViewInvMat[0].xyz;
+    vec3 basisZ = camera_ViewInvMat[1].xyz;
 
     vec3 localPosition = vec3(basisX * rotatedPoint.x + 
                 basisZ * rotatedPoint.y) * scale + position;
 
-    gl_Position = galacean_ProjMat * galacean_ViewMat * vec4(localPosition + galacean_ModelMat[3].xyz, 1.);
+    gl_Position = camera_ProjMat * camera_ViewMat * vec4(localPosition + renderer_ModelMat[3].xyz, 1.);
   #else
     #ifdef rotateToVelocity
       float s = sin(angle);
@@ -117,6 +117,6 @@ void main() {
 
     rotatedPoint = localMatrix * rotatedPoint;
 
-    gl_Position = galacean_MVPMat * rotatedPoint;
+    gl_Position = renderer_MVPMat * rotatedPoint;
   #endif
 }

--- a/packages/core/src/shaderlib/extra/pbr-specular.fs.glsl
+++ b/packages/core/src/shaderlib/extra/pbr-specular.fs.glsl
@@ -18,7 +18,7 @@ void main() {
     #include <pbr_frag>
     #include <FogFragment>
 
-    #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/pbr.fs.glsl
+++ b/packages/core/src/shaderlib/extra/pbr.fs.glsl
@@ -18,7 +18,7 @@ void main() {
     #include <pbr_frag>
     #include <FogFragment>
     
-    #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/shadow-map.fs.glsl
+++ b/packages/core/src/shaderlib/extra/shadow-map.fs.glsl
@@ -1,4 +1,4 @@
-#ifdef GALACEAN_NO_DEPTH_TEXTURE
+#ifdef ENGINE_NO_DEPTH_TEXTURE
 /**
  * Decompose and save depth value.
 */
@@ -17,7 +17,7 @@ vec4 pack (float depth) {
 #endif
 
 void main() {
-#ifdef GALACEAN_NO_DEPTH_TEXTURE
+#ifdef ENGINE_NO_DEPTH_TEXTURE
     gl_FragColor = pack(gl_FragCoord.z);
 #else
     gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);

--- a/packages/core/src/shaderlib/extra/shadow-map.vs.glsl
+++ b/packages/core/src/shaderlib/extra/shadow-map.vs.glsl
@@ -2,18 +2,18 @@
 #include <common_vert>
 #include <blendShape_input>
 #include <normal_share>
-uniform mat4 u_VPMat;
-uniform vec2 u_shadowBias; // x: depth bias, y: normal bias
-uniform vec3 u_lightDirection;
+uniform mat4 galacean_VPMat;
+uniform vec2 galacean_ShadowBias; // x: depth bias, y: normal bias
+uniform vec3 galacean_LightDirection;
 
 vec3 applyShadowBias(vec3 positionWS) {
-    positionWS -= u_lightDirection * u_shadowBias.x;
+    positionWS -= galacean_LightDirection * galacean_ShadowBias.x;
     return positionWS;
 }
 
 vec3 applyShadowNormalBias(vec3 positionWS, vec3 normalWS) {
-    float invNdotL = 1.0 - clamp(dot(-u_lightDirection, normalWS), 0.0, 1.0);
-    float scale = invNdotL * u_shadowBias.y;
+    float invNdotL = 1.0 - clamp(dot(-galacean_LightDirection, normalWS), 0.0, 1.0);
+    float scale = invNdotL * galacean_ShadowBias.y;
     positionWS += normalWS * vec3(scale);
     return positionWS;
 }
@@ -25,18 +25,18 @@ void main() {
     #include <blendShape_vert>
     #include <skinning_vert>
     
-    vec4 positionWS = u_modelMat * position;
+    vec4 positionWS = galacean_ModelMat * position;
 
     positionWS.xyz = applyShadowBias(positionWS.xyz);
     #ifndef OMIT_NORMAL
-        #ifdef O3_HAS_NORMAL
-            vec3 normalWS = normalize( mat3(u_normalMat) * normal );
+        #ifdef GALACEAN_HAS_NORMAL
+            vec3 normalWS = normalize( mat3(galacean_NormalMat) * normal );
             positionWS.xyz = applyShadowNormalBias(positionWS.xyz, normalWS);
         #endif
     #endif
 
 
-    vec4 positionCS = u_VPMat * positionWS;
+    vec4 positionCS = galacean_VPMat * positionWS;
     positionCS.z = max(positionCS.z, -1.0);// clamp to min ndc z
 
     gl_Position = positionCS;

--- a/packages/core/src/shaderlib/extra/shadow-map.vs.glsl
+++ b/packages/core/src/shaderlib/extra/shadow-map.vs.glsl
@@ -2,18 +2,18 @@
 #include <common_vert>
 #include <blendShape_input>
 #include <normal_share>
-uniform mat4 galacean_VPMat;
-uniform vec2 galacean_ShadowBias; // x: depth bias, y: normal bias
-uniform vec3 galacean_LightDirection;
+uniform mat4 camera_VPMat;
+uniform vec2 scene_ShadowBias; // x: depth bias, y: normal bias
+uniform vec3 scene_LightDirection;
 
 vec3 applyShadowBias(vec3 positionWS) {
-    positionWS -= galacean_LightDirection * galacean_ShadowBias.x;
+    positionWS -= scene_LightDirection * scene_ShadowBias.x;
     return positionWS;
 }
 
 vec3 applyShadowNormalBias(vec3 positionWS, vec3 normalWS) {
-    float invNdotL = 1.0 - clamp(dot(-galacean_LightDirection, normalWS), 0.0, 1.0);
-    float scale = invNdotL * galacean_ShadowBias.y;
+    float invNdotL = 1.0 - clamp(dot(-scene_LightDirection, normalWS), 0.0, 1.0);
+    float scale = invNdotL * scene_ShadowBias.y;
     positionWS += normalWS * vec3(scale);
     return positionWS;
 }
@@ -25,18 +25,18 @@ void main() {
     #include <blendShape_vert>
     #include <skinning_vert>
     
-    vec4 positionWS = galacean_ModelMat * position;
+    vec4 positionWS = renderer_ModelMat * position;
 
     positionWS.xyz = applyShadowBias(positionWS.xyz);
-    #ifndef OMIT_NORMAL
-        #ifdef GALACEAN_HAS_NORMAL
-            vec3 normalWS = normalize( mat3(galacean_NormalMat) * normal );
+    #ifndef MATERIAL_OMIT_NORMAL
+        #ifdef RENDERER_HAS_NORMAL
+            vec3 normalWS = normalize( mat3(renderer_NormalMat) * normal );
             positionWS.xyz = applyShadowNormalBias(positionWS.xyz, normalWS);
         #endif
     #endif
 
 
-    vec4 positionCS = galacean_VPMat * positionWS;
+    vec4 positionCS = camera_VPMat * positionWS;
     positionCS.z = max(positionCS.z, -1.0);// clamp to min ndc z
 
     gl_Position = positionCS;

--- a/packages/core/src/shaderlib/extra/skybox.fs.glsl
+++ b/packages/core/src/shaderlib/extra/skybox.fs.glsl
@@ -10,13 +10,13 @@ void main() {
 
     #ifdef DECODE_SKY_RGBM
         textureColor = RGBMToLinear(textureColor, 5.0);
-    #elif !defined(OASIS_COLORSPACE_GAMMA)
+    #elif !defined(GALACEAN_COLORSPACE_GAMMA)
         textureColor = gammaToLinear(textureColor);
     #endif
 
     textureColor.rgb *= u_exposure * u_tintColor.rgb;
 
-    #if defined(DECODE_SKY_RGBM) || !defined(OASIS_COLORSPACE_GAMMA)
+    #if defined(DECODE_SKY_RGBM) || !defined(GALACEAN_COLORSPACE_GAMMA)
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/skybox.fs.glsl
+++ b/packages/core/src/shaderlib/extra/skybox.fs.glsl
@@ -15,6 +15,8 @@ void main() {
     #endif
 
     textureColor.rgb *= material_Exposure * material_TintColor.rgb;
+    
+    gl_FragColor = textureColor;
 
     #if defined(MATERIAL_IS_DECODE_SKY_RGBM) || !defined(ENGINE_IS_COLORSPACE_GAMMA)
         gl_FragColor = linearToGamma(gl_FragColor);

--- a/packages/core/src/shaderlib/extra/skybox.fs.glsl
+++ b/packages/core/src/shaderlib/extra/skybox.fs.glsl
@@ -1,22 +1,22 @@
 #include <common>
-uniform samplerCube u_cubeTexture;
+uniform samplerCube material_CubeTexture;
 
 varying vec3 v_cubeUV;
-uniform float u_exposure;
-uniform vec4 u_tintColor;
+uniform float material_Exposure;
+uniform vec4 material_TintColor;
 
 void main() {
-    vec4 textureColor = textureCube( u_cubeTexture, v_cubeUV );
+    vec4 textureColor = textureCube( material_CubeTexture, v_cubeUV );
 
-    #ifdef DECODE_SKY_RGBM
+    #ifdef MATERIAL_IS_DECODE_SKY_RGBM
         textureColor = RGBMToLinear(textureColor, 5.0);
-    #elif !defined(GALACEAN_COLORSPACE_GAMMA)
+    #elif !defined(ENGINE_IS_COLORSPACE_GAMMA)
         textureColor = gammaToLinear(textureColor);
     #endif
 
-    textureColor.rgb *= u_exposure * u_tintColor.rgb;
+    textureColor.rgb *= material_Exposure * material_TintColor.rgb;
 
-    #if defined(DECODE_SKY_RGBM) || !defined(GALACEAN_COLORSPACE_GAMMA)
+    #if defined(MATERIAL_IS_DECODE_SKY_RGBM) || !defined(ENGINE_IS_COLORSPACE_GAMMA)
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/extra/skybox.vs.glsl
+++ b/packages/core/src/shaderlib/extra/skybox.vs.glsl
@@ -1,6 +1,6 @@
 #include <common_vert>
 
-uniform mat4 u_VPMat;
+uniform mat4 galacean_VPMat;
 
 varying vec3 v_cubeUV;
 uniform float u_rotation;
@@ -16,5 +16,5 @@ vec4 rotateY(vec4 v, float angle) {
 
 void main() {
     v_cubeUV = vec3( -POSITION.x, POSITION.yz ); // TextureCube is left-hand,so x need inverse
-    gl_Position = u_VPMat * rotateY(vec4(POSITION, 1.0), u_rotation);
+    gl_Position = galacean_VPMat * rotateY(vec4(POSITION, 1.0), u_rotation);
 }

--- a/packages/core/src/shaderlib/extra/skybox.vs.glsl
+++ b/packages/core/src/shaderlib/extra/skybox.vs.glsl
@@ -1,9 +1,9 @@
 #include <common_vert>
 
-uniform mat4 galacean_VPMat;
+uniform mat4 camera_VPMat;
 
 varying vec3 v_cubeUV;
-uniform float u_rotation;
+uniform float material_Rotation;
 
 vec4 rotateY(vec4 v, float angle) {
 	const float deg2rad = 3.1415926 / 180.0;
@@ -16,5 +16,5 @@ vec4 rotateY(vec4 v, float angle) {
 
 void main() {
     v_cubeUV = vec3( -POSITION.x, POSITION.yz ); // TextureCube is left-hand,so x need inverse
-    gl_Position = galacean_VPMat * rotateY(vec4(POSITION, 1.0), u_rotation);
+    gl_Position = camera_VPMat * rotateY(vec4(POSITION, 1.0), material_Rotation);
 }

--- a/packages/core/src/shaderlib/extra/sprite-mask.fs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite-mask.fs.glsl
@@ -1,11 +1,11 @@
-uniform sampler2D galacean_MaskTexture;
-uniform float galacean_MaskAlphaCutoff;
+uniform sampler2D renderer_MaskTexture;
+uniform float renderer_MaskAlphaCutoff;
 varying vec2 v_uv;
 
 void main()
 {
-  vec4 color = texture2D(galacean_MaskTexture, v_uv);
-  if (color.a < galacean_MaskAlphaCutoff) {
+  vec4 color = texture2D(renderer_MaskTexture, v_uv);
+  if (color.a < renderer_MaskAlphaCutoff) {
     discard;
   }
 

--- a/packages/core/src/shaderlib/extra/sprite-mask.fs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite-mask.fs.glsl
@@ -1,11 +1,11 @@
-uniform sampler2D u_maskTexture;
-uniform float u_maskAlphaCutoff;
+uniform sampler2D galacean_MaskTexture;
+uniform float galacean_MaskAlphaCutoff;
 varying vec2 v_uv;
 
 void main()
 {
-  vec4 color = texture2D(u_maskTexture, v_uv);
-  if (color.a < u_maskAlphaCutoff) {
+  vec4 color = texture2D(galacean_MaskTexture, v_uv);
+  if (color.a < galacean_MaskAlphaCutoff) {
     discard;
   }
 

--- a/packages/core/src/shaderlib/extra/sprite-mask.vs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite-mask.vs.glsl
@@ -1,4 +1,4 @@
-uniform mat4 u_VPMat;
+uniform mat4 galacean_VPMat;
 
 attribute vec3 POSITION;
 attribute vec2 TEXCOORD_0;
@@ -7,6 +7,6 @@ varying vec2 v_uv;
 
 void main()
 {
-  gl_Position = u_VPMat * vec4(POSITION, 1.0);
+  gl_Position = galacean_VPMat * vec4(POSITION, 1.0);
   v_uv = TEXCOORD_0;
 }

--- a/packages/core/src/shaderlib/extra/sprite-mask.vs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite-mask.vs.glsl
@@ -1,4 +1,4 @@
-uniform mat4 galacean_VPMat;
+uniform mat4 camera_VPMat;
 
 attribute vec3 POSITION;
 attribute vec2 TEXCOORD_0;
@@ -7,6 +7,6 @@ varying vec2 v_uv;
 
 void main()
 {
-  gl_Position = galacean_VPMat * vec4(POSITION, 1.0);
+  gl_Position = camera_VPMat * vec4(POSITION, 1.0);
   v_uv = TEXCOORD_0;
 }

--- a/packages/core/src/shaderlib/extra/sprite.fs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite.fs.glsl
@@ -1,7 +1,7 @@
 #ifdef USE_CUSTOM_TEXTURE
 uniform sampler2D u_cusTomTexture;
 #else
-uniform sampler2D u_spriteTexture;
+uniform sampler2D galacean_SpriteTexture;
 #endif
 
 varying vec2 v_uv;
@@ -13,7 +13,7 @@ void main()
   #ifdef USE_CUSTOM_TEXTURE
   vec4 baseColor = texture2D(u_cusTomTexture, v_uv);
   #else
-  vec4 baseColor = texture2D(u_spriteTexture, v_uv);
+  vec4 baseColor = texture2D(galacean_SpriteTexture, v_uv);
   #endif
   gl_FragColor = baseColor * v_color;
 }

--- a/packages/core/src/shaderlib/extra/sprite.fs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite.fs.glsl
@@ -1,19 +1,10 @@
-#ifdef USE_CUSTOM_TEXTURE
-uniform sampler2D u_cusTomTexture;
-#else
-uniform sampler2D galacean_SpriteTexture;
-#endif
+uniform sampler2D renderer_SpriteTexture;
 
 varying vec2 v_uv;
 varying vec4 v_color;
 
 void main()
 {
-  // Only use the Alpha of the texture as a mask, so that the tint color can still be controlled to fade out.
-  #ifdef USE_CUSTOM_TEXTURE
-  vec4 baseColor = texture2D(u_cusTomTexture, v_uv);
-  #else
-  vec4 baseColor = texture2D(galacean_SpriteTexture, v_uv);
-  #endif
+  vec4 baseColor = texture2D(renderer_SpriteTexture, v_uv);
   gl_FragColor = baseColor * v_color;
 }

--- a/packages/core/src/shaderlib/extra/sprite.vs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite.vs.glsl
@@ -1,4 +1,4 @@
-uniform mat4 u_MVPMat;
+uniform mat4 galacean_MVPMat;
 
 attribute vec3 POSITION;
 attribute vec2 TEXCOORD_0;
@@ -9,7 +9,7 @@ varying vec4 v_color;
 
 void main()
 {
-  gl_Position = u_MVPMat * vec4(POSITION, 1.0);
+  gl_Position = galacean_MVPMat * vec4(POSITION, 1.0);
 
   v_uv = TEXCOORD_0;
   v_color = COLOR_0;

--- a/packages/core/src/shaderlib/extra/sprite.vs.glsl
+++ b/packages/core/src/shaderlib/extra/sprite.vs.glsl
@@ -1,4 +1,4 @@
-uniform mat4 galacean_MVPMat;
+uniform mat4 renderer_MVPMat;
 
 attribute vec3 POSITION;
 attribute vec2 TEXCOORD_0;
@@ -9,7 +9,7 @@ varying vec4 v_color;
 
 void main()
 {
-  gl_Position = galacean_MVPMat * vec4(POSITION, 1.0);
+  gl_Position = renderer_MVPMat * vec4(POSITION, 1.0);
 
   v_uv = TEXCOORD_0;
   v_color = COLOR_0;

--- a/packages/core/src/shaderlib/extra/unlit.fs.glsl
+++ b/packages/core/src/shaderlib/extra/unlit.fs.glsl
@@ -2,39 +2,39 @@
 #include <uv_share>
 #include <FogFragmentDeclaration>
 
-uniform vec4 u_baseColor;
-uniform float u_alphaCutoff;
+uniform vec4 material_BaseColor;
+uniform float material_AlphaCutoff;
 
-#ifdef BASETEXTURE
-    uniform sampler2D u_baseTexture;
+#ifdef MATERIAL_HAS_BASETEXTURE
+    uniform sampler2D material_BaseTexture;
 #endif
 
 void main() {
-     vec4 baseColor = u_baseColor;
+     vec4 baseColor = material_BaseColor;
 
-    #ifdef BASETEXTURE
-        vec4 textureColor = texture2D(u_baseTexture, v_uv);
-        #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifdef MATERIAL_HAS_BASETEXTURE
+        vec4 textureColor = texture2D(material_BaseTexture, v_uv);
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
             textureColor = gammaToLinear(textureColor);
         #endif
         baseColor *= textureColor;
     #endif
 
-    #ifdef ALPHA_CUTOFF
-        if( baseColor.a < u_alphaCutoff ) {
+    #ifdef MATERIAL_IS_ALPHA_CUTOFF
+        if( baseColor.a < material_AlphaCutoff ) {
             discard;
         }
     #endif
 
     gl_FragColor = baseColor;
 
-    #ifndef OASIS_TRANSPARENT
+    #ifndef MATERIAL_IS_TRANSPARENT
         gl_FragColor.a = 1.0;
     #endif
 
     #include <FogFragment>
 
-     #ifndef GALACEAN_COLORSPACE_GAMMA
+     #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/packages/core/src/shaderlib/light_frag_define.glsl
+++ b/packages/core/src/shaderlib/light_frag_define.glsl
@@ -1,20 +1,20 @@
 // Directional light
-#ifdef O3_DIRECT_LIGHT_COUNT
+#ifdef SCENE_DIRECT_LIGHT_COUNT
 
     struct DirectLight {
         vec3 color;
         vec3 direction;
     };
 
-    uniform ivec2 galacean_DirectLightCullingMask[O3_DIRECT_LIGHT_COUNT];
-    uniform vec3 galacean_DirectLightColor[O3_DIRECT_LIGHT_COUNT];
-    uniform vec3 galacean_DirectLightDirection[O3_DIRECT_LIGHT_COUNT];
+    uniform ivec2 scene_DirectLightCullingMask[SCENE_DIRECT_LIGHT_COUNT];
+    uniform vec3 scene_DirectLightColor[SCENE_DIRECT_LIGHT_COUNT];
+    uniform vec3 scene_DirectLightDirection[SCENE_DIRECT_LIGHT_COUNT];
 
 #endif
 
 
 // Point light
-#ifdef O3_POINT_LIGHT_COUNT
+#ifdef SCENE_POINT_LIGHT_COUNT
 
     struct PointLight {
         vec3 color;
@@ -22,16 +22,16 @@
         float distance;
     };
 
-    uniform ivec2 galacean_PointLightCullingMask[ O3_POINT_LIGHT_COUNT ];
-    uniform vec3 galacean_PointLightColor[ O3_POINT_LIGHT_COUNT ];
-    uniform vec3 galacean_PointLightPosition[ O3_POINT_LIGHT_COUNT ];
-    uniform float galacean_PointLightDistance[ O3_POINT_LIGHT_COUNT ];
+    uniform ivec2 scene_PointLightCullingMask[ SCENE_POINT_LIGHT_COUNT ];
+    uniform vec3 scene_PointLightColor[ SCENE_POINT_LIGHT_COUNT ];
+    uniform vec3 scene_PointLightPosition[ SCENE_POINT_LIGHT_COUNT ];
+    uniform float scene_PointLightDistance[ SCENE_POINT_LIGHT_COUNT ];
 
 #endif
 
 
 // Spot light
-#ifdef O3_SPOT_LIGHT_COUNT
+#ifdef SCENE_SPOT_LIGHT_COUNT
 
     struct SpotLight {
         vec3 color;
@@ -42,13 +42,13 @@
         float penumbraCos;
     };
 
-    uniform ivec2 galacean_SpotLightCullingMask[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 galacean_SpotLightColor[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 galacean_SpotLightPosition[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 galacean_SpotLightDirection[ O3_SPOT_LIGHT_COUNT ];
-    uniform float galacean_SpotLightDistance[ O3_SPOT_LIGHT_COUNT ];
-    uniform float galacean_SpotLightAngleCos[ O3_SPOT_LIGHT_COUNT ];
-    uniform float galacean_SpotLightPenumbraCos[ O3_SPOT_LIGHT_COUNT ];
+    uniform ivec2 scene_SpotLightCullingMask[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform vec3 scene_SpotLightColor[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform vec3 scene_SpotLightPosition[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform vec3 scene_SpotLightDirection[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform float scene_SpotLightDistance[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform float scene_SpotLightAngleCos[ SCENE_SPOT_LIGHT_COUNT ];
+    uniform float scene_SpotLightPenumbraCos[ SCENE_SPOT_LIGHT_COUNT ];
 
 #endif
 
@@ -61,15 +61,15 @@ struct EnvMapLight {
 };
 
 
-uniform EnvMapLight u_envMapLight;
-uniform ivec4 galacean_RendererLayer;
+uniform EnvMapLight scene_EnvMapLight;
+uniform ivec4 renderer_Layer;
 
-#ifdef GALACEAN_USE_SH
-    uniform vec3 galacean_EnvSH[9];
+#ifdef SCENE_USE_SH
+    uniform vec3 scene_EnvSH[9];
 #endif
 
-#ifdef GALACEAN_USE_SPECULAR_ENV
-    uniform samplerCube galacean_EnvSpecularSampler;
+#ifdef SCENE_USE_SPECULAR_ENV
+    uniform samplerCube scene_EnvSpecularSampler;
 #endif
 
 #ifndef GRAPHICS_API_WEBGL2

--- a/packages/core/src/shaderlib/light_frag_define.glsl
+++ b/packages/core/src/shaderlib/light_frag_define.glsl
@@ -6,9 +6,9 @@
         vec3 direction;
     };
 
-    uniform ivec2 u_directLightCullingMask[O3_DIRECT_LIGHT_COUNT];
-    uniform vec3 u_directLightColor[O3_DIRECT_LIGHT_COUNT];
-    uniform vec3 u_directLightDirection[O3_DIRECT_LIGHT_COUNT];
+    uniform ivec2 galacean_DirectLightCullingMask[O3_DIRECT_LIGHT_COUNT];
+    uniform vec3 galacean_DirectLightColor[O3_DIRECT_LIGHT_COUNT];
+    uniform vec3 galacean_DirectLightDirection[O3_DIRECT_LIGHT_COUNT];
 
 #endif
 
@@ -22,10 +22,10 @@
         float distance;
     };
 
-    uniform ivec2 u_pointLightCullingMask[ O3_POINT_LIGHT_COUNT ];
-    uniform vec3 u_pointLightColor[ O3_POINT_LIGHT_COUNT ];
-    uniform vec3 u_pointLightPosition[ O3_POINT_LIGHT_COUNT ];
-    uniform float u_pointLightDistance[ O3_POINT_LIGHT_COUNT ];
+    uniform ivec2 galacean_PointLightCullingMask[ O3_POINT_LIGHT_COUNT ];
+    uniform vec3 galacean_PointLightColor[ O3_POINT_LIGHT_COUNT ];
+    uniform vec3 galacean_PointLightPosition[ O3_POINT_LIGHT_COUNT ];
+    uniform float galacean_PointLightDistance[ O3_POINT_LIGHT_COUNT ];
 
 #endif
 
@@ -42,13 +42,13 @@
         float penumbraCos;
     };
 
-    uniform ivec2 u_spotLightCullingMask[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 u_spotLightColor[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 u_spotLightPosition[ O3_SPOT_LIGHT_COUNT ];
-    uniform vec3 u_spotLightDirection[ O3_SPOT_LIGHT_COUNT ];
-    uniform float u_spotLightDistance[ O3_SPOT_LIGHT_COUNT ];
-    uniform float u_spotLightAngleCos[ O3_SPOT_LIGHT_COUNT ];
-    uniform float u_spotLightPenumbraCos[ O3_SPOT_LIGHT_COUNT ];
+    uniform ivec2 galacean_SpotLightCullingMask[ O3_SPOT_LIGHT_COUNT ];
+    uniform vec3 galacean_SpotLightColor[ O3_SPOT_LIGHT_COUNT ];
+    uniform vec3 galacean_SpotLightPosition[ O3_SPOT_LIGHT_COUNT ];
+    uniform vec3 galacean_SpotLightDirection[ O3_SPOT_LIGHT_COUNT ];
+    uniform float galacean_SpotLightDistance[ O3_SPOT_LIGHT_COUNT ];
+    uniform float galacean_SpotLightAngleCos[ O3_SPOT_LIGHT_COUNT ];
+    uniform float galacean_SpotLightPenumbraCos[ O3_SPOT_LIGHT_COUNT ];
 
 #endif
 
@@ -64,12 +64,12 @@ struct EnvMapLight {
 uniform EnvMapLight u_envMapLight;
 uniform ivec4 galacean_RendererLayer;
 
-#ifdef O3_USE_SH
-    uniform vec3 u_env_sh[9];
+#ifdef GALACEAN_USE_SH
+    uniform vec3 galacean_EnvSH[9];
 #endif
 
-#ifdef O3_USE_SPECULAR_ENV
-    uniform samplerCube u_env_specularSampler;
+#ifdef GALACEAN_USE_SPECULAR_ENV
+    uniform samplerCube galacean_EnvSpecularSampler;
 #endif
 
 #ifndef GRAPHICS_API_WEBGL2

--- a/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
@@ -13,21 +13,21 @@
     shadowAttenuation = 1.0;
     #ifdef GALACEAN_CALCULATE_SHADOWS
         shadowAttenuation *= sampleShadowMap();
-        int sunIndex = int(u_shadowInfo.z);
+        int sunIndex = int(galacean_ShadowInfo.z);
     #endif
 
     DirectLight directionalLight;
     for( int i = 0; i < O3_DIRECT_LIGHT_COUNT; i++ ) {
-        if(isRendererCulledByLight(galacean_RendererLayer.xy, u_directLightCullingMask[i])) 
+        if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_DirectLightCullingMask[i])) 
             continue;
 
-        directionalLight.color = u_directLightColor[i];
+        directionalLight.color = galacean_DirectLightColor[i];
         #ifdef GALACEAN_CALCULATE_SHADOWS
             if (i == sunIndex) {
                 directionalLight.color *= shadowAttenuation;
             }
         #endif
-        directionalLight.direction = u_directLightDirection[i];
+        directionalLight.direction = galacean_DirectLightDirection[i];
 
         float d = max(dot(N, -directionalLight.direction), 0.0);
         lightDiffuse += directionalLight.color * d;
@@ -44,12 +44,12 @@
     PointLight pointLight;
 
     for( int i = 0; i < O3_POINT_LIGHT_COUNT; i++ ) {
-        if(isRendererCulledByLight(galacean_RendererLayer.xy, u_pointLightCullingMask[i])) 
+        if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_PointLightCullingMask[i])) 
             continue;
 
-        pointLight.color = u_pointLightColor[i];
-        pointLight.position = u_pointLightPosition[i];
-        pointLight.distance = u_pointLightDistance[i];
+        pointLight.color = galacean_PointLightColor[i];
+        pointLight.position = galacean_PointLightPosition[i];
+        pointLight.distance = galacean_PointLightDistance[i];
 
         vec3 direction = v_pos - pointLight.position;
         float dist = length( direction );
@@ -72,15 +72,15 @@
     SpotLight spotLight;
 
     for( int i = 0; i < O3_SPOT_LIGHT_COUNT; i++) {
-        if(isRendererCulledByLight(galacean_RendererLayer.xy, u_spotLightCullingMask[i])) 
+        if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_SpotLightCullingMask[i])) 
             continue;
         
-        spotLight.color = u_spotLightColor[i];
-        spotLight.position = u_spotLightPosition[i];
-        spotLight.direction = u_spotLightDirection[i];
-        spotLight.distance = u_spotLightDistance[i];
-        spotLight.angleCos = u_spotLightAngleCos[i];
-        spotLight.penumbraCos = u_spotLightPenumbraCos[i];
+        spotLight.color = galacean_SpotLightColor[i];
+        spotLight.position = galacean_SpotLightPosition[i];
+        spotLight.direction = galacean_SpotLightDirection[i];
+        spotLight.distance = galacean_SpotLightDistance[i];
+        spotLight.angleCos = galacean_SpotLightAngleCos[i];
+        spotLight.penumbraCos = galacean_SpotLightPenumbraCos[i];
 
         vec3 direction = spotLight.position - v_pos;
         float lightDistance = length( direction );

--- a/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
@@ -11,7 +11,7 @@
 
     #ifdef SCENE_DIRECT_LIGHT_COUNT
     shadowAttenuation = 1.0;
-    #ifdef GALACEAN_CALCULATE_SHADOWS
+    #ifdef SCENE_IS_CALCULATE_SHADOWS
         shadowAttenuation *= sampleShadowMap();
         int sunIndex = int(scene_ShadowInfo.z);
     #endif
@@ -22,7 +22,7 @@
             continue;
 
         directionalLight.color = scene_DirectLightColor[i];
-        #ifdef GALACEAN_CALCULATE_SHADOWS
+        #ifdef SCENE_IS_CALCULATE_SHADOWS
             if (i == sunIndex) {
                 directionalLight.color *= shadowAttenuation;
             }

--- a/packages/core/src/shaderlib/mobile_material_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_material_frag.glsl
@@ -13,7 +13,7 @@ uniform float material_AlphaCutoff;
     uniform sampler2D material_BaseTexture;
 #endif
 
-#ifdef O3_SPECULAR_TEXTURE
+#ifdef MATERIAL_SPECULAR_TEXTURE
     uniform sampler2D material_SpecularTexture;
 #endif
 

--- a/packages/core/src/shaderlib/mobile_material_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_material_frag.glsl
@@ -1,22 +1,22 @@
-uniform vec4 u_emissiveColor;
-uniform vec4 u_baseColor;
-uniform vec4 u_specularColor;
-uniform float u_shininess;
-uniform float u_normalIntensity;
-uniform float u_alphaCutoff;
+uniform vec4 material_EmissiveColor;
+uniform vec4 material_BaseColor;
+uniform vec4 material_SpecularColor;
+uniform float material_Shininess;
+uniform float material_NormalIntensity;
+uniform float material_AlphaCutoff;
 
-#ifdef EMISSIVETEXTURE
-    uniform sampler2D u_emissiveTexture;
+#ifdef MATERIAL_HAS_EMISSIVETEXTURE
+    uniform sampler2D material_EmissiveTexture;
 #endif
 
-#ifdef BASETEXTURE
-    uniform sampler2D u_baseTexture;
+#ifdef MATERIAL_HAS_BASETEXTURE
+    uniform sampler2D material_BaseTexture;
 #endif
 
 #ifdef O3_SPECULAR_TEXTURE
-    uniform sampler2D u_specularTexture;
+    uniform sampler2D material_SpecularTexture;
 #endif
 
-#ifdef NORMALTEXTURE
-    uniform sampler2D u_normalTexture;
+#ifdef MATERIAL_HAS_NORMALTEXTURE
+    uniform sampler2D material_NormalTexture;
 #endif

--- a/packages/core/src/shaderlib/mobile_material_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_material_frag.glsl
@@ -13,7 +13,7 @@ uniform float material_AlphaCutoff;
     uniform sampler2D material_BaseTexture;
 #endif
 
-#ifdef MATERIAL_SPECULAR_TEXTURE
+#ifdef MATERIAL_HAS_SPECULAR_TEXTURE
     uniform sampler2D material_SpecularTexture;
 #endif
 

--- a/packages/core/src/shaderlib/normal_get.glsl
+++ b/packages/core/src/shaderlib/normal_get.glsl
@@ -22,7 +22,7 @@ vec3 getNormalByNormalTexture(mat3 tbn, sampler2D normalTexture, float normalInt
 }
 
 mat3 getTBN(){
-    #if defined(RENDERER_HAS_NORMAL) && defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+    #if defined(RENDERER_HAS_NORMAL) && defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
         mat3 tbn = v_TBN;
     #else
         vec3 normal = getNormal();

--- a/packages/core/src/shaderlib/normal_get.glsl
+++ b/packages/core/src/shaderlib/normal_get.glsl
@@ -1,5 +1,5 @@
 vec3 getNormal(){
-    #ifdef O3_HAS_NORMAL
+    #ifdef GALACEAN_HAS_NORMAL
         vec3 normal = normalize(v_normal);
     #elif defined(HAS_DERIVATIVES)
         vec3 pos_dx = dFdx(v_pos);
@@ -22,7 +22,7 @@ vec3 getNormalByNormalTexture(mat3 tbn, sampler2D normalTexture, float normalInt
 }
 
 mat3 getTBN(){
-    #if defined(O3_HAS_NORMAL) && defined(O3_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+    #if defined(GALACEAN_HAS_NORMAL) && defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
         mat3 tbn = v_TBN;
     #else
         vec3 normal = getNormal();

--- a/packages/core/src/shaderlib/normal_get.glsl
+++ b/packages/core/src/shaderlib/normal_get.glsl
@@ -1,5 +1,5 @@
 vec3 getNormal(){
-    #ifdef GALACEAN_HAS_NORMAL
+    #ifdef RENDERER_HAS_NORMAL
         vec3 normal = normalize(v_normal);
     #elif defined(HAS_DERIVATIVES)
         vec3 pos_dx = dFdx(v_pos);
@@ -22,7 +22,7 @@ vec3 getNormalByNormalTexture(mat3 tbn, sampler2D normalTexture, float normalInt
 }
 
 mat3 getTBN(){
-    #if defined(GALACEAN_HAS_NORMAL) && defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+    #if defined(RENDERER_HAS_NORMAL) && defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
         mat3 tbn = v_TBN;
     #else
         vec3 normal = getNormal();

--- a/packages/core/src/shaderlib/normal_share.glsl
+++ b/packages/core/src/shaderlib/normal_share.glsl
@@ -1,7 +1,7 @@
-#ifndef OMIT_NORMAL
-    #ifdef GALACEAN_HAS_NORMAL
+#ifndef MATERIAL_OMIT_NORMAL
+    #ifdef RENDERER_HAS_NORMAL
         varying vec3 v_normal;
-        #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
             varying mat3 v_TBN;
         #endif
     #endif

--- a/packages/core/src/shaderlib/normal_share.glsl
+++ b/packages/core/src/shaderlib/normal_share.glsl
@@ -1,7 +1,7 @@
 #ifndef OMIT_NORMAL
-    #ifdef O3_HAS_NORMAL
+    #ifdef GALACEAN_HAS_NORMAL
         varying vec3 v_normal;
-        #if defined(O3_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+        #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
             varying mat3 v_TBN;
         #endif
     #endif

--- a/packages/core/src/shaderlib/normal_share.glsl
+++ b/packages/core/src/shaderlib/normal_share.glsl
@@ -1,7 +1,7 @@
 #ifndef MATERIAL_OMIT_NORMAL
     #ifdef RENDERER_HAS_NORMAL
         varying vec3 v_normal;
-        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
             varying mat3 v_TBN;
         #endif
     #endif

--- a/packages/core/src/shaderlib/normal_vert.glsl
+++ b/packages/core/src/shaderlib/normal_vert.glsl
@@ -1,10 +1,10 @@
-#ifndef OMIT_NORMAL
-    #ifdef GALACEAN_HAS_NORMAL
-        v_normal = normalize( mat3(galacean_NormalMat) * normal );
+#ifndef MATERIAL_OMIT_NORMAL
+    #ifdef RENDERER_HAS_NORMAL
+        v_normal = normalize( mat3(renderer_NormalMat) * normal );
 
-        #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-            vec3 normalW = normalize( mat3(galacean_NormalMat) * normal.xyz );
-            vec3 tangentW = normalize( mat3(galacean_NormalMat) * tangent.xyz );
+        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+            vec3 normalW = normalize( mat3(renderer_NormalMat) * normal.xyz );
+            vec3 tangentW = normalize( mat3(renderer_NormalMat) * tangent.xyz );
             vec3 bitangentW = cross( normalW, tangentW ) * tangent.w;
 
             v_TBN = mat3( tangentW, bitangentW, normalW );

--- a/packages/core/src/shaderlib/normal_vert.glsl
+++ b/packages/core/src/shaderlib/normal_vert.glsl
@@ -2,7 +2,7 @@
     #ifdef RENDERER_HAS_NORMAL
         v_normal = normalize( mat3(renderer_NormalMat) * normal );
 
-        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+        #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
             vec3 normalW = normalize( mat3(renderer_NormalMat) * normal.xyz );
             vec3 tangentW = normalize( mat3(renderer_NormalMat) * tangent.xyz );
             vec3 bitangentW = cross( normalW, tangentW ) * tangent.w;

--- a/packages/core/src/shaderlib/normal_vert.glsl
+++ b/packages/core/src/shaderlib/normal_vert.glsl
@@ -1,10 +1,10 @@
 #ifndef OMIT_NORMAL
-    #ifdef O3_HAS_NORMAL
-        v_normal = normalize( mat3(u_normalMat) * normal );
+    #ifdef GALACEAN_HAS_NORMAL
+        v_normal = normalize( mat3(galacean_NormalMat) * normal );
 
-        #if defined(O3_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
-            vec3 normalW = normalize( mat3(u_normalMat) * normal.xyz );
-            vec3 tangentW = normalize( mat3(u_normalMat) * tangent.xyz );
+        #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+            vec3 normalW = normalize( mat3(galacean_NormalMat) * normal.xyz );
+            vec3 tangentW = normalize( mat3(galacean_NormalMat) * tangent.xyz );
             vec3 bitangentW = cross( normalW, tangentW ) * tangent.w;
 
             v_TBN = mat3( tangentW, bitangentW, normalW );

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -79,21 +79,21 @@ void addTotalDirectRadiance(Geometry geometry, Material material, inout Reflecte
         shadowAttenuation = 1.0;
     #ifdef GALACEAN_CALCULATE_SHADOWS
         shadowAttenuation *= sampleShadowMap();
-        int sunIndex = int(u_shadowInfo.z);
+        int sunIndex = int(galacean_ShadowInfo.z);
     #endif
 
         DirectLight directionalLight;
         for ( int i = 0; i < O3_DIRECT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, u_directLightCullingMask[i])) 
+            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_DirectLightCullingMask[i])) 
                 continue;
 
-            directionalLight.color = u_directLightColor[i];
+            directionalLight.color = galacean_DirectLightColor[i];
             #ifdef GALACEAN_CALCULATE_SHADOWS
                 if (i == sunIndex) {
                     directionalLight.color *= shadowAttenuation;
                 }
             #endif
-            directionalLight.direction = u_directLightDirection[i];
+            directionalLight.direction = galacean_DirectLightDirection[i];
             addDirectionalDirectLightRadiance( directionalLight, geometry, material, reflectedLight );
         }
 
@@ -104,12 +104,12 @@ void addTotalDirectRadiance(Geometry geometry, Material material, inout Reflecte
         PointLight pointLight;
 
         for ( int i = 0; i < O3_POINT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, u_pointLightCullingMask[i])) 
+            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_PointLightCullingMask[i])) 
                 continue;
 
-            pointLight.color = u_pointLightColor[i];
-            pointLight.position = u_pointLightPosition[i];
-            pointLight.distance = u_pointLightDistance[i];
+            pointLight.color = galacean_PointLightColor[i];
+            pointLight.position = galacean_PointLightPosition[i];
+            pointLight.distance = galacean_PointLightDistance[i];
 
             addPointDirectLightRadiance( pointLight, geometry, material, reflectedLight );
         }
@@ -121,15 +121,15 @@ void addTotalDirectRadiance(Geometry geometry, Material material, inout Reflecte
         SpotLight spotLight;
 
         for ( int i = 0; i < O3_SPOT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, u_spotLightCullingMask[i])) 
+            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_SpotLightCullingMask[i])) 
                 continue;
 
-            spotLight.color = u_spotLightColor[i];
-            spotLight.position = u_spotLightPosition[i];
-            spotLight.direction = u_spotLightDirection[i];
-            spotLight.distance = u_spotLightDistance[i];
-            spotLight.angleCos = u_spotLightAngleCos[i];
-            spotLight.penumbraCos = u_spotLightPenumbraCos[i];
+            spotLight.color = galacean_SpotLightColor[i];
+            spotLight.position = galacean_SpotLightPosition[i];
+            spotLight.direction = galacean_SpotLightDirection[i];
+            spotLight.distance = galacean_SpotLightDistance[i];
+            spotLight.angleCos = galacean_SpotLightAngleCos[i];
+            spotLight.penumbraCos = galacean_SpotLightPenumbraCos[i];
 
             addSpotDirectLightRadiance( spotLight, geometry, material, reflectedLight );
         }

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -3,7 +3,7 @@
 void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Material material, inout ReflectedLight reflectedLight) {
     float attenuation = 1.0;
 
-    #ifdef CLEARCOAT
+    #ifdef MATERIAL_CLEARCOAT
         float clearCoatDotNL = saturate( dot( geometry.clearCoatNormal, incidentDirection ) );
         vec3 clearCoatIrradiance = clearCoatDotNL * color;
         

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -77,7 +77,7 @@ void addTotalDirectRadiance(Geometry geometry, Material material, inout Reflecte
 
     #ifdef SCENE_DIRECT_LIGHT_COUNT
         shadowAttenuation = 1.0;
-    #ifdef GALACEAN_CALCULATE_SHADOWS
+    #ifdef SCENE_IS_CALCULATE_SHADOWS
         shadowAttenuation *= sampleShadowMap();
         int sunIndex = int(scene_ShadowInfo.z);
     #endif
@@ -88,7 +88,7 @@ void addTotalDirectRadiance(Geometry geometry, Material material, inout Reflecte
                 continue;
 
             directionalLight.color = scene_DirectLightColor[i];
-            #ifdef GALACEAN_CALCULATE_SHADOWS
+            #ifdef SCENE_IS_CALCULATE_SHADOWS
                 if (i == sunIndex) {
                     directionalLight.color *= shadowAttenuation;
                 }

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -19,7 +19,7 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
 
 }
 
-#ifdef O3_DIRECT_LIGHT_COUNT
+#ifdef SCENE_DIRECT_LIGHT_COUNT
 
     void addDirectionalDirectLightRadiance(DirectLight directionalLight, Geometry geometry, Material material, inout ReflectedLight reflectedLight) {
         vec3 color = directionalLight.color;
@@ -31,7 +31,7 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
 
 #endif
 
-#ifdef O3_POINT_LIGHT_COUNT
+#ifdef SCENE_POINT_LIGHT_COUNT
 
 	void addPointDirectLightRadiance(PointLight pointLight, Geometry geometry, Material material, inout ReflectedLight reflectedLight) {
 
@@ -49,7 +49,7 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
 
 #endif
 
-#ifdef O3_SPOT_LIGHT_COUNT
+#ifdef SCENE_SPOT_LIGHT_COUNT
 
 	void addSpotDirectLightRadiance(SpotLight spotLight, Geometry geometry, Material material, inout ReflectedLight reflectedLight) {
 
@@ -75,61 +75,61 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
 void addTotalDirectRadiance(Geometry geometry, Material material, inout ReflectedLight reflectedLight){
     float shadowAttenuation = 1.0;
 
-    #ifdef O3_DIRECT_LIGHT_COUNT
+    #ifdef SCENE_DIRECT_LIGHT_COUNT
         shadowAttenuation = 1.0;
     #ifdef GALACEAN_CALCULATE_SHADOWS
         shadowAttenuation *= sampleShadowMap();
-        int sunIndex = int(galacean_ShadowInfo.z);
+        int sunIndex = int(scene_ShadowInfo.z);
     #endif
 
         DirectLight directionalLight;
-        for ( int i = 0; i < O3_DIRECT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_DirectLightCullingMask[i])) 
+        for ( int i = 0; i < SCENE_DIRECT_LIGHT_COUNT; i ++ ) {
+            if(isRendererCulledByLight(renderer_Layer.xy, scene_DirectLightCullingMask[i])) 
                 continue;
 
-            directionalLight.color = galacean_DirectLightColor[i];
+            directionalLight.color = scene_DirectLightColor[i];
             #ifdef GALACEAN_CALCULATE_SHADOWS
                 if (i == sunIndex) {
                     directionalLight.color *= shadowAttenuation;
                 }
             #endif
-            directionalLight.direction = galacean_DirectLightDirection[i];
+            directionalLight.direction = scene_DirectLightDirection[i];
             addDirectionalDirectLightRadiance( directionalLight, geometry, material, reflectedLight );
         }
 
     #endif
 
-    #ifdef O3_POINT_LIGHT_COUNT
+    #ifdef SCENE_POINT_LIGHT_COUNT
 
         PointLight pointLight;
 
-        for ( int i = 0; i < O3_POINT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_PointLightCullingMask[i])) 
+        for ( int i = 0; i < SCENE_POINT_LIGHT_COUNT; i ++ ) {
+            if(isRendererCulledByLight(renderer_Layer.xy, scene_PointLightCullingMask[i])) 
                 continue;
 
-            pointLight.color = galacean_PointLightColor[i];
-            pointLight.position = galacean_PointLightPosition[i];
-            pointLight.distance = galacean_PointLightDistance[i];
+            pointLight.color = scene_PointLightColor[i];
+            pointLight.position = scene_PointLightPosition[i];
+            pointLight.distance = scene_PointLightDistance[i];
 
             addPointDirectLightRadiance( pointLight, geometry, material, reflectedLight );
         }
 
     #endif
 
-    #ifdef O3_SPOT_LIGHT_COUNT
+    #ifdef SCENE_SPOT_LIGHT_COUNT
 
         SpotLight spotLight;
 
-        for ( int i = 0; i < O3_SPOT_LIGHT_COUNT; i ++ ) {
-            if(isRendererCulledByLight(galacean_RendererLayer.xy, galacean_SpotLightCullingMask[i])) 
+        for ( int i = 0; i < SCENE_SPOT_LIGHT_COUNT; i ++ ) {
+            if(isRendererCulledByLight(renderer_Layer.xy, scene_SpotLightCullingMask[i])) 
                 continue;
 
-            spotLight.color = galacean_SpotLightColor[i];
-            spotLight.position = galacean_SpotLightPosition[i];
-            spotLight.direction = galacean_SpotLightDirection[i];
-            spotLight.distance = galacean_SpotLightDistance[i];
-            spotLight.angleCos = galacean_SpotLightAngleCos[i];
-            spotLight.penumbraCos = galacean_SpotLightPenumbraCos[i];
+            spotLight.color = scene_SpotLightColor[i];
+            spotLight.position = scene_SpotLightPosition[i];
+            spotLight.direction = scene_SpotLightDirection[i];
+            spotLight.distance = scene_SpotLightDistance[i];
+            spotLight.angleCos = scene_SpotLightAngleCos[i];
+            spotLight.penumbraCos = scene_SpotLightPenumbraCos[i];
 
             addSpotDirectLightRadiance( spotLight, geometry, material, reflectedLight );
         }

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -45,7 +45,7 @@ float getSpecularMIPLevel(float roughness, int maxMIPLevel ) {
 
 vec3 getLightProbeRadiance(vec3 viewDir, vec3 normal, float roughness, int maxMIPLevel, float specularIntensity) {
 
-    #ifndef O3_USE_SPECULAR_ENV
+    #ifndef GALACEAN_USE_SPECULAR_ENV
 
         return vec3(0);
 
@@ -57,12 +57,12 @@ vec3 getLightProbeRadiance(vec3 viewDir, vec3 normal, float roughness, int maxMI
         float specularMIPLevel = getSpecularMIPLevel(roughness, maxMIPLevel );
 
         #ifdef HAS_TEX_LOD
-            vec4 envMapColor = textureCubeLodEXT( u_env_specularSampler, reflectVec, specularMIPLevel );
+            vec4 envMapColor = textureCubeLodEXT( galacean_EnvSpecularSampler, reflectVec, specularMIPLevel );
         #else
-            vec4 envMapColor = textureCube( u_env_specularSampler, reflectVec, specularMIPLevel );
+            vec4 envMapColor = textureCube( galacean_EnvSpecularSampler, reflectVec, specularMIPLevel );
         #endif
 
-        #ifdef O3_DECODE_ENV_RGBM
+        #ifdef GALACEAN_DECODE_ENV_RGBM
             envMapColor.rgb = RGBMToLinear(envMapColor, 5.0).rgb;
             #ifdef GALACEAN_COLORSPACE_GAMMA
                 envMapColor = linearToGamma(envMapColor);

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -45,7 +45,7 @@ float getSpecularMIPLevel(float roughness, int maxMIPLevel ) {
 
 vec3 getLightProbeRadiance(vec3 viewDir, vec3 normal, float roughness, int maxMIPLevel, float specularIntensity) {
 
-    #ifndef GALACEAN_USE_SPECULAR_ENV
+    #ifndef SCENE_USE_SPECULAR_ENV
 
         return vec3(0);
 
@@ -57,18 +57,18 @@ vec3 getLightProbeRadiance(vec3 viewDir, vec3 normal, float roughness, int maxMI
         float specularMIPLevel = getSpecularMIPLevel(roughness, maxMIPLevel );
 
         #ifdef HAS_TEX_LOD
-            vec4 envMapColor = textureCubeLodEXT( galacean_EnvSpecularSampler, reflectVec, specularMIPLevel );
+            vec4 envMapColor = textureCubeLodEXT( scene_EnvSpecularSampler, reflectVec, specularMIPLevel );
         #else
-            vec4 envMapColor = textureCube( galacean_EnvSpecularSampler, reflectVec, specularMIPLevel );
+            vec4 envMapColor = textureCube( scene_EnvSpecularSampler, reflectVec, specularMIPLevel );
         #endif
 
-        #ifdef GALACEAN_DECODE_ENV_RGBM
+        #ifdef SCENE_IS_DECODE_ENV_RGBM
             envMapColor.rgb = RGBMToLinear(envMapColor, 5.0).rgb;
-            #ifdef GALACEAN_COLORSPACE_GAMMA
+            #ifdef ENGINE_IS_COLORSPACE_GAMMA
                 envMapColor = linearToGamma(envMapColor);
             #endif
         #else
-             #ifndef GALACEAN_COLORSPACE_GAMMA
+             #ifndef ENGINE_IS_COLORSPACE_GAMMA
                 envMapColor = gammaToLinear(envMapColor);
             #endif
         #endif

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -9,25 +9,25 @@ initMaterial(material, geometry);
 addTotalDirectRadiance(geometry, material, reflectedLight);
 
 // IBL diffuse
-#ifdef GALACEAN_USE_SH
-    vec3 irradiance = getLightProbeIrradiance(galacean_EnvSH, geometry.normal);
-    #ifdef GALACEAN_COLORSPACE_GAMMA
+#ifdef SCENE_USE_SH
+    vec3 irradiance = getLightProbeIrradiance(scene_EnvSH, geometry.normal);
+    #ifdef ENGINE_IS_COLORSPACE_GAMMA
         irradiance = linearToGamma(vec4(irradiance, 1.0)).rgb;
     #endif
-    irradiance *= galacean_EnvMapLight.diffuseIntensity;
+    irradiance *= scene_EnvMapLight.diffuseIntensity;
 #else
-   vec3 irradiance = galacean_EnvMapLight.diffuse * galacean_EnvMapLight.diffuseIntensity;
+   vec3 irradiance = scene_EnvMapLight.diffuse * scene_EnvMapLight.diffuseIntensity;
    irradiance *= PI;
 #endif
 
 reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 // IBL specular
-vec3 radiance = getLightProbeRadiance(geometry.viewDir, geometry.normal, material.roughness, int(galacean_EnvMapLight.mipMapLevel), galacean_EnvMapLight.specularIntensity);
+vec3 radiance = getLightProbeRadiance(geometry.viewDir, geometry.normal, material.roughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity);
 float radianceAttenuation = 1.0;
 
 #ifdef CLEARCOAT
-    vec3 clearCoatRadiance = getLightProbeRadiance( geometry.viewDir, geometry.clearCoatNormal, material.clearCoatRoughness, int(galacean_EnvMapLight.mipMapLevel), galacean_EnvMapLight.specularIntensity );
+    vec3 clearCoatRadiance = getLightProbeRadiance( geometry.viewDir, geometry.clearCoatNormal, material.clearCoatRoughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity );
 
     reflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * envBRDFApprox(vec3( 0.04 ), material.clearCoatRoughness, geometry.clearCoatDotNV);
     radianceAttenuation -= material.clearCoat * F_Schlick(geometry.clearCoatDotNV);
@@ -39,24 +39,24 @@ reflectedLight.indirectSpecular += radianceAttenuation * radiance * envBRDFAppro
 // Occlusion
 #ifdef OCCLUSIONTEXTURE
     vec2 aoUV = v_uv;
-    #ifdef GALACEAN_HAS_UV1
-        if(u_occlusionTextureCoord == 1.0){
+    #ifdef RENDERER_HAS_UV1
+        if(material_OcclusionTextureCoord == 1.0){
             aoUV = v_uv1;
         }
     #endif
-    float ambientOcclusion = (texture2D(u_occlusionTexture, aoUV).r - 1.0) * u_occlusionIntensity + 1.0;
+    float ambientOcclusion = (texture2D(material_OcclusionTexture, aoUV).r - 1.0) * material_OcclusionIntensity + 1.0;
     reflectedLight.indirectDiffuse *= ambientOcclusion;
-    #ifdef GALACEAN_USE_SPECULAR_ENV
+    #ifdef SCENE_USE_SPECULAR_ENV
         reflectedLight.indirectSpecular *= computeSpecularOcclusion(ambientOcclusion, material.roughness, geometry.dotNV);
     #endif
 #endif
 
 
 // Emissive
-vec3 emissiveRadiance = u_emissiveColor;
-#ifdef EMISSIVETEXTURE
-    vec4 emissiveColor = texture2D(u_emissiveTexture, v_uv);
-    #ifndef GALACEAN_COLORSPACE_GAMMA
+vec3 emissiveRadiance = material_EmissiveColor;
+#ifdef MATERIAL_HAS_EMISSIVETEXTURE
+    vec4 emissiveColor = texture2D(material_EmissiveTexture, v_uv);
+    #ifndef ENGINE_IS_COLORSPACE_GAMMA
         emissiveColor = gammaToLinear(emissiveColor);
     #endif
     emissiveRadiance *= emissiveColor.rgb;

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -9,25 +9,25 @@ initMaterial(material, geometry);
 addTotalDirectRadiance(geometry, material, reflectedLight);
 
 // IBL diffuse
-#ifdef O3_USE_SH
-    vec3 irradiance = getLightProbeIrradiance(u_env_sh, geometry.normal);
+#ifdef GALACEAN_USE_SH
+    vec3 irradiance = getLightProbeIrradiance(galacean_EnvSH, geometry.normal);
     #ifdef GALACEAN_COLORSPACE_GAMMA
         irradiance = linearToGamma(vec4(irradiance, 1.0)).rgb;
     #endif
-    irradiance *= u_envMapLight.diffuseIntensity;
+    irradiance *= galacean_EnvMapLight.diffuseIntensity;
 #else
-   vec3 irradiance = u_envMapLight.diffuse * u_envMapLight.diffuseIntensity;
+   vec3 irradiance = galacean_EnvMapLight.diffuse * galacean_EnvMapLight.diffuseIntensity;
    irradiance *= PI;
 #endif
 
 reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 // IBL specular
-vec3 radiance = getLightProbeRadiance(geometry.viewDir, geometry.normal, material.roughness, int(u_envMapLight.mipMapLevel), u_envMapLight.specularIntensity);
+vec3 radiance = getLightProbeRadiance(geometry.viewDir, geometry.normal, material.roughness, int(galacean_EnvMapLight.mipMapLevel), galacean_EnvMapLight.specularIntensity);
 float radianceAttenuation = 1.0;
 
 #ifdef CLEARCOAT
-    vec3 clearCoatRadiance = getLightProbeRadiance( geometry.viewDir, geometry.clearCoatNormal, material.clearCoatRoughness, int(u_envMapLight.mipMapLevel), u_envMapLight.specularIntensity );
+    vec3 clearCoatRadiance = getLightProbeRadiance( geometry.viewDir, geometry.clearCoatNormal, material.clearCoatRoughness, int(galacean_EnvMapLight.mipMapLevel), galacean_EnvMapLight.specularIntensity );
 
     reflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * envBRDFApprox(vec3( 0.04 ), material.clearCoatRoughness, geometry.clearCoatDotNV);
     radianceAttenuation -= material.clearCoat * F_Schlick(geometry.clearCoatDotNV);
@@ -39,14 +39,14 @@ reflectedLight.indirectSpecular += radianceAttenuation * radiance * envBRDFAppro
 // Occlusion
 #ifdef OCCLUSIONTEXTURE
     vec2 aoUV = v_uv;
-    #ifdef O3_HAS_UV1
+    #ifdef GALACEAN_HAS_UV1
         if(u_occlusionTextureCoord == 1.0){
             aoUV = v_uv1;
         }
     #endif
     float ambientOcclusion = (texture2D(u_occlusionTexture, aoUV).r - 1.0) * u_occlusionIntensity + 1.0;
     reflectedLight.indirectDiffuse *= ambientOcclusion;
-    #ifdef O3_USE_SPECULAR_ENV
+    #ifdef GALACEAN_USE_SPECULAR_ENV
         reflectedLight.indirectSpecular *= computeSpecularOcclusion(ambientOcclusion, material.roughness, geometry.dotNV);
     #endif
 #endif

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -26,7 +26,7 @@ reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.di
 vec3 radiance = getLightProbeRadiance(geometry.viewDir, geometry.normal, material.roughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity);
 float radianceAttenuation = 1.0;
 
-#ifdef CLEARCOAT
+#ifdef MATERIAL_CLEARCOAT
     vec3 clearCoatRadiance = getLightProbeRadiance( geometry.viewDir, geometry.clearCoatNormal, material.clearCoatRoughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity );
 
     reflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * envBRDFApprox(vec3( 0.04 ), material.clearCoatRoughness, geometry.clearCoatDotNV);
@@ -37,7 +37,7 @@ reflectedLight.indirectSpecular += radianceAttenuation * radiance * envBRDFAppro
 
 
 // Occlusion
-#ifdef OCCLUSIONTEXTURE
+#ifdef MATERIAL_OCCLUSIONTEXTURE
     vec2 aoUV = v_uv;
     #ifdef RENDERER_HAS_UV1
         if(material_OcclusionTextureCoord == 1.0){

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -6,7 +6,7 @@ uniform vec3 material_PBRSpecularColor;
 uniform float material_Glossiness;
 uniform vec3 material_EmissiveColor;
 
-#ifdef CLEARCOAT
+#ifdef MATERIAL_CLEARCOAT
     uniform float material_ClearCoat;
     uniform float material_ClearCoatRoughness;
 #endif
@@ -28,7 +28,7 @@ uniform float material_OcclusionTextureCoord;
     uniform sampler2D MATERIAL_HAS_EMISSIVETEXTURE;
 #endif
 
-#ifdef ROUGHNESSMETALLICTEXTURE
+#ifdef MATERIAL_ROUGHNESSMETALLICTEXTURE
     uniform sampler2D material_RoughnessMetallicTexture;
 #endif
 
@@ -37,19 +37,19 @@ uniform float material_OcclusionTextureCoord;
     uniform sampler2D material_SpecularGlossinessTexture;
 #endif
 
-#ifdef OCCLUSIONTEXTURE
+#ifdef MATERIAL_OCCLUSIONTEXTURE
     uniform sampler2D material_OcclusionTexture;
 #endif
 
-#ifdef HAS_CLEARCOATTEXTURE
+#ifdef MATERIAL_HAS_CLEARCOATTEXTURE
     uniform sampler2D material_ClearCoatTexture;
 #endif
 
-#ifdef HAS_CLEARCOATROUGHNESSTEXTURE
+#ifdef MATERIAL_HAS_CLEARCOATROUGHNESSTEXTURE
     uniform sampler2D material_ClearCoatRoughnessTexture;
 #endif
 
-#ifdef HAS_CLEARCOATNORMALTEXTURE
+#ifdef MATERIAL_HAS_CLEARCOATNORMALTEXTURE
     uniform sampler2D material_ClearCoatNormalTexture;
 #endif
 
@@ -69,7 +69,7 @@ struct Geometry {
     vec3  viewDir;
     float dotNV;
     
-    #ifdef CLEARCOAT
+    #ifdef MATERIAL_CLEARCOAT
         vec3 clearCoatNormal;
         float clearCoatDotNV;
     #endif
@@ -81,7 +81,7 @@ struct Material {
     float roughness;
     vec3  specularColor;
     float opacity;
-    #ifdef CLEARCOAT
+    #ifdef MATERIAL_CLEARCOAT
         float clearCoat;
         float clearCoatRoughness;
     #endif

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -1,56 +1,56 @@
-uniform float u_alphaCutoff;
-uniform vec4 u_baseColor;
-uniform float u_metal;
-uniform float u_roughness;
-uniform vec3 u_PBRSpecularColor;
-uniform float u_glossiness;
-uniform vec3 u_emissiveColor;
+uniform float material_AlphaCutoff;
+uniform vec4 material_BaseColor;
+uniform float material_Metal;
+uniform float material_Roughness;
+uniform vec3 material_PBRSpecularColor;
+uniform float material_Glossiness;
+uniform vec3 material_EmissiveColor;
 
 #ifdef CLEARCOAT
-    uniform float u_clearCoat;
-    uniform float u_clearCoatRoughness;
+    uniform float material_ClearCoat;
+    uniform float material_ClearCoatRoughness;
 #endif
 
-uniform float u_normalIntensity;
-uniform float u_occlusionIntensity;
-uniform float u_occlusionTextureCoord;
+uniform float material_NormalIntensity;
+uniform float material_OcclusionIntensity;
+uniform float material_OcclusionTextureCoord;
 
 // Texture
-#ifdef BASETEXTURE
-    uniform sampler2D u_baseTexture;
+#ifdef MATERIAL_HAS_BASETEXTURE
+    uniform sampler2D material_BaseTexture;
 #endif
 
-#ifdef NORMALTEXTURE
-    uniform sampler2D u_normalTexture;
+#ifdef MATERIAL_HAS_NORMALTEXTURE
+    uniform sampler2D material_NormalTexture;
 #endif
 
-#ifdef EMISSIVETEXTURE
-    uniform sampler2D u_emissiveTexture;
+#ifdef MATERIAL_HAS_EMISSIVETEXTURE
+    uniform sampler2D MATERIAL_HAS_EMISSIVETEXTURE;
 #endif
 
 #ifdef ROUGHNESSMETALLICTEXTURE
-    uniform sampler2D u_roughnessMetallicTexture;
+    uniform sampler2D material_RoughnessMetallicTexture;
 #endif
 
 
-#ifdef SPECULARGLOSSINESSTEXTURE
-    uniform sampler2D u_specularGlossinessTexture;
+#ifdef MATERIAL_HAS_SPECULARGLOSSINESSTEXTURE
+    uniform sampler2D material_SpecularGlossinessTexture;
 #endif
 
 #ifdef OCCLUSIONTEXTURE
-    uniform sampler2D u_occlusionTexture;
+    uniform sampler2D material_OcclusionTexture;
 #endif
 
 #ifdef HAS_CLEARCOATTEXTURE
-    uniform sampler2D u_clearCoatTexture;
+    uniform sampler2D material_ClearCoatTexture;
 #endif
 
 #ifdef HAS_CLEARCOATROUGHNESSTEXTURE
-    uniform sampler2D u_clearCoatRoughnessTexture;
+    uniform sampler2D material_ClearCoatRoughnessTexture;
 #endif
 
 #ifdef HAS_CLEARCOATNORMALTEXTURE
-    uniform sampler2D u_clearCoatNormalTexture;
+    uniform sampler2D material_ClearCoatNormalTexture;
 #endif
 
 

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -19,14 +19,14 @@ float getAARoughnessFactor(vec3 normal) {
 
 void initGeometry(out Geometry geometry){
     geometry.position = v_pos;
-    geometry.viewDir =  normalize(galacean_CameraPos - v_pos);
+    geometry.viewDir =  normalize(camera_Position - v_pos);
 
-    #if defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE)
+    #if defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE)
         mat3 tbn = getTBN();
     #endif
 
-    #ifdef NORMALTEXTURE
-        geometry.normal = getNormalByNormalTexture(tbn, u_normalTexture, u_normalIntensity, v_uv);
+    #ifdef MATERIAL_HAS_NORMALTEXTURE
+        geometry.normal = getNormalByNormalTexture(tbn, material_NormalTexture, material_NormalIntensity, v_uv);
     #else
         geometry.normal = getNormal();
     #endif
@@ -36,7 +36,7 @@ void initGeometry(out Geometry geometry){
 
     #ifdef CLEARCOAT
         #ifdef HAS_CLEARCOATNORMALTEXTURE
-            geometry.clearCoatNormal = getNormalByNormalTexture(tbn, u_clearCoatNormalTexture, u_normalIntensity, v_uv);
+            geometry.clearCoatNormal = getNormalByNormalTexture(tbn, material_ClearCoatNormalTexture, material_NormalIntensity, v_uv);
         #else
             geometry.clearCoatNormal = getNormal();
         #endif
@@ -46,41 +46,41 @@ void initGeometry(out Geometry geometry){
 }
 
 void initMaterial(out Material material, const in Geometry geometry){
-        vec4 baseColor = u_baseColor;
-        float metal = u_metal;
-        float roughness = u_roughness;
-        vec3 specularColor = u_PBRSpecularColor;
-        float glossiness = u_glossiness;
-        float alphaCutoff = u_alphaCutoff;
+        vec4 baseColor = material_BaseColor;
+        float metal = material_Metal;
+        float roughness = material_Roughness;
+        vec3 specularColor = material_PBRSpecularColor;
+        float glossiness = material_Glossiness;
+        float alphaCutoff = material_AlphaCutoff;
 
-        #ifdef BASETEXTURE
-            vec4 baseTextureColor = texture2D(u_baseTexture, v_uv);
-            #ifndef GALACEAN_COLORSPACE_GAMMA
+        #ifdef MATERIAL_HAS_BASETEXTURE
+            vec4 baseTextureColor = texture2D(material_BaseTexture, v_uv);
+            #ifndef ENGINE_IS_COLORSPACE_GAMMA
                 baseTextureColor = gammaToLinear(baseTextureColor);
             #endif
             baseColor *= baseTextureColor;
         #endif
 
-        #ifdef GALACEAN_HAS_VERTEXCOLOR
+        #ifdef RENDERER_HAS_VERTEXCOLOR
             baseColor *= v_color;
         #endif
 
 
-        #ifdef ALPHA_CUTOFF
+        #ifdef MATERIAL_IS_ALPHA_CUTOFF
             if( baseColor.a < alphaCutoff ) {
                 discard;
             }
         #endif
 
         #ifdef ROUGHNESSMETALLICTEXTURE
-            vec4 metalRoughMapColor = texture2D( u_roughnessMetallicTexture, v_uv );
+            vec4 metalRoughMapColor = texture2D( material_RoughnessMetallicTexture, v_uv );
             roughness *= metalRoughMapColor.g;
             metal *= metalRoughMapColor.b;
         #endif
 
-        #ifdef SPECULARGLOSSINESSTEXTURE
-            vec4 specularGlossinessColor = texture2D(u_specularGlossinessTexture, v_uv );
-            #ifndef GALACEAN_COLORSPACE_GAMMA
+        #ifdef MATERIAL_HAS_SPECULARGLOSSINESSTEXTURE
+            vec4 specularGlossinessColor = texture2D(material_SpecularGlossinessTexture, v_uv );
+            #ifndef ENGINE_IS_COLORSPACE_GAMMA
                 specularGlossinessColor = gammaToLinear(specularGlossinessColor);
             #endif
             specularColor *= specularGlossinessColor.rgb;
@@ -102,19 +102,19 @@ void initMaterial(out Material material, const in Geometry geometry){
         material.roughness = max(material.roughness, getAARoughnessFactor(geometry.normal));
 
         #ifdef CLEARCOAT
-            material.clearCoat = u_clearCoat;
-            material.clearCoatRoughness = u_clearCoatRoughness;
+            material.clearCoat = material_ClearCoat;
+            material.clearCoatRoughness = material_ClearCoatRoughness;
             #ifdef HAS_CLEARCOATTEXTURE
-                material.clearCoat *= texture2D( u_clearCoatTexture, v_uv ).r;
+                material.clearCoat *= texture2D( material_ClearCoatTexture, v_uv ).r;
             #endif
             #ifdef HAS_CLEARCOATROUGHNESSTEXTURE
-                material.clearCoatRoughness *= texture2D( u_clearCoatRoughnessTexture, v_uv ).g;
+                material.clearCoatRoughness *= texture2D( material_ClearCoatRoughnessTexture, v_uv ).g;
             #endif
             material.clearCoat = saturate( material.clearCoat );
             material.clearCoatRoughness = max(material.clearCoatRoughness, getAARoughnessFactor(geometry.clearCoatNormal));
         #endif
 
-        #ifdef OASIS_TRANSPARENT
+        #ifdef MATERIAL_IS_TRANSPARENT
             material.opacity = baseColor.a;
         #else
             material.opacity = 1.0;

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -19,7 +19,7 @@ float getAARoughnessFactor(vec3 normal) {
 
 void initGeometry(out Geometry geometry){
     geometry.position = v_pos;
-    geometry.viewDir =  normalize(u_cameraPos - v_pos);
+    geometry.viewDir =  normalize(galacean_CameraPos - v_pos);
 
     #if defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE)
         mat3 tbn = getTBN();
@@ -61,7 +61,7 @@ void initMaterial(out Material material, const in Geometry geometry){
             baseColor *= baseTextureColor;
         #endif
 
-        #ifdef O3_HAS_VERTEXCOLOR
+        #ifdef GALACEAN_HAS_VERTEXCOLOR
             baseColor *= v_color;
         #endif
 

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -21,7 +21,7 @@ void initGeometry(out Geometry geometry){
     geometry.position = v_pos;
     geometry.viewDir =  normalize(camera_Position - v_pos);
 
-    #if defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE)
+    #if defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE)
         mat3 tbn = getTBN();
     #endif
 
@@ -34,8 +34,8 @@ void initGeometry(out Geometry geometry){
     geometry.dotNV = saturate( dot(geometry.normal, geometry.viewDir) );
 
 
-    #ifdef CLEARCOAT
-        #ifdef HAS_CLEARCOATNORMALTEXTURE
+    #ifdef MATERIAL_CLEARCOAT
+        #ifdef MATERIAL_HAS_CLEARCOATNORMALTEXTURE
             geometry.clearCoatNormal = getNormalByNormalTexture(tbn, material_ClearCoatNormalTexture, material_NormalIntensity, v_uv);
         #else
             geometry.clearCoatNormal = getNormal();
@@ -72,7 +72,7 @@ void initMaterial(out Material material, const in Geometry geometry){
             }
         #endif
 
-        #ifdef ROUGHNESSMETALLICTEXTURE
+        #ifdef MATERIAL_ROUGHNESSMETALLICTEXTURE
             vec4 metalRoughMapColor = texture2D( material_RoughnessMetallicTexture, v_uv );
             roughness *= metalRoughMapColor.g;
             metal *= metalRoughMapColor.b;
@@ -101,13 +101,13 @@ void initMaterial(out Material material, const in Geometry geometry){
 
         material.roughness = max(material.roughness, getAARoughnessFactor(geometry.normal));
 
-        #ifdef CLEARCOAT
+        #ifdef MATERIAL_CLEARCOAT
             material.clearCoat = material_ClearCoat;
             material.clearCoatRoughness = material_ClearCoatRoughness;
-            #ifdef HAS_CLEARCOATTEXTURE
+            #ifdef MATERIAL_HAS_CLEARCOATTEXTURE
                 material.clearCoat *= texture2D( material_ClearCoatTexture, v_uv ).r;
             #endif
-            #ifdef HAS_CLEARCOATROUGHNESSTEXTURE
+            #ifdef MATERIAL_HAS_CLEARCOATROUGHNESSTEXTURE
                 material.clearCoatRoughness *= texture2D( material_ClearCoatRoughnessTexture, v_uv ).g;
             #endif
             material.clearCoat = saturate( material.clearCoat );

--- a/packages/core/src/shaderlib/position_vert.glsl
+++ b/packages/core/src/shaderlib/position_vert.glsl
@@ -1,1 +1,1 @@
-    gl_Position = galacean_MVPMat * position;
+    gl_Position = renderer_MVPMat * position;

--- a/packages/core/src/shaderlib/position_vert.glsl
+++ b/packages/core/src/shaderlib/position_vert.glsl
@@ -1,1 +1,1 @@
-    gl_Position = u_MVPMat * position;
+    gl_Position = galacean_MVPMat * position;

--- a/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
@@ -1,18 +1,18 @@
 
-uniform mat4 u_shadowMatrices[CASCADED_COUNT + 1];
-uniform vec4 u_shadowSplitSpheres[4];
+uniform mat4 galacean_ShadowMatrices[CASCADED_COUNT + 1];
+uniform vec4 galacean_ShadowSplitSpheres[4];
 
 mediump int computeCascadeIndex(vec3 positionWS) {
-    vec3 fromCenter0 = positionWS - u_shadowSplitSpheres[0].xyz;
-    vec3 fromCenter1 = positionWS - u_shadowSplitSpheres[1].xyz;
-    vec3 fromCenter2 = positionWS - u_shadowSplitSpheres[2].xyz;
-    vec3 fromCenter3 = positionWS - u_shadowSplitSpheres[3].xyz;
+    vec3 fromCenter0 = positionWS - galacean_ShadowSplitSpheres[0].xyz;
+    vec3 fromCenter1 = positionWS - galacean_ShadowSplitSpheres[1].xyz;
+    vec3 fromCenter2 = positionWS - galacean_ShadowSplitSpheres[2].xyz;
+    vec3 fromCenter3 = positionWS - galacean_ShadowSplitSpheres[3].xyz;
 
     mediump vec4 comparison = vec4(
-        dot(fromCenter0, fromCenter0) < u_shadowSplitSpheres[0].w,
-        dot(fromCenter1, fromCenter1) < u_shadowSplitSpheres[1].w,
-        dot(fromCenter2, fromCenter2) < u_shadowSplitSpheres[2].w,
-        dot(fromCenter3, fromCenter3) < u_shadowSplitSpheres[3].w);
+        dot(fromCenter0, fromCenter0) < galacean_ShadowSplitSpheres[0].w,
+        dot(fromCenter1, fromCenter1) < galacean_ShadowSplitSpheres[1].w,
+        dot(fromCenter2, fromCenter2) < galacean_ShadowSplitSpheres[2].w,
+        dot(fromCenter3, fromCenter3) < galacean_ShadowSplitSpheres[3].w);
     comparison.yzw = clamp(comparison.yzw - comparison.xyz,0.0,1.0);//keep the nearest
     mediump vec4 indexCoefficient = vec4(4.0,3.0,2.0,1.0);
     mediump int index = 4 - int(dot(comparison, indexCoefficient));
@@ -27,36 +27,36 @@ vec3 getShadowCoord() {
     #endif
 
     #ifdef GRAPHICS_API_WEBGL2
-        mat4 shadowMatrix = u_shadowMatrices[cascadeIndex];
+        mat4 shadowMatrix = galacean_ShadowMatrices[cascadeIndex];
     #else
         mat4 shadowMatrix;
         #if CASCADED_COUNT == 4
             if (cascadeIndex == 0) {
-                shadowMatrix = u_shadowMatrices[0];
+                shadowMatrix = galacean_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
-                shadowMatrix = u_shadowMatrices[1];
+                shadowMatrix = galacean_ShadowMatrices[1];
             } else if (cascadeIndex == 2) {
-                shadowMatrix = u_shadowMatrices[2];
+                shadowMatrix = galacean_ShadowMatrices[2];
             } else if (cascadeIndex == 3) {
-                shadowMatrix = u_shadowMatrices[3];
+                shadowMatrix = galacean_ShadowMatrices[3];
             } else {
-                shadowMatrix = u_shadowMatrices[4];
+                shadowMatrix = galacean_ShadowMatrices[4];
             }
         #endif
         #if CASCADED_COUNT == 2
             if (cascadeIndex == 0) {
-                shadowMatrix = u_shadowMatrices[0];
+                shadowMatrix = galacean_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
-                shadowMatrix = u_shadowMatrices[1];
+                shadowMatrix = galacean_ShadowMatrices[1];
             } else {
-                shadowMatrix = u_shadowMatrices[2];
+                shadowMatrix = galacean_ShadowMatrices[2];
             } 
         #endif
         #if CASCADED_COUNT == 1
             if (cascadeIndex == 0) {
-                shadowMatrix = u_shadowMatrices[0];
+                shadowMatrix = galacean_ShadowMatrices[0];
             } else  {
-                shadowMatrix = u_shadowMatrices[1];
+                shadowMatrix = galacean_ShadowMatrices[1];
             } 
         #endif
     #endif

--- a/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
@@ -1,18 +1,18 @@
 
-uniform mat4 galacean_ShadowMatrices[CASCADED_COUNT + 1];
-uniform vec4 galacean_ShadowSplitSpheres[4];
+uniform mat4 scene_ShadowMatrices[CASCADED_COUNT + 1];
+uniform vec4 scene_ShadowSplitSpheres[4];
 
 mediump int computeCascadeIndex(vec3 positionWS) {
-    vec3 fromCenter0 = positionWS - galacean_ShadowSplitSpheres[0].xyz;
-    vec3 fromCenter1 = positionWS - galacean_ShadowSplitSpheres[1].xyz;
-    vec3 fromCenter2 = positionWS - galacean_ShadowSplitSpheres[2].xyz;
-    vec3 fromCenter3 = positionWS - galacean_ShadowSplitSpheres[3].xyz;
+    vec3 fromCenter0 = positionWS - scene_ShadowSplitSpheres[0].xyz;
+    vec3 fromCenter1 = positionWS - scene_ShadowSplitSpheres[1].xyz;
+    vec3 fromCenter2 = positionWS - scene_ShadowSplitSpheres[2].xyz;
+    vec3 fromCenter3 = positionWS - scene_ShadowSplitSpheres[3].xyz;
 
     mediump vec4 comparison = vec4(
-        dot(fromCenter0, fromCenter0) < galacean_ShadowSplitSpheres[0].w,
-        dot(fromCenter1, fromCenter1) < galacean_ShadowSplitSpheres[1].w,
-        dot(fromCenter2, fromCenter2) < galacean_ShadowSplitSpheres[2].w,
-        dot(fromCenter3, fromCenter3) < galacean_ShadowSplitSpheres[3].w);
+        dot(fromCenter0, fromCenter0) < scene_ShadowSplitSpheres[0].w,
+        dot(fromCenter1, fromCenter1) < scene_ShadowSplitSpheres[1].w,
+        dot(fromCenter2, fromCenter2) < scene_ShadowSplitSpheres[2].w,
+        dot(fromCenter3, fromCenter3) < scene_ShadowSplitSpheres[3].w);
     comparison.yzw = clamp(comparison.yzw - comparison.xyz,0.0,1.0);//keep the nearest
     mediump vec4 indexCoefficient = vec4(4.0,3.0,2.0,1.0);
     mediump int index = 4 - int(dot(comparison, indexCoefficient));
@@ -27,36 +27,36 @@ vec3 getShadowCoord() {
     #endif
 
     #ifdef GRAPHICS_API_WEBGL2
-        mat4 shadowMatrix = galacean_ShadowMatrices[cascadeIndex];
+        mat4 shadowMatrix = scene_ShadowMatrices[cascadeIndex];
     #else
         mat4 shadowMatrix;
         #if CASCADED_COUNT == 4
             if (cascadeIndex == 0) {
-                shadowMatrix = galacean_ShadowMatrices[0];
+                shadowMatrix = scene_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
-                shadowMatrix = galacean_ShadowMatrices[1];
+                shadowMatrix = scene_ShadowMatrices[1];
             } else if (cascadeIndex == 2) {
-                shadowMatrix = galacean_ShadowMatrices[2];
+                shadowMatrix = scene_ShadowMatrices[2];
             } else if (cascadeIndex == 3) {
-                shadowMatrix = galacean_ShadowMatrices[3];
+                shadowMatrix = scene_ShadowMatrices[3];
             } else {
-                shadowMatrix = galacean_ShadowMatrices[4];
+                shadowMatrix = scene_ShadowMatrices[4];
             }
         #endif
         #if CASCADED_COUNT == 2
             if (cascadeIndex == 0) {
-                shadowMatrix = galacean_ShadowMatrices[0];
+                shadowMatrix = scene_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
-                shadowMatrix = galacean_ShadowMatrices[1];
+                shadowMatrix = scene_ShadowMatrices[1];
             } else {
-                shadowMatrix = galacean_ShadowMatrices[2];
+                shadowMatrix = scene_ShadowMatrices[2];
             } 
         #endif
         #if CASCADED_COUNT == 1
             if (cascadeIndex == 0) {
-                shadowMatrix = galacean_ShadowMatrices[0];
+                shadowMatrix = scene_ShadowMatrices[0];
             } else  {
-                shadowMatrix = galacean_ShadowMatrices[1];
+                shadowMatrix = scene_ShadowMatrices[1];
             } 
         #endif
     #endif

--- a/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowCoord.glsl
@@ -1,5 +1,5 @@
 
-uniform mat4 scene_ShadowMatrices[CASCADED_COUNT + 1];
+uniform mat4 scene_ShadowMatrices[SCENE_SHADOW_CASCADED_COUNT + 1];
 uniform vec4 scene_ShadowSplitSpheres[4];
 
 mediump int computeCascadeIndex(vec3 positionWS) {
@@ -20,7 +20,7 @@ mediump int computeCascadeIndex(vec3 positionWS) {
 }
 
 vec3 getShadowCoord() {
-    #if CASCADED_COUNT == 1
+    #if SCENE_SHADOW_CASCADED_COUNT == 1
         mediump int cascadeIndex = 0;
     #else
         mediump int cascadeIndex = computeCascadeIndex(v_pos);
@@ -30,7 +30,7 @@ vec3 getShadowCoord() {
         mat4 shadowMatrix = scene_ShadowMatrices[cascadeIndex];
     #else
         mat4 shadowMatrix;
-        #if CASCADED_COUNT == 4
+        #if SCENE_SHADOW_CASCADED_COUNT == 4
             if (cascadeIndex == 0) {
                 shadowMatrix = scene_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
@@ -43,7 +43,7 @@ vec3 getShadowCoord() {
                 shadowMatrix = scene_ShadowMatrices[4];
             }
         #endif
-        #if CASCADED_COUNT == 2
+        #if SCENE_SHADOW_CASCADED_COUNT == 2
             if (cascadeIndex == 0) {
                 shadowMatrix = scene_ShadowMatrices[0];
             } else if (cascadeIndex == 1) {
@@ -52,7 +52,7 @@ vec3 getShadowCoord() {
                 shadowMatrix = scene_ShadowMatrices[2];
             } 
         #endif
-        #if CASCADED_COUNT == 1
+        #if SCENE_SHADOW_CASCADED_COUNT == 1
             if (cascadeIndex == 0) {
                 shadowMatrix = scene_ShadowMatrices[0];
             } else  {

--- a/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
@@ -1,8 +1,8 @@
 #if defined(SCENE_SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
-    #define GALACEAN_CALCULATE_SHADOWS
+    #define SCENE_IS_CALCULATE_SHADOWS
 #endif
 
-#ifdef GALACEAN_CALCULATE_SHADOWS
+#ifdef SCENE_IS_CALCULATE_SHADOWS
     #if SCENE_SHADOW_CASCADED_COUNT == 1
         varying vec3 v_shadowCoord;
     #else

--- a/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
@@ -1,9 +1,9 @@
-#if defined(SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
+#if defined(SCENE_SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
     #define GALACEAN_CALCULATE_SHADOWS
 #endif
 
 #ifdef GALACEAN_CALCULATE_SHADOWS
-    #if CASCADED_COUNT == 1
+    #if SCENE_SHADOW_CASCADED_COUNT == 1
         varying vec3 v_shadowCoord;
     #else
         #include <ShadowCoord>
@@ -34,7 +34,7 @@
         #define TEXTURE2D_SHADOW_PARAM(shadowMap) mediump sampler2D shadowMap
     #endif
 
-    #if SHADOW_TYPE == 2
+    #if SCENE_SHADOW_TYPE == 2
         float sampleShadowMapFiltered4(TEXTURE2D_SHADOW_PARAM(shadowMap), vec3 shadowCoord, vec4 shadowMapSize) {
             float attenuation;
             vec4 attenuation4;
@@ -52,7 +52,7 @@
         }
     #endif
 
-    #if SHADOW_TYPE == 3
+    #if SCENE_SHADOW_TYPE == 3
         #include <shadow_sample_tent>
 
         float sampleShadowMapFiltered9(TEXTURE2D_SHADOW_PARAM(shadowMap), vec3 shadowCoord, vec4 shadowmapSize) {
@@ -74,7 +74,7 @@
     #endif
 
     float sampleShadowMap() {
-        #if CASCADED_COUNT == 1
+        #if SCENE_SHADOW_CASCADED_COUNT == 1
             vec3 shadowCoord = v_shadowCoord;
         #else
             vec3 shadowCoord = getShadowCoord();
@@ -82,15 +82,15 @@
         
         float attenuation = 1.0;
         if(shadowCoord.z > 0.0 && shadowCoord.z < 1.0) {
-        #if SHADOW_TYPE == 1
+        #if SCENE_SHADOW_TYPE == 1
             attenuation = SAMPLE_TEXTURE2D_SHADOW(scene_ShadowMap, shadowCoord);
         #endif
 
-        #if SHADOW_TYPE == 2
+        #if SCENE_SHADOW_TYPE == 2
             attenuation = sampleShadowMapFiltered4(scene_ShadowMap, shadowCoord, scene_ShadowMapSize);
         #endif
 
-        #if SHADOW_TYPE == 3
+        #if SCENE_SHADOW_TYPE == 3
             attenuation = sampleShadowMapFiltered9(scene_ShadowMap, shadowCoord, scene_ShadowMapSize);
         #endif
             attenuation = mix(1.0, attenuation, scene_ShadowInfo.x);

--- a/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
@@ -1,4 +1,4 @@
-#if defined(SHADOW_TYPE) && defined(GALACEAN_RECEIVE_SHADOWS)
+#if defined(SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
     #define GALACEAN_CALCULATE_SHADOWS
 #endif
 
@@ -10,16 +10,16 @@
     #endif
     
     // intensity, resolution, sunIndex
-    uniform vec3 galacean_ShadowInfo;
-    uniform vec4 galacean_ShadowMapSize;
+    uniform vec3 scene_ShadowInfo;
+    uniform vec4 scene_ShadowMapSize;
 
     #ifdef GRAPHICS_API_WEBGL2
-        uniform mediump sampler2DShadow galacean_ShadowMap;
+        uniform mediump sampler2DShadow scene_ShadowMap;
         #define SAMPLE_TEXTURE2D_SHADOW(textureName, coord3) textureLod(textureName, coord3 , 0.0)
         #define TEXTURE2D_SHADOW_PARAM(shadowMap) mediump sampler2DShadow shadowMap
     #else
-        uniform sampler2D galacean_ShadowMap;
-        #ifdef GALACEAN_NO_DEPTH_TEXTURE
+        uniform sampler2D scene_ShadowMap;
+        #ifdef ENGINE_NO_DEPTH_TEXTURE
             const vec4 bitShift = vec4(1.0, 1.0/256.0, 1.0/(256.0*256.0), 1.0/(256.0*256.0*256.0));
             /**
             * Unpack depth value.
@@ -83,17 +83,17 @@
         float attenuation = 1.0;
         if(shadowCoord.z > 0.0 && shadowCoord.z < 1.0) {
         #if SHADOW_TYPE == 1
-            attenuation = SAMPLE_TEXTURE2D_SHADOW(galacean_ShadowMap, shadowCoord);
+            attenuation = SAMPLE_TEXTURE2D_SHADOW(scene_ShadowMap, shadowCoord);
         #endif
 
         #if SHADOW_TYPE == 2
-            attenuation = sampleShadowMapFiltered4(galacean_ShadowMap, shadowCoord, galacean_ShadowMapSize);
+            attenuation = sampleShadowMapFiltered4(scene_ShadowMap, shadowCoord, scene_ShadowMapSize);
         #endif
 
         #if SHADOW_TYPE == 3
-            attenuation = sampleShadowMapFiltered9(galacean_ShadowMap, shadowCoord, galacean_ShadowMapSize);
+            attenuation = sampleShadowMapFiltered9(scene_ShadowMap, shadowCoord, scene_ShadowMapSize);
         #endif
-            attenuation = mix(1.0, attenuation, galacean_ShadowInfo.x);
+            attenuation = mix(1.0, attenuation, scene_ShadowInfo.x);
         }
         return attenuation;
     }

--- a/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowFragmentDeclaration.glsl
@@ -10,15 +10,15 @@
     #endif
     
     // intensity, resolution, sunIndex
-    uniform vec3 u_shadowInfo;
-    uniform vec4 u_shadowMapSize;
+    uniform vec3 galacean_ShadowInfo;
+    uniform vec4 galacean_ShadowMapSize;
 
     #ifdef GRAPHICS_API_WEBGL2
-        uniform mediump sampler2DShadow u_shadowMap;
+        uniform mediump sampler2DShadow galacean_ShadowMap;
         #define SAMPLE_TEXTURE2D_SHADOW(textureName, coord3) textureLod(textureName, coord3 , 0.0)
         #define TEXTURE2D_SHADOW_PARAM(shadowMap) mediump sampler2DShadow shadowMap
     #else
-        uniform sampler2D u_shadowMap;
+        uniform sampler2D galacean_ShadowMap;
         #ifdef GALACEAN_NO_DEPTH_TEXTURE
             const vec4 bitShift = vec4(1.0, 1.0/256.0, 1.0/(256.0*256.0), 1.0/(256.0*256.0*256.0));
             /**
@@ -83,17 +83,17 @@
         float attenuation = 1.0;
         if(shadowCoord.z > 0.0 && shadowCoord.z < 1.0) {
         #if SHADOW_TYPE == 1
-            attenuation = SAMPLE_TEXTURE2D_SHADOW(u_shadowMap, shadowCoord);
+            attenuation = SAMPLE_TEXTURE2D_SHADOW(galacean_ShadowMap, shadowCoord);
         #endif
 
         #if SHADOW_TYPE == 2
-            attenuation = sampleShadowMapFiltered4(u_shadowMap, shadowCoord, u_shadowMapSize);
+            attenuation = sampleShadowMapFiltered4(galacean_ShadowMap, shadowCoord, galacean_ShadowMapSize);
         #endif
 
         #if SHADOW_TYPE == 3
-            attenuation = sampleShadowMapFiltered9(u_shadowMap, shadowCoord, u_shadowMapSize);
+            attenuation = sampleShadowMapFiltered9(galacean_ShadowMap, shadowCoord, galacean_ShadowMapSize);
         #endif
-            attenuation = mix(1.0, attenuation, u_shadowInfo.x);
+            attenuation = mix(1.0, attenuation, galacean_ShadowInfo.x);
         }
         return attenuation;
     }

--- a/packages/core/src/shaderlib/shadow/ShadowVertex.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowVertex.glsl
@@ -1,5 +1,5 @@
 #ifdef GALACEAN_CALCULATE_SHADOWS
-    #if CASCADED_COUNT == 1
+    #if SCENE_SHADOW_CASCADED_COUNT == 1
         v_shadowCoord = getShadowCoord();
     #endif
 #endif

--- a/packages/core/src/shaderlib/shadow/ShadowVertex.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowVertex.glsl
@@ -1,4 +1,4 @@
-#ifdef GALACEAN_CALCULATE_SHADOWS
+#ifdef SCENE_IS_CALCULATE_SHADOWS
     #if SCENE_SHADOW_CASCADED_COUNT == 1
         v_shadowCoord = getShadowCoord();
     #endif

--- a/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
@@ -1,4 +1,4 @@
-#if defined(SHADOW_TYPE) && defined(GALACEAN_RECEIVE_SHADOWS)
+#if defined(SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
     #define GALACEAN_CALCULATE_SHADOWS
 #endif
 

--- a/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
@@ -1,9 +1,9 @@
-#if defined(SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
+#if defined(SCENE_SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
     #define GALACEAN_CALCULATE_SHADOWS
 #endif
 
 #ifdef GALACEAN_CALCULATE_SHADOWS
-    #if CASCADED_COUNT==1
+    #if SCENE_SHADOW_CASCADED_COUNT==1
         #include <ShadowCoord>
         varying vec3 v_shadowCoord;
     #endif

--- a/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
+++ b/packages/core/src/shaderlib/shadow/ShadowVertexDeclaration.glsl
@@ -1,8 +1,8 @@
 #if defined(SCENE_SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
-    #define GALACEAN_CALCULATE_SHADOWS
+    #define SCENE_IS_CALCULATE_SHADOWS
 #endif
 
-#ifdef GALACEAN_CALCULATE_SHADOWS
+#ifdef SCENE_IS_CALCULATE_SHADOWS
     #if SCENE_SHADOW_CASCADED_COUNT==1
         #include <ShadowCoord>
         varying vec3 v_shadowCoord;

--- a/packages/core/src/shaderlib/skinning_vert.glsl
+++ b/packages/core/src/shaderlib/skinning_vert.glsl
@@ -2,25 +2,25 @@
 
         #ifdef O3_USE_JOINT_TEXTURE
             mat4 skinMatrix =
-                WEIGHTS_0.x * getJointMatrix(u_jointSampler, JOINTS_0.x ) +
-                WEIGHTS_0.y * getJointMatrix(u_jointSampler, JOINTS_0.y ) +
-                WEIGHTS_0.z * getJointMatrix(u_jointSampler, JOINTS_0.z ) +
-                WEIGHTS_0.w * getJointMatrix(u_jointSampler, JOINTS_0.w );
+                WEIGHTS_0.x * getJointMatrix(galacean_JointSampler, JOINTS_0.x ) +
+                WEIGHTS_0.y * getJointMatrix(galacean_JointSampler, JOINTS_0.y ) +
+                WEIGHTS_0.z * getJointMatrix(galacean_JointSampler, JOINTS_0.z ) +
+                WEIGHTS_0.w * getJointMatrix(galacean_JointSampler, JOINTS_0.w );
 
         #else
             mat4 skinMatrix =
-                WEIGHTS_0.x * u_jointMatrix[ int( JOINTS_0.x ) ] +
-                WEIGHTS_0.y * u_jointMatrix[ int( JOINTS_0.y ) ] +
-                WEIGHTS_0.z * u_jointMatrix[ int( JOINTS_0.z ) ] +
-                WEIGHTS_0.w * u_jointMatrix[ int( JOINTS_0.w ) ];
+                WEIGHTS_0.x * galacean_JointMatrix[ int( JOINTS_0.x ) ] +
+                WEIGHTS_0.y * galacean_JointMatrix[ int( JOINTS_0.y ) ] +
+                WEIGHTS_0.z * galacean_JointMatrix[ int( JOINTS_0.z ) ] +
+                WEIGHTS_0.w * galacean_JointMatrix[ int( JOINTS_0.w ) ];
         #endif
 
         position = skinMatrix * position;
 
-        #if defined(O3_HAS_NORMAL) && !defined(OMIT_NORMAL)
+        #if defined(GALACEAN_HAS_NORMAL) && !defined(OMIT_NORMAL)
             mat3 skinNormalMatrix = INVERSE_MAT(mat3(skinMatrix));
             normal = normal * skinNormalMatrix;
-            #if defined(O3_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+            #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
                 tangent.xyz = tangent.xyz * skinNormalMatrix;
             #endif
 

--- a/packages/core/src/shaderlib/skinning_vert.glsl
+++ b/packages/core/src/shaderlib/skinning_vert.glsl
@@ -1,26 +1,26 @@
-#ifdef O3_HAS_SKIN
+#ifdef RENDERER_HAS_SKIN
 
-        #ifdef O3_USE_JOINT_TEXTURE
+        #ifdef RENDERER_USE_JOINT_TEXTURE
             mat4 skinMatrix =
-                WEIGHTS_0.x * getJointMatrix(galacean_JointSampler, JOINTS_0.x ) +
-                WEIGHTS_0.y * getJointMatrix(galacean_JointSampler, JOINTS_0.y ) +
-                WEIGHTS_0.z * getJointMatrix(galacean_JointSampler, JOINTS_0.z ) +
-                WEIGHTS_0.w * getJointMatrix(galacean_JointSampler, JOINTS_0.w );
+                WEIGHTS_0.x * getJointMatrix(renderer_JointSampler, JOINTS_0.x ) +
+                WEIGHTS_0.y * getJointMatrix(renderer_JointSampler, JOINTS_0.y ) +
+                WEIGHTS_0.z * getJointMatrix(renderer_JointSampler, JOINTS_0.z ) +
+                WEIGHTS_0.w * getJointMatrix(renderer_JointSampler, JOINTS_0.w );
 
         #else
             mat4 skinMatrix =
-                WEIGHTS_0.x * galacean_JointMatrix[ int( JOINTS_0.x ) ] +
-                WEIGHTS_0.y * galacean_JointMatrix[ int( JOINTS_0.y ) ] +
-                WEIGHTS_0.z * galacean_JointMatrix[ int( JOINTS_0.z ) ] +
-                WEIGHTS_0.w * galacean_JointMatrix[ int( JOINTS_0.w ) ];
+                WEIGHTS_0.x * renderer_JointMatrix[ int( JOINTS_0.x ) ] +
+                WEIGHTS_0.y * renderer_JointMatrix[ int( JOINTS_0.y ) ] +
+                WEIGHTS_0.z * renderer_JointMatrix[ int( JOINTS_0.z ) ] +
+                WEIGHTS_0.w * renderer_JointMatrix[ int( JOINTS_0.w ) ];
         #endif
 
         position = skinMatrix * position;
 
-        #if defined(GALACEAN_HAS_NORMAL) && !defined(OMIT_NORMAL)
+        #if defined(RENDERER_HAS_NORMAL) && !defined(MATERIAL_OMIT_NORMAL)
             mat3 skinNormalMatrix = INVERSE_MAT(mat3(skinMatrix));
             normal = normal * skinNormalMatrix;
-            #if defined(GALACEAN_HAS_TANGENT) && ( defined(NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+            #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
                 tangent.xyz = tangent.xyz * skinNormalMatrix;
             #endif
 

--- a/packages/core/src/shaderlib/skinning_vert.glsl
+++ b/packages/core/src/shaderlib/skinning_vert.glsl
@@ -20,7 +20,7 @@
         #if defined(RENDERER_HAS_NORMAL) && !defined(MATERIAL_OMIT_NORMAL)
             mat3 skinNormalMatrix = INVERSE_MAT(mat3(skinMatrix));
             normal = normal * skinNormalMatrix;
-            #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(HAS_CLEARCOATNORMALTEXTURE) )
+            #if defined(RENDERER_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEARCOATNORMALTEXTURE) )
                 tangent.xyz = tangent.xyz * skinNormalMatrix;
             #endif
 

--- a/packages/core/src/shaderlib/transform_declare.glsl
+++ b/packages/core/src/shaderlib/transform_declare.glsl
@@ -1,7 +1,7 @@
-uniform mat4 galacean_LocalMat;
-uniform mat4 galacean_ModelMat;
-uniform mat4 galacean_ViewMat;
-uniform mat4 galacean_ProjMat;
-uniform mat4 galacean_MVMat;
-uniform mat4 galacean_MVPMat;
-uniform mat4 galacean_NormalMat;
+uniform mat4 renderer_LocalMat;
+uniform mat4 renderer_ModelMat;
+uniform mat4 camera_ViewMat;
+uniform mat4 camera_ProjMat;
+uniform mat4 renderer_MVMat;
+uniform mat4 renderer_MVPMat;
+uniform mat4 renderer_NormalMat;

--- a/packages/core/src/shaderlib/transform_declare.glsl
+++ b/packages/core/src/shaderlib/transform_declare.glsl
@@ -1,7 +1,7 @@
-uniform mat4 u_localMat;
-uniform mat4 u_modelMat;
-uniform mat4 u_viewMat;
-uniform mat4 u_projMat;
-uniform mat4 u_MVMat;
-uniform mat4 u_MVPMat;
-uniform mat4 u_normalMat;
+uniform mat4 galacean_LocalMat;
+uniform mat4 galacean_ModelMat;
+uniform mat4 galacean_ViewMat;
+uniform mat4 galacean_ProjMat;
+uniform mat4 galacean_MVMat;
+uniform mat4 galacean_MVPMat;
+uniform mat4 galacean_NormalMat;

--- a/packages/core/src/shaderlib/uv_share.glsl
+++ b/packages/core/src/shaderlib/uv_share.glsl
@@ -1,5 +1,5 @@
 varying vec2 v_uv;
 
-#ifdef O3_HAS_UV1
+#ifdef GALACEAN_HAS_UV1
     varying vec2 v_uv1;
 #endif

--- a/packages/core/src/shaderlib/uv_share.glsl
+++ b/packages/core/src/shaderlib/uv_share.glsl
@@ -1,5 +1,5 @@
 varying vec2 v_uv;
 
-#ifdef GALACEAN_HAS_UV1
+#ifdef RENDERER_HAS_UV1
     varying vec2 v_uv1;
 #endif

--- a/packages/core/src/shaderlib/uv_vert.glsl
+++ b/packages/core/src/shaderlib/uv_vert.glsl
@@ -1,14 +1,14 @@
-#ifdef GALACEAN_HAS_UV
+#ifdef RENDERER_HAS_UV
     v_uv = TEXCOORD_0;
 #else
     // may need this calculate normal
     v_uv = vec2( 0., 0. );
 #endif
 
-#ifdef GALACEAN_HAS_UV1
+#ifdef RENDERER_HAS_UV1
     v_uv1 = TEXCOORD_1;
 #endif
 
-#ifdef O3_NEED_TILINGOFFSET
-    v_uv = v_uv * u_tilingOffset.xy + u_tilingOffset.zw;
+#ifdef MATERIAL_NEED_TILINGOFFSET
+    v_uv = v_uv * material_TilingOffset.xy + material_TilingOffset.zw;
 #endif

--- a/packages/core/src/shaderlib/uv_vert.glsl
+++ b/packages/core/src/shaderlib/uv_vert.glsl
@@ -1,11 +1,11 @@
-#ifdef O3_HAS_UV
+#ifdef GALACEAN_HAS_UV
     v_uv = TEXCOORD_0;
 #else
     // may need this calculate normal
     v_uv = vec2( 0., 0. );
 #endif
 
-#ifdef O3_HAS_UV1
+#ifdef GALACEAN_HAS_UV1
     v_uv1 = TEXCOORD_1;
 #endif
 

--- a/packages/core/src/shaderlib/worldpos_share.glsl
+++ b/packages/core/src/shaderlib/worldpos_share.glsl
@@ -1,3 +1,3 @@
-#ifdef O3_NEED_WORLDPOS
+#ifdef MATERIAL_NEED_WORLDPOS
     varying vec3 v_pos;
 #endif

--- a/packages/core/src/shaderlib/worldpos_vert.glsl
+++ b/packages/core/src/shaderlib/worldpos_vert.glsl
@@ -1,4 +1,4 @@
 #ifdef O3_NEED_WORLDPOS
-    vec4 temp_pos = u_modelMat * position;
+    vec4 temp_pos = galacean_ModelMat * position;
     v_pos = temp_pos.xyz / temp_pos.w;
 #endif

--- a/packages/core/src/shaderlib/worldpos_vert.glsl
+++ b/packages/core/src/shaderlib/worldpos_vert.glsl
@@ -1,4 +1,4 @@
-#ifdef O3_NEED_WORLDPOS
-    vec4 temp_pos = galacean_ModelMat * position;
+#ifdef MATERIAL_NEED_WORLDPOS
+    vec4 temp_pos = renderer_ModelMat * position;
     v_pos = temp_pos.xyz / temp_pos.w;
 #endif

--- a/packages/core/src/shadow/CascadedShadowCasterPass.ts
+++ b/packages/core/src/shadow/CascadedShadowCasterPass.ts
@@ -21,14 +21,14 @@ import { ShadowUtils } from "./ShadowUtils";
  * Cascade shadow caster.
  */
 export class CascadedShadowCasterPass {
-  private static _lightShadowBiasProperty = ShaderProperty.getByName("galacean_ShadowBias");
-  private static _lightDirectionProperty = ShaderProperty.getByName("galacean_LightDirection");
+  private static _lightShadowBiasProperty = ShaderProperty.getByName("scene_ShadowBias");
+  private static _lightDirectionProperty = ShaderProperty.getByName("scene_LightDirection");
 
-  private static _shadowMatricesProperty = ShaderProperty.getByName("galacean_ShadowMatrices");
-  private static _shadowMapSize = ShaderProperty.getByName("galacean_ShadowMapSize");
-  private static _shadowInfosProperty = ShaderProperty.getByName("galacean_ShadowInfo");
-  private static _shadowMapsProperty = ShaderProperty.getByName("galacean_ShadowMap");
-  private static _shadowSplitSpheresProperty = ShaderProperty.getByName("galacean_ShadowSplitSpheres");
+  private static _shadowMatricesProperty = ShaderProperty.getByName("scene_ShadowMatrices");
+  private static _shadowMapSize = ShaderProperty.getByName("scene_ShadowMapSize");
+  private static _shadowInfosProperty = ShaderProperty.getByName("scene_ShadowInfo");
+  private static _shadowMapsProperty = ShaderProperty.getByName("scene_ShadowMap");
+  private static _shadowSplitSpheresProperty = ShaderProperty.getByName("scene_ShadowSplitSpheres");
 
   private static _maxCascades: number = 4;
   private static _cascadesSplitDistance: number[] = new Array(CascadedShadowCasterPass._maxCascades + 1);

--- a/packages/core/src/shadow/CascadedShadowCasterPass.ts
+++ b/packages/core/src/shadow/CascadedShadowCasterPass.ts
@@ -21,14 +21,14 @@ import { ShadowUtils } from "./ShadowUtils";
  * Cascade shadow caster.
  */
 export class CascadedShadowCasterPass {
-  private static _lightShadowBiasProperty = ShaderProperty.getByName("u_shadowBias");
-  private static _lightDirectionProperty = ShaderProperty.getByName("u_lightDirection");
+  private static _lightShadowBiasProperty = ShaderProperty.getByName("galacean_ShadowBias");
+  private static _lightDirectionProperty = ShaderProperty.getByName("galacean_LightDirection");
 
-  private static _shadowMatricesProperty = ShaderProperty.getByName("u_shadowMatrices");
-  private static _shadowMapSize = ShaderProperty.getByName("u_shadowMapSize");
-  private static _shadowInfosProperty = ShaderProperty.getByName("u_shadowInfo");
-  private static _shadowMapsProperty = ShaderProperty.getByName("u_shadowMap");
-  private static _shadowSplitSpheresProperty = ShaderProperty.getByName("u_shadowSplitSpheres");
+  private static _shadowMatricesProperty = ShaderProperty.getByName("galacean_ShadowMatrices");
+  private static _shadowMapSize = ShaderProperty.getByName("galacean_ShadowMapSize");
+  private static _shadowInfosProperty = ShaderProperty.getByName("galacean_ShadowInfo");
+  private static _shadowMapsProperty = ShaderProperty.getByName("galacean_ShadowMap");
+  private static _shadowSplitSpheresProperty = ShaderProperty.getByName("galacean_ShadowSplitSpheres");
 
   private static _maxCascades: number = 4;
   private static _cascadesSplitDistance: number[] = new Array(CascadedShadowCasterPass._maxCascades + 1);

--- a/packages/core/src/sky/SkyBoxMaterial.ts
+++ b/packages/core/src/sky/SkyBoxMaterial.ts
@@ -89,7 +89,6 @@ export class SkyBoxMaterial extends Material {
     this.renderState.rasterState.cullMode = CullMode.Off;
     this.renderState.depthState.compareFunction = CompareFunction.LessEqual;
 
-    this.shaderData.enableMacro(SkyBoxMaterial._decodeSkyRGBMMacro);
     this.shaderData.setFloat(SkyBoxMaterial._rotationProp, 0);
     this.shaderData.setFloat(SkyBoxMaterial._exposureProp, 1);
     this.shaderData.setColor(SkyBoxMaterial._tintColorProp, this._tintColor);

--- a/packages/core/src/sky/SkyBoxMaterial.ts
+++ b/packages/core/src/sky/SkyBoxMaterial.ts
@@ -12,11 +12,11 @@ import { TextureCube } from "../texture";
  * SkyBoxMaterial.
  */
 export class SkyBoxMaterial extends Material {
-  private static _tintColorProp = ShaderProperty.getByName("u_tintColor");
-  private static _textureCubeProp = ShaderProperty.getByName("u_cubeTexture");
-  private static _rotationProp = ShaderProperty.getByName("u_rotation");
-  private static _exposureProp = ShaderProperty.getByName("u_exposure");
-  private static _decodeSkyRGBMMacro = ShaderMacro.getByName("DECODE_SKY_RGBM");
+  private static _tintColorProp = ShaderProperty.getByName("material_TintColor");
+  private static _textureCubeProp = ShaderProperty.getByName("material_CubeTexture");
+  private static _rotationProp = ShaderProperty.getByName("material_Rotation");
+  private static _exposureProp = ShaderProperty.getByName("material_Exposure");
+  private static _decodeSkyRGBMMacro = ShaderMacro.getByName("MATERIAL_IS_DECODE_SKY_RGBM");
 
   private _textureDecodeRGBM: boolean = false;
   private _tintColor: Color = new Color(1, 1, 1, 1);

--- a/packages/core/src/sky/SkyProceduralMaterial.ts
+++ b/packages/core/src/sky/SkyProceduralMaterial.ts
@@ -20,15 +20,15 @@ export enum SunMode {
  * Sky procedural material.
  */
 export class SkyProceduralMaterial extends Material {
-  private static _sunSizeProp: ShaderProperty = ShaderProperty.getByName("u_SunSize");
-  private static _sunSizeConvergenceProp: ShaderProperty = ShaderProperty.getByName("u_SunSizeConvergence");
-  private static _atmosphereThicknessProp: ShaderProperty = ShaderProperty.getByName("u_AtmosphereThickness");
-  private static _skyTintProp: ShaderProperty = ShaderProperty.getByName("u_SkyTint");
-  private static _groundTintProp: ShaderProperty = ShaderProperty.getByName("u_GroundTint");
-  private static _exposureProp: ShaderProperty = ShaderProperty.getByName("u_Exposure");
+  private static _sunSizeProp: ShaderProperty = ShaderProperty.getByName("material_SunSize");
+  private static _sunSizeConvergenceProp: ShaderProperty = ShaderProperty.getByName("material_SunSizeConvergence");
+  private static _atmosphereThicknessProp: ShaderProperty = ShaderProperty.getByName("material_AtmosphereThickness");
+  private static _skyTintProp: ShaderProperty = ShaderProperty.getByName("material_SkyTint");
+  private static _groundTintProp: ShaderProperty = ShaderProperty.getByName("material_GroundTint");
+  private static _exposureProp: ShaderProperty = ShaderProperty.getByName("material_Exposure");
 
-  private static _sunHighQualityMacro: ShaderMacro = ShaderMacro.getByName("SUN_HIGH_QUALITY");
-  private static _sunSimpleMacro: ShaderMacro = ShaderMacro.getByName("SUN_SIMPLE");
+  private static _sunHighQualityMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_SUN_HIGH_QUALITY");
+  private static _sunSimpleMacro: ShaderMacro = ShaderMacro.getByName("MATERIAL_SUN_SIMPLE");
 
   private _sunDisk: SunMode;
 

--- a/packages/core/src/trail/trail.vs.glsl
+++ b/packages/core/src/trail/trail.vs.glsl
@@ -3,12 +3,12 @@ attribute vec2 TEXCOORD_0;
 
 varying vec2 v_uv;
 
-uniform mat4 u_projMat;
-uniform mat4 u_viewMat;
+uniform mat4 galacean_ProjMat;
+uniform mat4 galacean_ViewMat;
 
 void main() {
 
-  gl_Position = u_projMat * u_viewMat * vec4( POSITION, 1.0 );
+  gl_Position = galacean_ProjMat * galacean_ViewMat * vec4( POSITION, 1.0 );
   v_uv = TEXCOORD_0;
 
 }

--- a/packages/core/src/trail/trail.vs.glsl
+++ b/packages/core/src/trail/trail.vs.glsl
@@ -3,12 +3,12 @@ attribute vec2 TEXCOORD_0;
 
 varying vec2 v_uv;
 
-uniform mat4 galacean_ProjMat;
-uniform mat4 galacean_ViewMat;
+uniform mat4 camera_ProjMat;
+uniform mat4 camera_ViewMat;
 
 void main() {
 
-  gl_Position = galacean_ProjMat * galacean_ViewMat * vec4( POSITION, 1.0 );
+  gl_Position = camera_ProjMat * camera_ViewMat * vec4( POSITION, 1.0 );
   v_uv = TEXCOORD_0;
 
 }

--- a/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
+++ b/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
@@ -1,13 +1,11 @@
 import { AnimationClip, AnimationEvent } from "@galacean/engine-core";
-import { GLTFResource } from "../GLTFResource";
-import { GLTFExtensionOwnerSchema } from "../GLTFSchema";
 import { registerGLTFExtension } from "../parser/GLTFParser";
 import { GLTFParserContext } from "../parser/GLTFParserContext";
 import { GLTFExtensionMode, GLTFExtensionParser } from "./GLTFExtensionParser";
 import { IOasisAnimation } from "./GLTFExtensionSchema";
 
-@registerGLTFExtension("OASIS_animation_event", GLTFExtensionMode.AdditiveParse)
-class OASIS_animation_event extends GLTFExtensionParser {
+@registerGLTFExtension("GALACEAN_animation_event", GLTFExtensionMode.AdditiveParse)
+class GALACEAN_animation_event extends GLTFExtensionParser {
   /**
    * @override
    */

--- a/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
+++ b/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
@@ -2,7 +2,7 @@ import { AnimationClip, AnimationEvent } from "@galacean/engine-core";
 import { registerGLTFExtension } from "../parser/GLTFParser";
 import { GLTFParserContext } from "../parser/GLTFParserContext";
 import { GLTFExtensionMode, GLTFExtensionParser } from "./GLTFExtensionParser";
-import { IOasisAnimation } from "./GLTFExtensionSchema";
+import { IGalaceanAnimation } from "./GLTFExtensionSchema";
 
 @registerGLTFExtension("GALACEAN_animation_event", GLTFExtensionMode.AdditiveParse)
 class GALACEAN_animation_event extends GLTFExtensionParser {

--- a/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
+++ b/packages/loader/src/gltf/extensions/GALACEAN_animation_event.ts
@@ -9,7 +9,7 @@ class GALACEAN_animation_event extends GLTFExtensionParser {
   /**
    * @override
    */
-  additiveParse(context: GLTFParserContext, animationClip: AnimationClip, schema: IOasisAnimation): void {
+  additiveParse(context: GLTFParserContext, animationClip: AnimationClip, schema: IGalaceanAnimation): void {
     const { engine } = context.glTFResource;
     const { events } = schema;
     events.map((eventData) => {

--- a/packages/loader/src/gltf/extensions/GLTFExtensionSchema.ts
+++ b/packages/loader/src/gltf/extensions/GLTFExtensionSchema.ts
@@ -159,7 +159,7 @@ export interface IGalaceanMaterialRemap {
   isClone?: boolean;
 }
 
-export interface IOasisAnimation {
+export interface IGalaceanAnimation {
   events: {
     time: number;
     functionName: string;
@@ -184,5 +184,5 @@ export type GLTFExtensionSchema =
   | IKHRTextureTransform
   | IKHRXmp
   | IKHRXmp_Node
-  | IOasisAnimation
+  | IGalaceanAnimation
   | Object;

--- a/packages/loader/src/gltf/extensions/index.ts
+++ b/packages/loader/src/gltf/extensions/index.ts
@@ -11,7 +11,7 @@ import "./KHR_materials_volume";
 import "./KHR_mesh_quantization";
 import "./KHR_texture_basisu";
 import "./KHR_texture_transform";
-import "./Galacean_materials_remap";
+import "./GALACEAN_materials_remap";
 import "./GALACEAN_animation_event";
 
 export { GLTFExtensionParser, GLTFExtensionMode } from "./GLTFExtensionParser";

--- a/packages/loader/src/gltf/extensions/index.ts
+++ b/packages/loader/src/gltf/extensions/index.ts
@@ -12,7 +12,7 @@ import "./KHR_mesh_quantization";
 import "./KHR_texture_basisu";
 import "./KHR_texture_transform";
 import "./Galacean_materials_remap";
-import "./OASIS_animation_event";
+import "./GALACEAN_animation_event";
 
 export { GLTFExtensionParser, GLTFExtensionMode } from "./GLTFExtensionParser";
 export * from "./GLTFExtensionSchema";

--- a/tests/src/core/Shader.test.ts
+++ b/tests/src/core/Shader.test.ts
@@ -152,39 +152,39 @@ const customFS = `
 #include <uv_share>
 #include <FogFragmentDeclaration>
 
-uniform vec4 u_baseColor;
-uniform float u_alphaCutoff;
+uniform vec4 material_BaseColor;
+uniform float material_AlphaCutoff;
 
-#ifdef BASETEXTURE
-    uniform sampler2D u_baseTexture;
+#ifdef MATERIAL_HAS_BASETEXTURE
+    uniform sampler2D material_BaseTexture;
 #endif
 
 void main() {
-     vec4 baseColor = u_baseColor;
+     vec4 baseColor = material_BaseColor;
 
-    #ifdef BASETEXTURE
-        vec4 textureColor = texture2D(u_baseTexture, v_uv);
-        #ifndef GALACEAN_COLORSPACE_GAMMA
+    #ifdef MATERIAL_HAS_BASETEXTURE
+        vec4 textureColor = texture2D(material_BaseTexture, v_uv);
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
             textureColor = gammaToLinear(textureColor);
         #endif
         baseColor *= textureColor;
     #endif
 
-    #ifdef ALPHA_CUTOFF
-        if( baseColor.a < u_alphaCutoff ) {
+    #ifdef MATERIAL_IS_ALPHA_CUTOFF
+        if( baseColor.a < material_AlphaCutoff ) {
             discard;
         }
     #endif
 
     gl_FragColor = baseColor;
 
-    #ifndef OASIS_TRANSPARENT
+    #ifndef MATERIAL_IS_TRANSPARENT
         gl_FragColor.a = 1.0;
     #endif
 
     #include <FogFragment>
 
-     #ifndef GALACEAN_COLORSPACE_GAMMA
+     #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }

--- a/tests/src/core/Shader.test.ts
+++ b/tests/src/core/Shader.test.ts
@@ -164,7 +164,7 @@ void main() {
 
     #ifdef BASETEXTURE
         vec4 textureColor = texture2D(u_baseTexture, v_uv);
-        #ifndef OASIS_COLORSPACE_GAMMA
+        #ifndef GALACEAN_COLORSPACE_GAMMA
             textureColor = gammaToLinear(textureColor);
         #endif
         baseColor *= textureColor;
@@ -184,7 +184,7 @@ void main() {
 
     #include <FogFragment>
 
-     #ifndef OASIS_COLORSPACE_GAMMA
+     #ifndef GALACEAN_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);
     #endif
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Main modification:**
- Unified build-in shader property name style(`O3_、Oasis_、u_--->scene_/camera_/renderer_/material_`)
- Unified build-in shader macro name style(`O3_、OASIS_--->SCENE_/CAMERA_/RENDERER_/MATERIAL_`)
- Remove deprecate API `Shader.getPropertyByName` and `Shader.getMacroByName`

**Associated modification:**
- Toolkit: https://github.com/galacean/engine-toolkit/pull/191
- Example and document: https://github.com/galacean/oasis-engine.github.io/pull/695
