### PR TITLE
Fix parse glTF texture wrap & filterMode bug

### DIFF
--- a/packages/loader/src/gltf/parser/GLTFTextureParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFTextureParser.ts
@@ -113,11 +113,11 @@ export class GLTFTextureParser extends GLTFParser {
       texture.filterMode = filterMode;
     }
 
-    if (wrapModeU) {
+    if (wrapModeU !== undefined) {
       texture.wrapModeU = wrapModeU;
     }
 
-    if (wrapModeV) {
+    if (wrapModeV !== undefined) {
       texture.wrapModeV = wrapModeV;
     }
   }

--- a/packages/loader/src/gltf/parser/GLTFTextureParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFTextureParser.ts
@@ -109,7 +109,7 @@ export class GLTFTextureParser extends GLTFParser {
   private _parseSampler(texture: Texture2D, samplerInfo: ISamplerInfo): void {
     const { filterMode, wrapModeU, wrapModeV } = samplerInfo;
 
-    if (filterMode) {
+    if (filterMode !== undefined) {
       texture.filterMode = filterMode;
     }
 


### PR DESCRIPTION
### 修复 glTF samplers wrapS & wrapT & magFilter 解析错误 bug

- 当 wrapT 或  wrapS 为 33071 即 Clamp 时，代码中 samplerInfo.wrapModeU 或 samplerInfo.wrapModeV 是 0， 导致 if 判断无法进入，进一步导致 wrapMode 设置出错
- 当 magFilter 为 9728，代码中 samplerInfo.filterMode 是 0， 导致 if 判断无法进入，进一步导致 filterMode 设置出错
- 代码逻辑如下：
![image](https://github.com/galacean/engine/assets/73691835/f1416f08-d5cd-4f47-b80d-b8b564632589)
- glTF 设置如下：
![image](https://github.com/galacean/engine/assets/73691835/e0c4ca5e-c449-4a90-a44c-4c8376da8e2d)
- 渲染结果如下：
![image](https://github.com/galacean/engine/assets/73691835/22b23ae8-fe4a-4fbb-bbfd-f6d47e730047)

