### PR TITLE
Add uniform decorator for improving custom material code

### DIFF
--- a/packages/core/src/shader/ShaderUniformDecorator.ts
+++ b/packages/core/src/shader/ShaderUniformDecorator.ts
@@ -1,0 +1,74 @@
+import { Material } from "../material/Material";
+import { ShaderProperty } from "./ShaderProperty";
+import { ShaderUniformType } from "./ShaderUniformType";
+
+export type UniformOptions = {
+  varName?: string; // the variable name in glsl
+  macroName?: string; // whether enable or disable a macro in glsl depends on setting value
+  keepRef?: boolean; // whether setting a value to a property will change reference or just copy value. Only available for vector or matrix type
+}
+
+function handleMacro(value: any, macroName?: string) {
+  if (macroName) {
+    if (value !== undefined) {
+      this.shaderData.enableMacro(macroName);
+    } else {
+      this.shaderData.disableMacro(macroName);
+    }
+  }
+}
+
+/**
+ * Shader uniform decorator.
+ */
+export function uniform(type: ShaderUniformType, options?: UniformOptions) {
+  return function (target: Material, propertyKey: string) {
+    const shaderProp = ShaderProperty.getByName(options?.varName || propertyKey);
+    const get = "get" + type;
+    const set = "set" + type;
+
+    let setFunc: (value: any) => void;
+    if (type === ShaderUniformType.Float || type === ShaderUniformType.Int || type === ShaderUniformType.Texture || type === ShaderUniformType.TextureArray) {
+      setFunc = function (value: any) {
+        this.shaderData[set](shaderProp, value);
+        handleMacro(value, options?.macroName);
+      }
+    } else if (options?.keepRef) {
+      if (type === ShaderUniformType.FloatArray || type === ShaderUniformType.IntArray) {
+        setFunc = function (value: any) {
+          let data = this.shaderData[get](shaderProp);
+          if (!data) {
+            this.shaderData[set](shaderProp, value);
+            data = value;
+          }
+          data.set(value);
+          handleMacro(value, options?.macroName);
+        }
+      } else if (type === ShaderUniformType.Vector2 || type === ShaderUniformType.Vector3 || type === ShaderUniformType.Vector4 || type === ShaderUniformType.Matrix || type === ShaderUniformType.Color) {
+        setFunc = function (value: any) {
+          let data = this.shaderData[get](shaderProp);
+          if (!data) {
+            this.shaderData[set](shaderProp, value);
+            data = value;
+          }
+          data.copyFrom(value);
+          handleMacro(value, options?.macroName);
+        }
+      }
+    } else {
+      setFunc = function (value: any) {
+        this.shaderData[set](shaderProp, value);
+        handleMacro(value, options?.macroName);
+      }
+    }
+
+    Reflect.defineProperty(target, propertyKey, {
+      get: function () {
+        return this.shaderData[get](shaderProp);
+      },
+      set: setFunc!,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+}

--- a/packages/core/src/shader/ShaderUniformType.ts
+++ b/packages/core/src/shader/ShaderUniformType.ts
@@ -1,0 +1,13 @@
+export enum ShaderUniformType {
+  Float = "Float",
+  Texture = "Texture",
+  Int = "Int",
+  FloatArray = "FloatArray",
+  IntArray = "IntArray",
+  TextureArray = "TextureArray",
+  Vector2 = "Vector2",
+  Vector3 = "Vector3",
+  Vector4 = "Vector4",
+  Color = "Color",
+  Matrix = "Matrix",
+}

--- a/packages/core/src/shader/index.ts
+++ b/packages/core/src/shader/index.ts
@@ -13,5 +13,7 @@ export { ShaderMacro } from "./ShaderMacro";
 export { ShaderPass } from "./ShaderPass";
 export { ShaderProperty } from "./ShaderProperty";
 export { ShaderTagKey } from "./ShaderTagKey";
+export { ShaderUniformType } from "./ShaderUniformType";
 export { SubShader } from "./SubShader";
+export { uniform } from "./ShaderUniformDecorator";
 export * from "./state";


### PR DESCRIPTION
![image](https://github.com/galacean/engine/assets/7953802/2fdb2160-001d-49f7-ba9a-add8c8594756)

With uniform decorator, it will be easier for create uniform property in material class.

Features:
## 1. support define glsl variable name

```typescript
class XXXMaterial extends BaseMaterial {
  // In this case, decorator only know baseColor is a Color type. So in glsl code, the variable name is the same as property name 'baseColor'
  @uniform(ShaderUniformType.Color)
  baseColor: Color = new Color(1, 1, 1, 1);
}

class XXXMaterial2 extends BaseMaterial {
  // In this case, decorator has second param, and varName in glsl is 'material_BaseColor' instead of using the same property name in js
  @uniform(ShaderUniformType.Color, {
    varName: 'material_BaseColor'
  })
  baseColor: Color = new Color(1, 1, 1, 1);
}
```

## 2. support macro
```typescript
class XXXMaterial extends BaseMaterial {
  // In this case, decorator knows if we set the texture, we should also need to enable MATERIAL_HAS_BASETEXTURE macro. If we remove the texture, we should disable the macro.
  @uniform(ShaderUniformType.Texture, {
    varName: "material_BaseColor",
    macroName: "MATERIAL_HAS_BASETEXTURE"
  })
  baseTexture: Texture2D;
}

// the above code logic is the same as following code:
class UnlitMaterial extends BaseMaterial {
  /**
   * Base texture.
   */
  get baseTexture(): Texture2D {
    return <Texture2D>this.shaderData.getTexture(UnlitMaterial._baseTextureProp);
  }

  set baseTexture(value: Texture2D) {
    this.shaderData.setTexture(UnlitMaterial._baseTextureProp, value);
    if (value) {
      this.shaderData.enableMacro(UnlitMaterial._baseTextureMacro);
    } else {
      this.shaderData.disableMacro(UnlitMaterial._baseTextureMacro);
    }
  }
}
```

## 3. support keeping reference
```typescript
class XXXMaterial extends BaseMaterial {
  @uniform(ShaderUniformType.Color, {
    keepRef: true
  })
  baseColor: Color = new Color(1, 1, 1, 1);
}

// If we keepRef, the baseColor will not be changed reference but only copy data just like:
const material = new XXXMaterial();
const newColor = new Color(0,0,0,0);
material.baseColor = newColor; // This code will not change reference
material.baseColor === newColor // false, but the baseColor's data is 0,0,0,0


```