### PR TITLE
Fix Sprite can't batch bug caused by material instance

### DIFF
--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -16,7 +16,6 @@ import { SpriteMaskLayer } from "../enums/SpriteMaskLayer";
 import { SpriteModifyFlags } from "../enums/SpriteModifyFlags";
 import { SpriteTileMode } from "../enums/SpriteTileMode";
 import { Sprite } from "./Sprite";
-import { Material } from "../../material";
 
 /**
  * Renders a Sprite for 2D graphics.

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -38,6 +38,8 @@ import { CullMode } from "./shader/enums/CullMode";
 import { RenderQueueType } from "./shader/enums/RenderQueueType";
 import { RenderState } from "./shader/state/RenderState";
 import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFormat } from "./texture";
+import { CompareFunction } from "./shader";
+import { SpriteMaskInteraction } from "./2d";
 
 ShaderPool.init();
 
@@ -81,6 +83,8 @@ export class Engine extends EventDispatcher {
 
   /* @internal */
   _spriteDefaultMaterial: Material;
+  /** @internal */
+  _spriteDefaultMaterials: Material[] = [];
   /* @internal */
   _spriteMaskDefaultMaterial: Material;
   /* @internal */
@@ -232,7 +236,16 @@ export class Engine extends EventDispatcher {
     this._canvas = canvas;
 
     this._spriteMaskManager = new SpriteMaskManager(this);
-    this._spriteDefaultMaterial = this._createSpriteMaterial();
+    const { _spriteDefaultMaterials: spriteDefaultMaterials } = this;
+    this._spriteDefaultMaterial = spriteDefaultMaterials[SpriteMaskInteraction.None] = this._createSpriteMaterial(
+      SpriteMaskInteraction.None
+    );
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleInsideMask] = this._createSpriteMaterial(
+      SpriteMaskInteraction.VisibleInsideMask
+    );
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleOutsideMask] = this._createSpriteMaterial(
+      SpriteMaskInteraction.VisibleOutsideMask
+    );
     this._spriteMaskDefaultMaterial = this._createSpriteMaskMaterial();
     this._textDefaultFont = Font.createFromOS(this, "Arial");
     this._textDefaultFont.isGCIgnored = true;
@@ -606,7 +619,7 @@ export class Engine extends EventDispatcher {
     return Promise.all(initializePromises).then(() => this);
   }
 
-  private _createSpriteMaterial(): Material {
+  private _createSpriteMaterial(maskInteraction: SpriteMaskInteraction): Material {
     const material = new Material(this, Shader.find("Sprite"));
     const renderState = material.renderState;
     const target = renderState.blendState.targetBlendState;
@@ -616,9 +629,21 @@ export class Engine extends EventDispatcher {
     target.sourceAlphaBlendFactor = BlendFactor.One;
     target.destinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
     target.colorBlendOperation = target.alphaBlendOperation = BlendOperation.Add;
+    if (maskInteraction !== SpriteMaskInteraction.None) {
+      const stencilState = renderState.stencilState;
+      stencilState.enabled = true;
+      stencilState.writeMask = 0x00;
+      stencilState.referenceValue = 1;
+      const compare =
+        maskInteraction === SpriteMaskInteraction.VisibleInsideMask
+          ? CompareFunction.LessEqual
+          : CompareFunction.Greater;
+      stencilState.compareFunctionFront = compare;
+      stencilState.compareFunctionBack = compare;
+    }
     renderState.depthState.writeEnabled = false;
     renderState.rasterState.cullMode = CullMode.Off;
-    material.renderState.renderQueueType = RenderQueueType.Transparent;
+    renderState.renderQueueType = RenderQueueType.Transparent;
     material.isGCIgnored = true;
     return material;
   }

--- a/tests/src/core/SpriteRenderer.test.ts
+++ b/tests/src/core/SpriteRenderer.test.ts
@@ -1304,12 +1304,48 @@ describe("SpriteRenderer", async () => {
   it("get set maskInteraction", () => {
     const rootEntity = scene.getRootEntity();
     const spriteRenderer = rootEntity.addComponent(SpriteRenderer);
+    const noneMaterial = spriteRenderer.getMaterial();
+
     spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
     expect(spriteRenderer.maskInteraction).to.eq(SpriteMaskInteraction.VisibleInsideMask);
+    const insideMaterial = spriteRenderer.getMaterial();
+
     spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleOutsideMask;
     expect(spriteRenderer.maskInteraction).to.eq(SpriteMaskInteraction.VisibleOutsideMask);
+    const outsideMaterial = spriteRenderer.getMaterial();
+
     spriteRenderer.maskInteraction = SpriteMaskInteraction.None;
     expect(spriteRenderer.maskInteraction).to.eq(SpriteMaskInteraction.None);
+    expect(spriteRenderer.getMaterial()).to.eq(noneMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
+    expect(spriteRenderer.getMaterial()).to.eq(insideMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleOutsideMask;
+    expect(spriteRenderer.getMaterial()).to.eq(outsideMaterial);
+
+    spriteRenderer.setMaterial(noneMaterial.clone());
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.None;
+    expect(spriteRenderer.getMaterial()).to.not.eq(noneMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
+    expect(spriteRenderer.getMaterial()).to.not.eq(insideMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleOutsideMask;
+    expect(spriteRenderer.getMaterial()).to.not.eq(outsideMaterial);
+
+    spriteRenderer.setMaterial(noneMaterial);
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.None;
+    expect(spriteRenderer.getMaterial()).to.eq(noneMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
+    expect(spriteRenderer.getMaterial()).to.eq(insideMaterial);
+
+    spriteRenderer.maskInteraction = SpriteMaskInteraction.VisibleOutsideMask;
+    expect(spriteRenderer.getMaterial()).to.eq(outsideMaterial);
+
+    const cloneRenderer = rootEntity.clone().getComponent(SpriteRenderer);
+    expect(cloneRenderer.getMaterial()).to.eq(outsideMaterial);
   });
 
   it("DirtyFlag", () => {


### PR DESCRIPTION
It will invalidate the batch.
```typescript
import {
  SpriteMaskInteraction,
  SpriteRenderer,
  WebGLEngine,
} from "@galacean/engine";

// Create engine object.
WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
  const entity = engine.sceneManager.activeScene
    .createRootEntity()
    .createChild("sprite");
  const renderer = entity.addComponent(SpriteRenderer);
  const beforeMat = renderer.getMaterial();
  renderer.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
  renderer.maskInteraction = SpriteMaskInteraction.None;
  const afterMat = renderer.getMaterial();
  console.log("material", beforeMat === afterMat);
});

```