### PR TITLE
Fix viewport bug when camera has render target

### DIFF
--- a/packages/rhi-webgl/src/WebGLGraphicDevice.ts
+++ b/packages/rhi-webgl/src/WebGLGraphicDevice.ts
@@ -33,8 +33,8 @@ import { GLTexture } from "./GLTexture";
 import { GLTexture2D } from "./GLTexture2D";
 import { GLTexture2DArray } from "./GLTexture2DArray";
 import { GLTextureCube } from "./GLTextureCube";
-import { WebGLExtension } from "./type";
 import { WebCanvas } from "./WebCanvas";
+import { WebGLExtension } from "./type";
 
 /**
  * WebGL mode.
@@ -316,23 +316,23 @@ export class WebGLGraphicDevice implements IHardwareRenderer {
 
   activeRenderTarget(renderTarget: RenderTarget, viewport: Vector4, mipLevel: number) {
     const gl = this._gl;
+    let bufferWidth: number, bufferHeight: number;
     if (renderTarget) {
       /** @ts-ignore */
       (renderTarget._platformRenderTarget as GLRenderTarget)?._activeRenderTarget();
-      const width = renderTarget.width >> mipLevel;
-      const height = renderTarget.height >> mipLevel;
-      this.viewport(0, 0, width, height);
-      this.scissor(0, 0, width, height);
+      bufferWidth = renderTarget.width >> mipLevel;
+      bufferHeight = renderTarget.height >> mipLevel;
     } else {
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-      const { drawingBufferWidth, drawingBufferHeight } = gl;
-      const width = drawingBufferWidth * viewport.z;
-      const height = drawingBufferHeight * viewport.w;
-      const x = viewport.x * drawingBufferWidth;
-      const y = drawingBufferHeight - viewport.y * drawingBufferHeight - height;
-      this.viewport(x, y, width, height);
-      this.scissor(x, y, width, height);
+      bufferWidth = gl.drawingBufferWidth;
+      bufferHeight = gl.drawingBufferHeight;
     }
+    const width = bufferWidth * viewport.z;
+    const height = bufferHeight * viewport.w;
+    const x = viewport.x * bufferWidth;
+    const y = bufferHeight - viewport.y * bufferHeight - height;
+    this.viewport(x, y, width, height);
+    this.scissor(x, y, width, height);
   }
 
   activeTexture(textureID: number): void {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Toolkit related PR: https://github.com/galacean/engine-toolkit/pull/203

When camera view port is (0, 0, 1, 0.5)
Before:
![image](https://user-images.githubusercontent.com/4967545/233677873-fd270158-4cf4-4655-94ae-9a5239a38fd2.png)
Now:
![image](https://user-images.githubusercontent.com/4967545/233677976-98eb5cf3-3009-455c-a47f-3410fb2b334b.png)



