### PR TITLE
Feature: Add alias for loading resource

### DIFF
--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -7,6 +7,10 @@ type PickOnlyOne<T extends {}, Keys extends keyof T = keyof T> = Keys extends un
  */
 export type LoadItem = {
   /**
+   * Resource's alias.
+   */
+  name?: string;
+  /**
    * Asset Type.
    */
   type?: string;


### PR DESCRIPTION
resourceManager.getFromCache is very difficult to use. For example

```typescript
await engine.resourceManager.load([{
    url: "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.jpg",
}]);

xxxMaterial.texture = engine.resourceManager.getFromCache("xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.jpg");
```

Sometimes a resource url is a hash string and we don't know what is it util we check the resource by url. We can't know what is it when writing code. And another much worse situation is loading a spine, it has 3 urls and we must join the url array. The code would be very ugly.

If we give LoadItem a name, we can just get cache by their name, for example:
```typescript
await engine.resourceManager.load([{
    urls: [
        "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.jpg",
        "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.atlas",
        "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.json",
    ],
    type: "spine",
    name: "boy"
}]);


const spine1 = engine.resourceManager.getFromCache('boy'); // it would be very easy to know what we get
// and the up code is the same as
const spine2 = engine.resourceManager.getFromCache([
    "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.jpg",
    "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.atlas",
    "xxx.com/83b812c361e2c2d0bd68626b2b07a58a20fc0839.json",
].join(','));

spine1 === spine2; // true
```
