### PR TITLE
fix character controller enable/disable bug

### DIFF
--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -141,10 +141,10 @@ export class PhysXPhysicsManager implements IPhysicsManager {
    * {@inheritDoc IPhysicsManager.addCharacterController }
    */
   addCharacterController(characterController: PhysXCharacterController): void {
-    const lastPXManager = characterController._pxManager;
     if (!characterController._pxController) {
       const shape = characterController._shape;
       if (shape) {
+        const lastPXManager = characterController._pxManager;
         if (lastPXManager !== this) {
           lastPXManager && characterController._destroyPXController();
           characterController._createPXController(this, shape);

--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -142,11 +142,13 @@ export class PhysXPhysicsManager implements IPhysicsManager {
    */
   addCharacterController(characterController: PhysXCharacterController): void {
     const lastPXManager = characterController._pxManager;
-    const shape = characterController._shape;
-    if (shape) {
-      if (lastPXManager !== this) {
-        lastPXManager && characterController._destroyPXController();
-        characterController._createPXController(this, shape);
+    if (!characterController._pxController) {
+      const shape = characterController._shape;
+      if (shape) {
+        if (lastPXManager !== this) {
+          lastPXManager && characterController._destroyPXController();
+          characterController._createPXController(this, shape);
+        }
       }
     }
     characterController._pxManager = this;
@@ -156,7 +158,6 @@ export class PhysXPhysicsManager implements IPhysicsManager {
    * {@inheritDoc IPhysicsManager.removeCharacterController }
    */
   removeCharacterController(characterController: PhysXCharacterController): void {
-    characterController._pxController = null;
     characterController._pxManager = null;
   }
 

--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -141,6 +141,7 @@ export class PhysXPhysicsManager implements IPhysicsManager {
    * {@inheritDoc IPhysicsManager.addCharacterController }
    */
   addCharacterController(characterController: PhysXCharacterController): void {
+    // Physx have no API to remove/readd cct into scene.
     if (!characterController._pxController) {
       const shape = characterController._shape;
       if (shape) {


### PR DESCRIPTION
when use inactive/active to enable/disable cct, it will recreate new one. Physx have no API to remove/readd cct into scene. 