### PR TITLE
Open max allow skin uniform vector count and improve compatibility

### DIFF
--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -29,8 +29,8 @@ import { GLTexture } from "./GLTexture";
 import { GLTexture2D } from "./GLTexture2D";
 import { GLTexture2DArray } from "./GLTexture2DArray";
 import { GLTextureCube } from "./GLTextureCube";
-import { WebGLExtension } from "./type";
 import { WebCanvas } from "./WebCanvas";
+import { WebGLExtension } from "./type";
 
 /**
  * WebGL mode.
@@ -50,11 +50,20 @@ export enum WebGLMode {
 export interface WebGLRendererOptions extends WebGLContextAttributes {
   /** WebGL mode.*/
   webGLMode?: WebGLMode;
+
   /**
    * @internal
-   * iOS 15 webgl implement has bug, maybe should force call flush command buffer, for exmaple iPhone13(iOS 15.4.1).
+   * iOS 15 webgl implement has bug, maybe should force call flush command buffer, for example iPhone13(iOS 15.4.1).
    */
   _forceFlush?: boolean;
+
+  /**
+   * @internal
+   * Max allow skin uniform vectors count, default is 256
+   * 
+   * @remarks large count maybe cause performance issue.
+   */
+  _maxAllowSkinUniformVectorsCount?: number;
 }
 
 /**
@@ -120,6 +129,7 @@ export class WebGLRenderer implements IHardwareRenderer {
       alpha: false,
       stencil: true,
       _forceFlush: false,
+      _maxAllowSkinUniformVectorCount: 256,
       ...initializeOptions
     };
     if (SystemInfo.platform === Platform.IPhone || SystemInfo.platform === Platform.IPad) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

example:
const engine = new WebGLEngine("canvas", {
  // @ts-ignore
  _maxAllowSkinUniformVectorCount: 512,
});