### PR TITLE
types: optimize ResourceManager overload for type checking

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
+registry=https://registry.npmmirror.com/
 chromedriver_cdnurl=https://npmmirror.com/mirrors/chromedriver/
 electron_mirror=https://npmmirror.com/mirrors/electron/
+operadriver_cdnurl=https://npmmirror.com/mirrors/operadriver/
+sass_binary_site=https://npmmirror.com/mirrors/node-sass/
+canvas_binary_host_mirror=https://npmmirror.com/mirrors/canvas/
+
 auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chai": "^4.3.6",
     "chai-spies": "^1.0.0",
     "cross-env": "^5.2.0",
-    "electron": "^13",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -59,32 +59,32 @@ export class ResourceManager {
   constructor(public readonly engine: Engine) {}
 
   /**
-   * Load asset asynchronously through the path.
-   * @param path - Path
-   * @returns Asset promise
-   */
-  load<T>(path: string): AssetPromise<T>;
-
-  /**
-   * Load asset collection asynchronously through urls.
-   * @param paths - Path collections
-   * @returns Asset Promise
-   */
-  load(paths: string[]): AssetPromise<Object[]>;
-
-  /**
    * Load the asset asynchronously by asset item information.
    * @param assetItem - AssetItem
    * @returns AssetPromise
    */
-  load<T>(assetItem: LoadItem): AssetPromise<T>;
+  load<T extends EngineObject>(assetItem: LoadItem): AssetPromise<T>;
 
   /**
    * Load the asset collection asynchronously by loading the information collection.
    * @param assetItems - Asset collection
    * @returns AssetPromise
    */
-  load(assetItems: LoadItem[]): AssetPromise<Object[]>;
+  load<T extends EngineObject[]>(assetItems: LoadItem[]): AssetPromise<T>;
+
+  /**
+   * Load asset collection asynchronously through urls.
+   * @param paths - Path collections
+   * @returns Asset Promise
+   */
+  load<T extends EngineObject[]>(paths: string[]): AssetPromise<T>;
+
+  /**
+   * Load asset asynchronously through the path.
+   * @param path - Path
+   * @returns Asset promise
+   */
+  load<T extends EngineObject>(path: string): AssetPromise<T>;
 
   load<T>(assetInfo: string | LoadItem | (LoadItem | string)[]): AssetPromise<T | Object[]> {
     // single item

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       cypress-recurse:
         specifier: ^1.23.0
         version: 1.23.0
-      electron:
-        specifier: ^13
-        version: 13.6.9
       eslint:
         specifier: ^8.44.0
         version: 8.46.0


### PR DESCRIPTION
**### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

type update

### What is the current behavior? (You can also link to an open issue here)

Currently `engine.resourceManager.load` and the overloads could missing type checking due to the order of overloads. Like:

```ts
  // Failed. Indicated that the parameter should be type of `path: string`
  const result = await engine.resourceManager.load<[TextureCube]>([{ type: AssetType.TextureCube, url: '' }]) 
  const result2 = await engine.resourceManager.load<TextureCube[]>(['']) // Failed as before.
  const result3 = await engine.resourceManager.load<TextureCube>('') // Success
  const result4 = await engine.resourceManager.load<TextureCube>({}) // Failed as before
```


### What is the new behavior (if this is a feature change)?

```ts
const result = await engine.resourceManager.load<[TextureCube]>([{
  type: AssetType.AnimationClip,
  url: ''
}]) // type check successful

const result2 = await engine.resourceManager.load<TextureCube[]>(['']) // type check successful

const result3 = await engine.resourceManager.load<TextureCube>('') // type check successful

const result4 = await engine.resourceManager.load<TextureCube>({}) // type check failed as expected. Argument of type '{}' is not assignable to parameter of type 'LoadItem'.
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.