### PR TITLE
Clamp shadow strength to 0~1

### DIFF
--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix } from "@galacean/engine-math";
+import { Color, MathUtil, Matrix } from "@galacean/engine-math";
 import { Component } from "../Component";
 import { Layer } from "../Layer";
 import { ignoreClone } from "../clone/CloneManager";
@@ -25,8 +25,8 @@ export abstract class Light extends Component {
   shadowNormalBias: number = 1;
   /** Near plane value to use for shadow frustums. */
   shadowNearPlane: number = 0.1;
-  /** Shadow intensity, the larger the value, the clearer and darker the shadow. */
-  shadowStrength: number = 1.0;
+
+  private _shadowStrength: number = 1.0;
 
   /** @internal */
   @ignoreClone
@@ -37,6 +37,15 @@ export abstract class Light extends Component {
   private _color: Color = new Color(1, 1, 1, 1);
   private _viewMat: Matrix;
   private _inverseViewMat: Matrix;
+
+  /** Shadow intensity, the larger the value, the clearer and darker the shadow, range [0,1] */
+  get shadowStrength(): number {
+    return this._shadowStrength;
+  }
+
+  set shadowStrength(value: number) {
+    this._shadowStrength = MathUtil.clamp(value, 0, 1);
+  }
 
   /**
    * Light Color.

--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -37,7 +37,7 @@ export abstract class Light extends Component {
   private _viewMat: Matrix;
   private _inverseViewMat: Matrix;
 
-  /** Shadow intensity, the larger the value, the clearer and darker the shadow, range [0,1] */
+  /** Shadow intensity, the larger the value, the clearer and darker the shadow, range [0,1]. */
   get shadowStrength(): number {
     return this._shadowStrength;
   }

--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -26,14 +26,13 @@ export abstract class Light extends Component {
   /** Near plane value to use for shadow frustums. */
   shadowNearPlane: number = 0.1;
 
-  private _shadowStrength: number = 1.0;
-
   /** @internal */
   @ignoreClone
   _lightIndex: number = -1;
   /** @internal */
   _lightColor: Color = new Color();
 
+  private _shadowStrength: number = 1.0;
   private _color: Color = new Color(1, 1, 1, 1);
   private _viewMat: Matrix;
   private _inverseViewMat: Matrix;

--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -9,31 +9,31 @@ import { ShadowType } from "../shadow";
  */
 export abstract class Light extends Component {
   /** Light Intensity */
-  intensity: number = 1;
+  intensity = 1;
 
   /**
    * Culling mask - which layers the light affect.
    * @remarks Support bit manipulation, corresponding to `Layer`.
    */
-  cullingMask: Layer = Layer.Everything;
+  cullingMask = Layer.Everything;
 
   /** How this light casts shadows. */
-  shadowType: ShadowType = ShadowType.None;
+  shadowType = ShadowType.None;
   /** Shadow bias.*/
-  shadowBias: number = 1;
+  shadowBias = 1;
   /** Shadow mapping normal-based bias. */
-  shadowNormalBias: number = 1;
+  shadowNormalBias = 1;
   /** Near plane value to use for shadow frustums. */
-  shadowNearPlane: number = 0.1;
+  shadowNearPlane = 0.1;
 
   /** @internal */
   @ignoreClone
-  _lightIndex: number = -1;
+  _lightIndex = -1;
   /** @internal */
-  _lightColor: Color = new Color();
+  _lightColor = new Color();
 
-  private _shadowStrength: number = 1.0;
-  private _color: Color = new Color(1, 1, 1, 1);
+  private _shadowStrength = 1.0;
+  private _color = new Color(1, 1, 1, 1);
   private _viewMat: Matrix;
   private _inverseViewMat: Matrix;
 

--- a/packages/core/src/postProcess/effects/BloomEffect.ts
+++ b/packages/core/src/postProcess/effects/BloomEffect.ts
@@ -108,7 +108,7 @@ export class BloomEffect {
   }
 
   set scatter(value: number) {
-    value = Math.min(Math.max(0, value), 1);
+    value = MathUtil.clamp(value, 0, 1);
 
     if (value !== this._scatter) {
       this._scatter = value;

--- a/tests/src/core/Light.test.ts
+++ b/tests/src/core/Light.test.ts
@@ -155,9 +155,14 @@ describe("Light test", function () {
   });
 
   it("update shadow strength", function () {
-    const expectShadowStrength = 0.8;
-    directLight.shadowStrength = expectShadowStrength;
-    expect(directLight.shadowStrength).to.equal(expectShadowStrength);
+    directLight.shadowStrength = 0.8;
+    expect(directLight.shadowStrength).to.equal(0.8);
+
+    directLight.shadowStrength = 2;
+    expect(directLight.shadowStrength).to.equal(1);
+
+    directLight.shadowStrength = -2;
+    expect(directLight.shadowStrength).to.equal(0);
   });
 
   it("multiple directlight or sunlight", function () {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added getter and setter for `shadowStrength` in the Light class for enhanced control and encapsulation.

- **Refactor**
  - Updated the BloomEffect class to use `MathUtil.clamp` for value clamping.

- **Tests**
  - Updated tests to validate new setter behavior for `shadowStrength` in the Light class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->