### PR TITLE
Fix brdf.rg may less than 0

### DIFF
--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -34,6 +34,7 @@ vec3 envBRDFApprox(vec3 specularColor,float roughness, float dotNV ) {
 
     vec2 AB = vec2( -1.04, 1.04 ) * a004 + r.zw;
 
+    // AB may less than 0 at high roughness, ref: https://github.com/galacean/engine/pull/2173
     return max(specularColor * AB.x + AB.y, 0.0);
 
 }

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -34,7 +34,7 @@ vec3 envBRDFApprox(vec3 specularColor,float roughness, float dotNV ) {
 
     vec2 AB = vec2( -1.04, 1.04 ) * a004 + r.zw;
 
-    return specularColor * AB.x + AB.y;
+    return max(specularColor * AB.x + AB.y, 0.0);
 
 }
 


### PR DESCRIPTION
`brdf.rg` may less than 0 at `high roughness`:
![image-20240713015202171](https://github.com/user-attachments/assets/d4eb99ae-9241-465f-a50b-5fcb35ad6f4a)

and some specular material with `linearToGamma(specular * brdf.r + brdf.g)` will be `NaN` at fragOut and the fragIn in Bloom:
![image](https://github.com/user-attachments/assets/4b625b91-8853-4519-8083-f02eaa0830e7)

expect:
![image](https://github.com/user-attachments/assets/eb62da84-3bc6-4b3c-a9f1-9505c86f3107)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the shader function to ensure that specular highlights are not negative, enhancing visual accuracy in rendered scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->