### PR TITLE
Fix `viewportPointToRay` triggers precision issues when the depth value is 1

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -405,7 +405,7 @@ export class Camera extends Component {
     // Use the intersection of the near clipping plane as the origin point.
     const origin = this._innerViewportToWorldPoint(point.x, point.y, 0.0, invViewProjMat, out.origin);
     // Use the intersection of the far clipping plane as the origin point.
-    const direction = this._innerViewportToWorldPoint(point.x, point.y, 1.0, invViewProjMat, out.direction);
+    const direction = this._innerViewportToWorldPoint(point.x, point.y, 0.95, invViewProjMat, out.direction);
     Vector3.subtract(direction, origin, direction);
     direction.normalize();
     return out;

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -408,7 +408,7 @@ export class Camera extends Component {
     const direction = this._innerViewportToWorldPoint(
       point.x,
       point.y,
-      1 - MathUtil.oneTolerance,
+      1 - MathUtil.zeroTolerance,
       invViewProjMat,
       out.direction
     );

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -405,7 +405,13 @@ export class Camera extends Component {
     // Use the intersection of the near clipping plane as the origin point.
     const origin = this._innerViewportToWorldPoint(point.x, point.y, 0.0, invViewProjMat, out.origin);
     // Use the intersection of the far clipping plane as the origin point.
-    const direction = this._innerViewportToWorldPoint(point.x, point.y, 0.95, invViewProjMat, out.direction);
+    const direction = this._innerViewportToWorldPoint(
+      point.x,
+      point.y,
+      MathUtil.oneTolerance,
+      invViewProjMat,
+      out.direction
+    );
     Vector3.subtract(direction, origin, direction);
     direction.normalize();
     return out;

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -408,7 +408,7 @@ export class Camera extends Component {
     const direction = this._innerViewportToWorldPoint(
       point.x,
       point.y,
-      MathUtil.oneTolerance,
+      1 - MathUtil.oneTolerance,
       invViewProjMat,
       out.direction
     );

--- a/packages/math/src/MathUtil.ts
+++ b/packages/math/src/MathUtil.ts
@@ -4,6 +4,8 @@
 export class MathUtil {
   /** The value for which all absolute numbers smaller than are considered equal to zero. */
   static readonly zeroTolerance: number = 1e-6;
+  /** The value for which all absolute numbers smaller than are considered equal to one. */
+  static readonly oneTolerance: number = 1 - 1e-6;
   /** The conversion factor that radian to degree. */
   static readonly radToDegreeFactor: number = 180 / Math.PI;
   /** The conversion factor that degree to radian. */

--- a/packages/math/src/MathUtil.ts
+++ b/packages/math/src/MathUtil.ts
@@ -4,8 +4,6 @@
 export class MathUtil {
   /** The value for which all absolute numbers smaller than are considered equal to zero. */
   static readonly zeroTolerance: number = 1e-6;
-  /** The value for which all absolute numbers smaller than are considered equal to one. */
-  static readonly oneTolerance: number = 1 - 1e-6;
   /** The conversion factor that radian to degree. */
   static readonly radToDegreeFactor: number = 180 / Math.PI;
   /** The conversion factor that degree to radian. */

--- a/tests/src/core/Camera.test.ts
+++ b/tests/src/core/Camera.test.ts
@@ -9,7 +9,7 @@ describe("camera test", function () {
   let camera: Camera;
   let identityMatrix: Matrix = new Matrix();
 
- before(async function () {
+  before(async function () {
     this.timeout(10000);
     const engine = await WebGLEngine.create({ canvas: canvasDOM });
     rootEntity = engine.sceneManager.scenes[0].createRootEntity();
@@ -204,6 +204,15 @@ describe("camera test", function () {
     const screenPoint = camera.worldToScreenPoint(worldPoint, new Vector3());
     const expectedworldPoint = camera.screenToWorldPoint(screenPoint, new Vector3());
     expect(worldPoint.z).to.be.closeTo(expectedworldPoint.z, 0.1, "Result z should match expected value");
+  });
+
+  it("precision of viewportPointToRay", () => {
+    camera.farClipPlane = 1000000000;
+    camera.nearClipPlane = 0.1;
+    const ray = camera.viewportPointToRay(new Vector2(0.5, 0.5), new Ray());
+    expect(ray.direction.x).not.to.be.NaN;
+    expect(ray.direction.y).not.to.be.NaN;
+    expect(Math.abs(ray.direction.z)).not.eq(Infinity);
   });
 
   /*


### PR DESCRIPTION
#1720 
