### PR TITLE
Fix quaternion to euler bug

### DIFF
--- a/packages/math/src/Quaternion.ts
+++ b/packages/math/src/Quaternion.ts
@@ -780,11 +780,11 @@ export class Quaternion implements IClone<Quaternion>, ICopy<QuaternionLike, Qua
     const unit = xx + yy + zz + ww;
     const test = 2 * (x * w - y * z);
     if (test > (1 - MathUtil.zeroTolerance) * unit) {
-      out._x = Math.atan2(2.0 * (w * y - x * z), zz + ww - yy - zz);
+      out._x = Math.atan2(2.0 * (w * y - x * z), xx + ww - yy - zz);
       out._y = Math.PI / 2;
       out._z = 0;
     } else if (test < -(1 - MathUtil.zeroTolerance) * unit) {
-      out._x = Math.atan2(2.0 * (w * y - x * z), zz + ww - yy - zz);
+      out._x = Math.atan2(2.0 * (w * y - x * z), xx + ww - yy - zz);
       out._y = -Math.PI / 2;
       out._z = 0;
     } else {

--- a/tests/src/math/Quaternion.test.ts
+++ b/tests/src/math/Quaternion.test.ts
@@ -1,4 +1,4 @@
-import { MathUtil, Quaternion, Vector3, Matrix3x3 } from "@galacean/engine-math";
+import { MathUtil, Quaternion, Vector3, Matrix3x3, Matrix } from "@galacean/engine-math";
 import { expect } from "chai";
 
 function toString(q: Quaternion): string {
@@ -210,6 +210,28 @@ describe("Quaternion test", () => {
     expect(MathUtil.radianToDegree(euler.x)).to.eq(90);
     expect(MathUtil.radianToDegree(euler.y)).to.eq(-90);
     expect(MathUtil.radianToDegree(euler.z)).to.eq(0);
+
+    const matrixBef = new Matrix();
+    const matrixAft = new Matrix();
+    const scale = new Vector3(1, 1, 1);
+    const transform = new Vector3(0, 0, 0);
+    for (let x = 0; x <= 180; x += 10) {
+      for (let y = 0; y <= 180; y += 10) {
+        for (let z = 0; z <= 180; z += 10) {
+          Quaternion.rotationEuler(
+            MathUtil.degreeToRadian(x),
+            MathUtil.degreeToRadian(y),
+            MathUtil.degreeToRadian(z),
+            a
+          );
+          Matrix.affineTransformation(scale, a, transform, matrixBef);
+          a.toEuler(euler);
+          Quaternion.rotationEuler(euler.x, euler.y, euler.z, a);
+          Matrix.affineTransformation(scale, a, transform, matrixAft);
+          expect(Matrix.equals(matrixBef, matrixAft)).to.eq(true);
+        }
+      }
+    }
   });
 
   it("setValue", () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

The derivation process：

1.  Use YXZ Order and expand matrix elements：https://github.com/mrdoob/three.js/blob/ce756225c802ff24cc27a1f615cc9bf420023ae8/src/math/Euler.js#L134
2.  Convert normalized version to non-normalized version ：http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/

