### PR TITLE
Fix the logic that incorrectly determines the length of the atlas when loading it

### DIFF
--- a/packages/loader/src/SpriteAtlasLoader.ts
+++ b/packages/loader/src/SpriteAtlasLoader.ts
@@ -38,12 +38,12 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
           const atlasItemsLen = atlasItems ? atlasItems.length : 0;
           const { engine } = resourceManager;
           const spriteAtlas = new SpriteAtlas(engine);
-          if (atlasItemsLen < 0) {
+          if (atlasItemsLen <= 0) {
             resolve(spriteAtlas);
             return;
           }
           chainPromises.length = 0;
-          for (let i = 0; i < atlasItems.length; i++) {
+          for (let i = 0; i < atlasItemsLen; i++) {
             const atlasItem = atlasItems[i];
             if (atlasItem.img) {
               chainPromises.push(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue in the `SpriteAtlasLoader` where the loop condition could cause incorrect handling of the sprite atlas items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->