### PR TITLE
Fix array index loss after compilation

### DIFF
--- a/packages/shader-lab/src/ast-node/AstNode.ts
+++ b/packages/shader-lab/src/ast-node/AstNode.ts
@@ -628,10 +628,9 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
     const objName = this.content.variable;
     const propName = this.content.properties?.[0].content;
 
-    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])]
-      .sort((a, b) => AstNodeUtils.astSortAsc(a.position, b.position))
-      .map((item) => item.serialize(context))
-      .join("");
+    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])].sort((a, b) =>
+      AstNodeUtils.astSortAsc(a.position, b.position)
+    );
 
     if (propName) {
       if (objName === context.varyingStructInfo.objectName) {
@@ -639,7 +638,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
           (ref) => ref.property.content.variableNode.content.variable === propName
         );
         ref && (ref.referenced = true);
-        return propList;
+        return propList.map((item) => item.content).join(".");
       } else {
         const attribStruct = context.attributeStructListInfo.find((struct) => struct.objectName === objName);
         if (attribStruct) {
@@ -647,7 +646,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
             (ref) => ref.property.content.variableNode.content.variable === propName
           );
           ref && (ref.referenced = true);
-          return propList;
+          return propList.map((item) => item.content).join(".");
         }
       }
     }
@@ -661,7 +660,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
       }
     }
 
-    return objName + propList;
+    return objName + propList.map((item) => item.serialize(context)).join("");
   }
 }
 

--- a/packages/shader-lab/src/ast-node/AstNode.ts
+++ b/packages/shader-lab/src/ast-node/AstNode.ts
@@ -628,9 +628,10 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
     const objName = this.content.variable;
     const propName = this.content.properties?.[0].content;
 
-    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])].sort((a, b) =>
-      AstNodeUtils.astSortAsc(a.position, b.position)
-    );
+    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])]
+      .sort((a, b) => AstNodeUtils.astSortAsc(a.position, b.position))
+      .map((item) => item.serialize(context))
+      .join("");
 
     if (propName) {
       if (objName === context.varyingStructInfo.objectName) {
@@ -638,7 +639,8 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
           (ref) => ref.property.content.variableNode.content.variable === propName
         );
         ref && (ref.referenced = true);
-        return propList.map((item) => item.content).join(".");
+        if (propList.startsWith(".")) return propList.slice(1);
+        return propList;
       } else {
         const attribStruct = context.attributeStructListInfo.find((struct) => struct.objectName === objName);
         if (attribStruct) {
@@ -646,7 +648,8 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
             (ref) => ref.property.content.variableNode.content.variable === propName
           );
           ref && (ref.referenced = true);
-          return propList.map((item) => item.content).join(".");
+          if (propList.startsWith(".")) return propList.slice(1);
+          return propList;
         }
       }
     }
@@ -660,7 +663,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
       }
     }
 
-    return objName + propList.map((item) => item.serialize(context)).join("");
+    return objName + propList;
   }
 }
 

--- a/packages/shader-lab/src/ast-node/AstNode.ts
+++ b/packages/shader-lab/src/ast-node/AstNode.ts
@@ -627,13 +627,19 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
   override _doSerialization(context: RuntimeContext): string {
     const objName = this.content.variable;
     const propName = this.content.properties?.[0].content;
+
+    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])]
+      .sort((a, b) => AstNodeUtils.astSortAsc(a.position, b.position))
+      .map((item) => item.serialize(context))
+      .join("");
+
     if (propName) {
       if (objName === context.varyingStructInfo.objectName) {
         const ref = context.varyingStructInfo.reference?.find(
           (ref) => ref.property.content.variableNode.content.variable === propName
         );
         ref && (ref.referenced = true);
-        return this.content.properties.map((item) => item.content).join(".");
+        return propList;
       } else {
         const attribStruct = context.attributeStructListInfo.find((struct) => struct.objectName === objName);
         if (attribStruct) {
@@ -641,7 +647,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
             (ref) => ref.property.content.variableNode.content.variable === propName
           );
           ref && (ref.referenced = true);
-          return this.content.properties.map((item) => item.content).join(".");
+          return propList;
         }
       }
     }
@@ -654,10 +660,7 @@ export class FnVariableAstNode extends AstNode<IFnVariableAstContent> {
         });
       }
     }
-    const propList = [...(this.content.properties ?? []), ...(this.content.indexes ?? [])]
-      .sort((a, b) => AstNodeUtils.astSortAsc(a.position, b.position))
-      .map((item) => item.serialize(context))
-      .join("");
+
     return objName + propList;
   }
 }

--- a/tests/src/shader-lab/shaders/demo.shader
+++ b/tests/src/shader-lab/shaders/demo.shader
@@ -43,6 +43,7 @@ Shader "Water" {
       struct a2v {
        vec4 POSITION;
        vec2 TEXCOORD_0; 
+       mat3 TBN;
       }
 
       struct v2f {
@@ -88,6 +89,7 @@ Shader "Water" {
         vec4 tmp = renderer_MVMat * POSITION;
         o.v_position = tmp.xyz;
         gl_Position = renderer_MVPMat * v.POSITION;
+        vec3 tangentW = v.TBN[0];
         return o;
       }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix the array index loss in ShaderLab compilation:
```glsl
// source
vec3 tangentW = v.TBN[0];
```
compiled
```
// before
vec3 tangentW = TBN;

// Fixed
vec3 tangentW = TBN[0];
```
