### PR TITLE
Replace `throw` with `console.error` to prevent blocking the main thread

### DIFF
--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -91,7 +91,7 @@ export class Shader implements IReferable {
 
       const shaderInfo = Shader._shaderLab.parseShader(nameOrShaderSource);
       if (shaderMap[shaderInfo.name]) {
-        console.error(`Shader named "${shaderInfo.name}" already exists.`)
+        console.error(`Shader named "${shaderInfo.name}" already exists.`);
         return;
       }
       const subShaderList = shaderInfo.subShaders.map((subShaderInfo) => {

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -91,7 +91,8 @@ export class Shader implements IReferable {
 
       const shaderInfo = Shader._shaderLab.parseShader(nameOrShaderSource);
       if (shaderMap[shaderInfo.name]) {
-        throw `Shader named "${shaderInfo.name}" already exists.`;
+        console.error(`Shader named "${shaderInfo.name}" already exists.`)
+        return;
       }
       const subShaderList = shaderInfo.subShaders.map((subShaderInfo) => {
         const passList = subShaderInfo.passes.map((passInfo) => {
@@ -136,7 +137,8 @@ export class Shader implements IReferable {
       return shader;
     } else {
       if (shaderMap[nameOrShaderSource]) {
-        throw `Shader named "${nameOrShaderSource}" already exists.`;
+        console.error(`Shader named "${nameOrShaderSource}" already exists.`);
+        return;
       }
       if (typeof vertexSourceOrShaderPassesOrSubShaders === "string") {
         const shaderPass = new ShaderPass(vertexSourceOrShaderPassesOrSubShaders, fragmentSource);

--- a/tests/src/core/Shader.test.ts
+++ b/tests/src/core/Shader.test.ts
@@ -31,7 +31,8 @@ describe("Shader", () => {
       // Create same name shader
       const errorSpy = chai.spy.on(console, "error");
       Shader.create("custom", [new SubShader("Default", [new ShaderPass(customVS, customFS)])]);
-      expect(errorSpy).to.have.been.called.with("Shader named 'custom' already exists.");
+      expect(errorSpy).to.have.been.called.with('Shader named "custom" already exists.');
+      chai.spy.restore(console, "error");
 
       // Create shader by empty SubShader array
       expect(() => {

--- a/tests/src/core/Shader.test.ts
+++ b/tests/src/core/Shader.test.ts
@@ -29,9 +29,9 @@ describe("Shader", () => {
       customShader = Shader.create("custom", [new SubShader("Default", [new ShaderPass(customVS, customFS)])]);
 
       // Create same name shader
-      expect(() => {
-        Shader.create("custom", [new SubShader("Default", [new ShaderPass(customVS, customFS)])]);
-      }).throw();
+      const errorSpy = chai.spy.on(console, "error");
+      Shader.create("custom", [new SubShader("Default", [new ShaderPass(customVS, customFS)])]);
+      expect(errorSpy).to.have.been.called.with("Shader named 'custom' already exists.");
 
       // Create shader by empty SubShader array
       expect(() => {

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -227,8 +227,9 @@ describe("ShaderLab", () => {
 
     const errorSpy = chai.spy.on(console, "error");
     Shader.create(demoShader);
-    expect(errorSpy).to.have.been.called.with("Shader named 'Glass' already exists.");
+    expect(errorSpy).to.have.been.called.with('Shader named "Gem" already exists.');
     shaderInstance.destroy();
+    chai.spy.restore(console, "error");
 
     const sameNameShader = Shader.create(demoShader);
     expect(sameNameShader).instanceOf(Shader);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -224,8 +224,12 @@ describe("ShaderLab", () => {
 
     const shaderInstance = Shader.create(demoShader);
     expect(shaderInstance).instanceOf(Shader);
-    expect(Shader.create.bind(null, demoShader)).to.throw('Shader named "Gem" already exists.');
+
+    const errorSpy = chai.spy.on(console, "error");
+    Shader.create(demoShader);
+    expect(errorSpy).to.have.been.called.with("Shader named 'Glass' already exists.");
     shaderInstance.destroy();
+
     const sameNameShader = Shader.create(demoShader);
     expect(sameNameShader).instanceOf(Shader);
   });


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This prevent tweaks the shader registration process to provide a better DX for developer.

### What is the current behavior? (You can also link to an open issue here)

Currently, if Galacean detects a shader registered with the same name, it will throw an uncaught error, which will block the main thread.

### What is the new behavior (if this is a feature change)?

We just console an error inside of throwing it to prevent blocking the user's main thread.
