### PR TITLE
fix(shader-lab): compatible with empty macro

### DIFF
--- a/packages/shader-lab/src/RuntimeContext.ts
+++ b/packages/shader-lab/src/RuntimeContext.ts
@@ -270,7 +270,7 @@ export default class RuntimeContext {
 
   getMacroText(macros: (FnMacroAstNode | FnMacroConditionAstNode)[], needSort = false): string {
     const list = needSort ? macros.sort(AstNodeUtils.astSortAsc) : macros;
-    return list.map((item) => item.serialize(this)).join("\n");
+    return list?.map((item) => item.serialize(this)).join("\n");
   }
 
   getGlobalText(): string {

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -195,4 +195,9 @@ describe("ShaderLab", () => {
     const demoShader = fs.readFileSync(path.join(__dirname, "shaders/planarShadow.shader")).toString();
     glslValidate(demoShader, shaderLab);
   });
+
+  it("Empty macro shader", () => {
+    const demoShader = fs.readFileSync(path.join(__dirname, "shaders/triangle.shader")).toString();
+    glslValidate(demoShader, shaderLab);
+  });
 });

--- a/tests/src/shader-lab/shaders/triangle.shader
+++ b/tests/src/shader-lab/shaders/triangle.shader
@@ -1,0 +1,31 @@
+Shader "Triangle" {
+  SubShader "Default" {
+    Pass "0" {
+      mat4 renderer_MVPMat;
+      vec3 u_color;
+
+      struct a2v {
+        vec4 POSITION;
+      }
+
+      struct v2f {
+        vec3 v_color;
+      }
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      v2f vert(a2v v) {
+        v2f o;
+
+        gl_Position = renderer_MVPMat * v.POSITION;
+        o.v_color = u_color;
+        return o;
+      }
+
+      void frag(v2f i) {
+        gl_FragColor = vec4(i.v_color, 1.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fixed compatibility issue with empty macros in ShaderLab