### PR TITLE
Add animatorController to GLTF subAsset

### DIFF
--- a/packages/loader/src/gltf/GLTFResource.ts
+++ b/packages/loader/src/gltf/GLTFResource.ts
@@ -1,5 +1,6 @@
 import {
   AnimationClip,
+  AnimatorController,
   Camera,
   Engine,
   Entity,
@@ -27,6 +28,8 @@ export class GLTFResource extends ReferResource {
   readonly skins?: Skin[];
   /** AnimationClip after AnimationParser. */
   readonly animations?: AnimationClip[];
+  /** AnimatorController after AnimatorControllerParser. */
+  readonly animatorController?: AnimatorController;
 
   /** @internal */
   _defaultSceneRoot: Entity;

--- a/packages/loader/src/gltf/parser/GLTFAnimatorControllerParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFAnimatorControllerParser.ts
@@ -1,0 +1,44 @@
+import {
+  AnimationClip,
+  AnimatorController,
+  AnimatorControllerLayer,
+  AnimatorStateMachine
+} from "@galacean/engine-core";
+import { GLTFParser } from "./GLTFParser";
+import { GLTFParserContext, GLTFParserType, registerGLTFParser } from "./GLTFParserContext";
+
+@registerGLTFParser(GLTFParserType.AnimatorController)
+export class GLTFAnimatorControllerParser extends GLTFParser {
+  parse(context: GLTFParserContext): Promise<AnimatorController> {
+    return context.get<AnimationClip>(GLTFParserType.Animation).then((animations) => {
+      if (context.needAnimatorController) {
+        const animatorController = this._createAnimatorController(animations);
+        return Promise.resolve(animatorController);
+      } else {
+        return Promise.resolve(null);
+      }
+    });
+  }
+
+  private _createAnimatorController(animations: AnimationClip[]): AnimatorController {
+    const animatorController = new AnimatorController();
+    const layer = new AnimatorControllerLayer("layer");
+    const animatorStateMachine = new AnimatorStateMachine();
+    animatorController.addLayer(layer);
+    layer.stateMachine = animatorStateMachine;
+    if (animations) {
+      for (let i = 0; i < animations.length; i++) {
+        const animationClip = animations[i];
+        const name = animationClip.name;
+        const uniqueName = animatorStateMachine.makeUniqueStateName(name);
+        if (uniqueName !== name) {
+          console.warn(`AnimatorState name is existed, name: ${name} reset to ${uniqueName}`);
+        }
+        const animatorState = animatorStateMachine.addState(uniqueName);
+        animatorState.clip = animationClip;
+      }
+    }
+
+    return animatorController;
+  }
+}

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -113,19 +113,19 @@ export class GLTFParserContext {
         this.get<ModelMesh[]>(GLTFParserType.Mesh),
         this.get<Skin>(GLTFParserType.Skin),
         this.get<AnimationClip>(GLTFParserType.Animation),
+        this.get<AnimatorController>(GLTFParserType.AnimatorController),
         this.get<Entity>(GLTFParserType.Scene)
       ]).then(() => {
-        return this.get<AnimatorController>(GLTFParserType.AnimatorController).then((animatorController) => {
-          const glTFResource = this.glTFResource;
+        const glTFResource = this.glTFResource;
+        const animatorController = glTFResource.animatorController;
 
-          if (animatorController) {
-            const animator = glTFResource._defaultSceneRoot.addComponent(Animator);
-            animator.animatorController = animatorController;
-          }
+        if (animatorController) {
+          const animator = glTFResource._defaultSceneRoot.addComponent(Animator);
+          animator.animatorController = animatorController;
+        }
 
-          this.resourceManager.addContentRestorer(this.contentRestorer);
-          return glTFResource;
-        });
+        this.resourceManager.addContentRestorer(this.contentRestorer);
+        return glTFResource;
       });
     });
 

--- a/packages/loader/src/gltf/parser/index.ts
+++ b/packages/loader/src/gltf/parser/index.ts
@@ -11,3 +11,4 @@ export { GLTFTextureParser } from "./GLTFTextureParser";
 export { GLTFValidator } from "./GLTFValidator";
 export { GLTFParserContext, GLTFParserType, registerGLTFParser, BufferInfo } from "./GLTFParserContext";
 export { GLTFBufferViewParser } from "./GLTFBufferViewParser";
+export { GLTFAnimatorControllerParser } from "./GLTFAnimatorControllerParser";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
"Resolve the error in referencing the AnimatorController in the GLTF model within the editor by making the AnimatorController a subAsset of the GLTF


add GLTFAnimatorControllerParser
support get any asset from GLTFParser
remove special process for Validator、Schema