### PR TITLE
Fix `VertexData2D.triangles` reference error when change `DrawMode` to `Tiled`

### DIFF
--- a/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
@@ -14,13 +14,11 @@ export class SimpleSpriteAssembler {
 
   static resetData(renderer: SpriteRenderer | SpriteMask): void {
     const { _verticesData: verticesData } = renderer;
-    const vertexCount = (verticesData.vertexCount = 4);
     const { positions, uvs } = verticesData;
-    if (positions.length < vertexCount) {
-      for (let i = positions.length; i < vertexCount; i++) {
-        positions.push(new Vector3());
-        uvs.push(new Vector2());
-      }
+    verticesData.vertexCount = positions.length = uvs.length = 4;
+    for (let i = 0; i < 4; i++) {
+      positions[i] ||= new Vector3();
+      uvs[i] ||= new Vector2();
     }
     verticesData.triangles = SimpleSpriteAssembler._rectangleTriangles;
   }

--- a/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
@@ -2,6 +2,7 @@ import { Matrix, Vector2, Vector3 } from "@galacean/engine-math";
 import { StaticInterfaceImplement } from "../../base/StaticInterfaceImplement";
 import { SpriteRenderer } from "../sprite/SpriteRenderer";
 import { IAssembler } from "./IAssembler";
+import { SimpleSpriteAssembler } from "./SimpleSpriteAssembler";
 
 /**
  * @internal
@@ -12,13 +13,15 @@ export class SlicedSpriteAssembler {
   static resetData(renderer: SpriteRenderer): void {
     const { _verticesData: verticesData } = renderer;
     const { positions, uvs } = verticesData;
-    if (positions.length < 16) {
-      for (let i = positions.length; i < 16; i++) {
-        positions.push(new Vector3());
-        uvs.push(new Vector2());
-      }
+    positions.length = uvs.length = 16;
+    for (let i = 0; i < 16; i++) {
+      positions[i] ||= new Vector3();
+      uvs[i] ||= new Vector2();
     }
-    verticesData.triangles = [];
+    const { triangles } = verticesData;
+    if (triangles === SimpleSpriteAssembler._rectangleTriangles || !triangles) {
+      verticesData.triangles = [];
+    }
   }
 
   static updatePositions(renderer: SpriteRenderer): void {

--- a/packages/core/src/2d/assembler/TiledSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/TiledSpriteAssembler.ts
@@ -21,10 +21,7 @@ export class TiledSpriteAssembler {
   static _uvColumn: DisorderedArray<number> = new DisorderedArray<number>();
 
   static resetData(renderer: SpriteRenderer): void {
-    const { triangles } = renderer._verticesData;
-    if (triangles === SimpleSpriteAssembler._rectangleTriangles || !triangles) {
-      renderer._verticesData.triangles = [];
-    }
+    renderer._verticesData.triangles = [];
   }
 
   static updatePositions(renderer: SpriteRenderer): void {

--- a/packages/core/src/2d/assembler/TiledSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/TiledSpriteAssembler.ts
@@ -7,6 +7,7 @@ import { Sprite } from "../sprite";
 import { SpriteRenderer } from "../sprite/SpriteRenderer";
 import { IAssembler } from "./IAssembler";
 import { Logger } from "../../base";
+import { SimpleSpriteAssembler } from "./SimpleSpriteAssembler";
 
 /**
  * @internal
@@ -20,7 +21,10 @@ export class TiledSpriteAssembler {
   static _uvColumn: DisorderedArray<number> = new DisorderedArray<number>();
 
   static resetData(renderer: SpriteRenderer): void {
-    renderer._verticesData.triangles ||= [];
+    const { triangles } = renderer._verticesData;
+    if (triangles === SimpleSpriteAssembler._rectangleTriangles || !triangles) {
+      renderer._verticesData.triangles = [];
+    }
   }
 
   static updatePositions(renderer: SpriteRenderer): void {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information: