### PR TITLE
Export `ClearableObjectPool` and `ReturnableObjectPool` from utils

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export { Downsampling } from "./enums/Downsampling";
 export { ColorSpace } from "./enums/ColorSpace";
 export { BackgroundTextureFillMode } from "./enums/BackgroundTextureFillMode";
 export { XRManager } from "./xr/XRManager";
+export * from "./utils/index";
 export * from "./input/index";
 export * from "./lighting/index";
 export * from "./shadow/index";

--- a/packages/core/src/utils/ClearableObjectPool.ts
+++ b/packages/core/src/utils/ClearableObjectPool.ts
@@ -11,6 +11,9 @@ export class ClearableObjectPool<T extends IPoolElement> extends ObjectPool<T> {
     this._elements = [];
   }
 
+  /**
+   * Get an object.
+   */
   get(): T {
     const { _usedElementCount: usedElementCount, _elements: elements } = this;
     this._usedElementCount++;
@@ -23,6 +26,9 @@ export class ClearableObjectPool<T extends IPoolElement> extends ObjectPool<T> {
     }
   }
 
+  /**
+   * Clear used object count to 0, not destroy any object, just change index.
+   */
   clear(): void {
     this._usedElementCount = 0;
   }

--- a/packages/core/src/utils/ObjectPool.ts
+++ b/packages/core/src/utils/ObjectPool.ts
@@ -17,6 +17,12 @@ export abstract class ObjectPool<T extends IPoolElement> {
   abstract get(): T;
 }
 
+/**
+ * The basic interface for Object Pool's element.
+ */
 export interface IPoolElement {
+  /**
+   * Called when the object need be release.
+   */
   dispose?(): void;
 }

--- a/packages/core/src/utils/ReturnableObjectPool.ts
+++ b/packages/core/src/utils/ReturnableObjectPool.ts
@@ -15,6 +15,9 @@ export class ReturnableObjectPool<T extends IPoolElement> extends ObjectPool<T> 
     }
   }
 
+  /**
+   * Get an object from the pool.
+   */
   get(): T {
     if (this._lastElementIndex < 0) {
       return new this._type();
@@ -22,6 +25,9 @@ export class ReturnableObjectPool<T extends IPoolElement> extends ObjectPool<T> 
     return this._elements[this._lastElementIndex--];
   }
 
+  /**
+   * Return an object to the pool.
+   */
   return(element: T): void {
     this._elements[++this._lastElementIndex] = element;
   }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,5 @@
+export { ClearableObjectPool } from "./ClearableObjectPool";
+export { IPoolElement, ObjectPool } from "./ObjectPool";
+export { ReturnableObjectPool } from "./ReturnableObjectPool";
+export { SafeLoopArray } from "./SafeLoopArray";
+

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,4 +3,3 @@ export { ObjectPool } from "./ObjectPool";
 export type { IPoolElement } from "./ObjectPool";
 export { ReturnableObjectPool } from "./ReturnableObjectPool";
 export { SafeLoopArray } from "./SafeLoopArray";
-

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,3 @@
 export { ClearableObjectPool } from "./ClearableObjectPool";
-export { ObjectPool } from "./ObjectPool";
 export type { IPoolElement } from "./ObjectPool";
 export { ReturnableObjectPool } from "./ReturnableObjectPool";
-export { SafeLoopArray } from "./SafeLoopArray";

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { ClearableObjectPool } from "./ClearableObjectPool";
-export { IPoolElement, ObjectPool } from "./ObjectPool";
+export { ObjectPool } from "./ObjectPool";
+export type { IPoolElement } from "./ObjectPool";
 export { ReturnableObjectPool } from "./ReturnableObjectPool";
 export { SafeLoopArray } from "./SafeLoopArray";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation comments to improve clarity for methods in `ClearableObjectPool` and `ReturnableObjectPool` classes.
  - Introduced a comment block explaining the `IPoolElement` interface.

- **New Features**
  - Exported various utility classes and interfaces (`ClearableObjectPool`, `ObjectPool`, `IPoolElement`, `ReturnableObjectPool`, `SafeLoopArray`) for broader use within the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->