### PR TITLE
Fix `Renderer._bounds` clone bug

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -43,7 +43,7 @@ export class Renderer extends Component implements IComponentCustomClone {
   @ignoreClone
   _globalShaderMacro: ShaderMacroCollection = new ShaderMacroCollection();
   /** @internal */
-  @deepClone
+  @ignoreClone
   _bounds: BoundingBox = new BoundingBox();
   @ignoreClone
   _renderFrameCount: number;


### PR DESCRIPTION
```
import { WebGLEngine, MeshRenderer } from "@galacean/engine";

WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
  engine.canvas.resizeByClientSize();
  const entity = engine.sceneManager.activeScene.createRootEntity("renderer");
  const renderer = entity.addComponent(MeshRenderer);
  console.log(
    "compare",
    entity.clone().getComponent(MeshRenderer)?.bounds.min ===
      renderer.bounds.min
  );
});

```