### PR TITLE
Fix background texture render abnormal

### DIFF
--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -54,6 +54,7 @@ export class Background {
       this._texture?._addReferCount(-1);
       this._texture = value;
       this._material.shaderData.setTexture("material_BaseTexture", value);
+      this._resizeBackgroundTexture();
     }
   }
 
@@ -100,13 +101,12 @@ export class Background {
    * @internal
    */
   _resizeBackgroundTexture(): void {
+    const { _texture: texture, _mesh: mesh } = this;
     if (!this._texture) {
       return;
     }
-    const { canvas } = this._engine;
-    const { width, height } = canvas;
-    const { _mesh: _backgroundTextureMesh } = this;
-    const positions = _backgroundTextureMesh.getPositions();
+    const { width, height } = this._engine.canvas;
+    const positions = mesh.getPositions();
 
     switch (this._textureFillMode) {
       case BackgroundTextureFillMode.Fill:
@@ -116,22 +116,22 @@ export class Background {
         positions[3].set(1, 1, 1);
         break;
       case BackgroundTextureFillMode.AspectFitWidth:
-        const fitWidthScale = (this._texture.height * width) / this.texture.width / height;
+        const fitWidthScale = (texture.height * width) / texture.width / height;
         positions[0].set(-1, -fitWidthScale, 1);
         positions[1].set(1, -fitWidthScale, 1);
         positions[2].set(-1, fitWidthScale, 1);
         positions[3].set(1, fitWidthScale, 1);
         break;
       case BackgroundTextureFillMode.AspectFitHeight:
-        const fitHeightScale = (this._texture.width * height) / this.texture.height / width;
+        const fitHeightScale = (texture.width * height) / texture.height / width;
         positions[0].set(-fitHeightScale, -1, 1);
         positions[1].set(fitHeightScale, -1, 1);
         positions[2].set(-fitHeightScale, 1, 1);
         positions[3].set(fitHeightScale, 1, 1);
         break;
     }
-    _backgroundTextureMesh.setPositions(positions);
-    _backgroundTextureMesh.uploadData(false);
+    mesh.setPositions(positions);
+    mesh.uploadData(false);
   }
 
   private _initMesh(engine: Engine): void {

--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -59,7 +59,6 @@ export class Background {
   }
 
   /**
-   * @internal
    * Background texture fill mode.
    * @remarks When `mode` is `BackgroundMode.Texture`, the property will take effects.
    * @defaultValue `BackgroundTextureFillMode.FitHeight`


### PR DESCRIPTION
When setting `textureFillMode` to `fill` first and then setting `texutre`, the background texture will render abnormally because the `position` of the `mesh` is not updated.
```
import {
  AssetType,
  BackgroundMode,
  BackgroundTextureFillMode,
  Camera,
  Texture2D,
  WebGLEngine,
} from "@galacean/engine";

WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
  const scene = engine.sceneManager.activeScene;
  const { background } = scene;
  const root = scene.createRootEntity();
  const cameraEntity = root.createChild();
  cameraEntity.addComponent(Camera);
  engine.canvas.width = 480;
  engine.canvas.height = 360;

  engine.resourceManager
    .load<Texture2D>({
      url: "https://mdn.alipayobjects.com/huamei_jvf0dp/afts/img/A*nvhjTrdxAKEAAAAAAAAAAAAADleLAQ/original",
      type: AssetType.Texture2D,
    })
    .then((texture: Texture2D) => {
      background.mode = BackgroundMode.Texture;
      background.texture = texture;
      background.textureFillMode = BackgroundTextureFillMode.Fill;
    });

  engine.run();
});
```
