### PR TITLE
Fixed the problem that function macro declaration is lost after compilation

### DIFF
--- a/packages/shader-lab/src/RuntimeContext.ts
+++ b/packages/shader-lab/src/RuntimeContext.ts
@@ -138,11 +138,12 @@ export default class RuntimeContext {
 
   addDiagnostic(diagnostic: IDiagnostic) {
     let offset = this._parsingContext.getTextLineOffsetAt(diagnostic.token.start.index);
+    let token: IPositionRange = { start: { ...diagnostic.token.start }, end: { ...diagnostic.token.end } };
     if (offset) {
-      diagnostic.token.start.line += offset;
-      diagnostic.token.end.line += offset;
+      token.start.line += offset;
+      token.end.line += offset;
     }
-    this._diagnostics.push(diagnostic);
+    this._diagnostics.push({ ...diagnostic, token });
   }
 
   setSerializingNode(node: AstNode) {
@@ -313,9 +314,8 @@ export default class RuntimeContext {
   // If be aware of the complete input macro list when parsing, the snippets below is not required.
   getExtendedDefineMacros() {
     return Array.from(this._preprocessor._definePairs.entries())
-      .map(([k, v]) => {
-        let ret = `#define ${k} ${v.originText}`;
-        return ret;
+      .map(([_, v]) => {
+        return v.originText;
       })
       .join("\n");
   }

--- a/packages/shader-lab/src/RuntimeContext.ts
+++ b/packages/shader-lab/src/RuntimeContext.ts
@@ -314,10 +314,7 @@ export default class RuntimeContext {
   getExtendedDefineMacros() {
     return Array.from(this._preprocessor._definePairs.entries())
       .map(([k, v]) => {
-        let ret = `#define ${k}`;
-        if (!v.isFunction) {
-          ret += ` ${v.replacer}`;
-        }
+        let ret = `#define ${k} ${v.originText}`;
         return ret;
       })
       .join("\n");

--- a/packages/shader-lab/src/preprocessor/Preprocessor.ts
+++ b/packages/shader-lab/src/preprocessor/Preprocessor.ts
@@ -16,8 +16,8 @@ export class Preprocessor {
   private _curMacroLvl = 0;
 
   /** @internal */
-  _definePairs: Map<string, { isFunction: boolean; replacer: TextReplacer }> = new Map();
-  private set definePairs(pairs: Map<string, { isFunction: boolean; replacer: TextReplacer }>) {
+  _definePairs: Map<string, { isFunction: boolean; replacer: TextReplacer; originText: string }> = new Map();
+  private set definePairs(pairs: Map<string, { isFunction: boolean; replacer: TextReplacer; originText: string }>) {
     this._definePairs = pairs;
   }
   private _replacers: IReplaceSegment[] = [];
@@ -156,9 +156,9 @@ export class Preprocessor {
           const idx = macroArgs.findIndex((item) => item === m);
           return args[idx];
         });
-      this._definePairs.set(variable.res.text, { isFunction: true, replacer });
+      this._definePairs.set(variable.res.text, { isFunction: true, replacer, originText: chunk });
     } else {
-      this._definePairs.set(variable.res.text, { isFunction: false, replacer: chunk });
+      this._definePairs.set(variable.res.text, { isFunction: false, replacer: chunk, originText: chunk });
     }
 
     this._replacers.push({ startIdx: macroToken.start.index, endIdx: tokenizer.curIndex, replace: "" });

--- a/packages/shader-lab/src/preprocessor/Preprocessor.ts
+++ b/packages/shader-lab/src/preprocessor/Preprocessor.ts
@@ -156,9 +156,17 @@ export class Preprocessor {
           const idx = macroArgs.findIndex((item) => item === m);
           return args[idx];
         });
-      this._definePairs.set(variable.res.text, { isFunction: true, replacer, originText: chunk });
+      this._definePairs.set(variable.res.text, {
+        isFunction: true,
+        replacer,
+        originText: `#define ${variable.res.text}(${macroArgs.join(",")}) ${chunk}`
+      });
     } else {
-      this._definePairs.set(variable.res.text, { isFunction: false, replacer: chunk, originText: chunk });
+      this._definePairs.set(variable.res.text, {
+        isFunction: false,
+        replacer: chunk,
+        originText: `#define ${variable.res.text} ${chunk}`
+      });
     }
 
     this._replacers.push({ startIdx: macroToken.start.index, endIdx: tokenizer.curIndex, replace: "" });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -133,6 +133,10 @@ describe("ShaderLab", () => {
     expect(usePass).to.equal("pbr/Default/Forward");
   });
 
+  it("marco completeness", () => {
+    expect(pass.vertexSource.includes("#define saturate clamp( a, 0.0, 1.0 )")).to.true;
+  });
+
   it("render state", () => {
     expect(pass.renderStates).not.be.null;
 

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -134,7 +134,7 @@ describe("ShaderLab", () => {
   });
 
   it("marco completeness", () => {
-    expect(pass.vertexSource.includes("#define saturate clamp( a, 0.0, 1.0 )")).to.true;
+    expect(pass.vertexSource.includes("#define saturate(a) clamp( a, 0.0, 1.0 )")).to.true;
   });
 
   it("render state", () => {

--- a/tests/src/shader-lab/shaders/demo.shader
+++ b/tests/src/shader-lab/shaders/demo.shader
@@ -36,6 +36,8 @@ Shader "Water" {
     UsePass "pbr/Default/Forward"
 
     Pass "default" {
+      #define saturate( a ) clamp( a, 0.0, 1.0 )
+
       Tags { ReplacementTag = "Opaque", Tag2 = true, Tag3 = 1.9 }
 
       struct a2v {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Keep the complete function macro declaration.

Fix the bug:
```
// shaderlab
#define saturate(a) clamp( a, 0.0, 1.0 )

// after compilation
#define saturate
```

fix #2086 & #2091
