### PR TITLE
Support parameter passing in component constructor

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -205,9 +205,12 @@ export class Entity extends EngineObject {
    * @param type - The type of the component
    * @returns	The component which has been added
    */
-  addComponent<T extends Component>(type: new (entity: Entity) => T): T {
+  addComponent<T extends new (entity: Entity, ...args: any[]) => Component>(
+    type: T,
+    ...args: ComponentArguments<T>
+  ): InstanceType<T> {
     ComponentsDependencies._addCheck(this, type);
-    const component = new type(this);
+    const component = new type(this, ...args) as InstanceType<T>;
     this._components.push(component);
     component._setActive(true, ActiveChangeFlag.All);
     return component;
@@ -751,3 +754,10 @@ export class Entity extends EngineObject {
     return this._invModelMatrix;
   }
 }
+
+type ComponentArguments<T extends new (entity: Entity, ...args: any[]) => Component> = T extends new (
+  entity: Entity,
+  ...args: infer P
+) => Component
+  ? P
+  : never;


### PR DESCRIPTION
You can:
```
class TestA extends Script {
    constructor(entity:Entity, a: number) {
        super(entity);
    }
}

entity.addComponent(TestA, 1);
```
![image](https://github.com/galacean/engine/assets/7768919/c5f64ec9-3e34-43df-9a50-9cd1f799d2eb)

