### PR TITLE
Add `Script` in `onStart` may cause some functions to not be executed correctly.

### DIFF
--- a/packages/core/src/ComponentsManager.ts
+++ b/packages/core/src/ComponentsManager.ts
@@ -143,11 +143,16 @@ export class ComponentsManager {
     const onStartScripts = this._onStartScripts;
     if (onStartScripts.length > 0) {
       // The 'onStartScripts.length' maybe add if you add some Script with addComponent() in some Script's onStart()
-      onStartScripts.forEachAndClean((script: Script) => {
-        script._started = true;
-        this.removeOnStartScript(script);
-        script.onStart();
-      });
+      onStartScripts.forEachAndClean(
+        (script: Script) => {
+          script._started = true;
+          this.removeOnStartScript(script);
+          script.onStart();
+        },
+        (element: Script, index: number) => {
+          element._onStartIndex = index;
+        }
+      );
     }
   }
 

--- a/packages/core/src/DisorderedArray.ts
+++ b/packages/core/src/DisorderedArray.ts
@@ -78,14 +78,25 @@ export class DisorderedArray<T> {
     this._endLoop(swapFn);
   }
 
-  forEachAndClean(callbackFn: (e: T) => void): void {
+  forEachAndClean(callbackFn: (e: T) => void, swapFn: (element: T, index: number) => void): void {
     this._startLoop();
+    const preEnd = this.length;
     const elements = this._elements;
-    for (let i = 0, n = this.length; i < n; i++) {
+    for (let i = 0, n = preEnd; i < n; i++) {
       const element = elements[i];
       element && callbackFn(element);
     }
-    this._endLoopAndClear();
+    let index = 0;
+    for (let i = preEnd, n = this.length; i < n; i++) {
+      const element = elements[i];
+      if (!element) continue;
+      elements[index] = element;
+      swapFn(element, index);
+      index++;
+    }
+    this._isLooping = false;
+    this.length = index;
+    this._blankCount = 0;
   }
 
   sort(compareFn: (a: T, b: T) => number): void {
@@ -126,11 +137,5 @@ export class DisorderedArray<T> {
       this.length -= this._blankCount;
       this._blankCount = 0;
     }
-  }
-
-  private _endLoopAndClear(): void {
-    this._isLooping = false;
-    this.length = 0;
-    this._blankCount = 0;
   }
 }

--- a/packages/core/src/DisorderedArray.ts
+++ b/packages/core/src/DisorderedArray.ts
@@ -86,17 +86,7 @@ export class DisorderedArray<T> {
       const element = elements[i];
       element && callbackFn(element);
     }
-    let index = 0;
-    for (let i = preEnd, n = this.length; i < n; i++) {
-      const element = elements[i];
-      if (!element) continue;
-      elements[index] = element;
-      swapFn(element, index);
-      index++;
-    }
-    this._isLooping = false;
-    this.length = index;
-    this._blankCount = 0;
+    this._endLoopAndClean(preEnd, elements, swapFn);
   }
 
   sort(compareFn: (a: T, b: T) => number): void {
@@ -137,5 +127,19 @@ export class DisorderedArray<T> {
       this.length -= this._blankCount;
       this._blankCount = 0;
     }
+  }
+
+  private _endLoopAndClean(preEnd: number, elements: T[], swapFn: (element: T, index: number) => void): void {
+    let index = 0;
+    for (let i = preEnd, n = this.length; i < n; i++) {
+      const element = elements[i];
+      if (!element) continue;
+      elements[index] = element;
+      swapFn(element, index);
+      index++;
+    }
+    this._isLooping = false;
+    this.length = index;
+    this._blankCount = 0;
   }
 }

--- a/tests/src/core/Script.test.ts
+++ b/tests/src/core/Script.test.ts
@@ -196,6 +196,32 @@ describe("Script", () => {
       expect(script3.onUpdate).to.have.been.called.exactly(3);
     });
 
+    it("Script add in script's onStart", async () => {
+      const engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+      const scene = engine.sceneManager.activeScene;
+      class Script1 extends Script {
+        onStart(): void {
+          entity1.addComponent(Script2);
+        }
+      }
+      class Script2 extends Script {
+        onStart(): void {}
+      }
+
+      Script1.prototype.onStart = chai.spy(Script1.prototype.onStart);
+      Script2.prototype.onStart = chai.spy(Script2.prototype.onStart);
+
+      const entity1 = scene.createRootEntity("1");
+      const script1 = entity1.addComponent(Script1);
+      engine.update();
+      expect(script1.onStart).to.have.been.called.exactly(1);
+      const script2 = entity1.getComponent(Script2);
+      expect(script2.onStart).to.have.been.called.exactly(0);
+      engine.update();
+      expect(script1.onStart).to.have.been.called.exactly(1);
+      expect(script2.onStart).to.have.been.called.exactly(1);
+    });
+
     it("Engine destroy outside the main loop", async () => {
       class TestScript extends Script {
         onAwake() {


### PR DESCRIPTION
link:https://github.com/galacean/engine/pull/2102
Case:
```
class Script1 extends Script {
      const engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
      const scene = engine.sceneManager.activeScene;
        onStart(): void {
          entity1.addComponent(Script2);
        }
      }
      class Script2 extends Script {
        onStart(): void {
            console.log('called');
        }
      }

      const entity = scene.createRootEntity("1");
      entity.addComponent(Script1);
      engine.run();
```