### PR TITLE
Fix: particleRenderer colorOverLifetime precision error

### DIFF
--- a/packages/core/src/shaderlib/particle/color_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/color_over_lifetime_module.glsl
@@ -38,6 +38,7 @@
         for(int i = 0; i < 4; i++){
             vec4 key = colorKeys[i];
             float time = key.x;
+            // equal will bring precision problem to age, possibly making it over 1.0
             if(colorAge < time){
                 if(i == 0){
                     value.rgb = colorKeys[0].yzw;

--- a/packages/core/src/shaderlib/particle/color_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/color_over_lifetime_module.glsl
@@ -20,7 +20,7 @@
         for(int i = 0; i < 4; i++){
             vec2 key = alphaKeys[i];
             float time = key.x;
-            if(alphaAge <= time){
+            if(alphaAge < time){
                 if(i == 0){
                     value.a = colorKeys[0].y;
                 }
@@ -38,7 +38,7 @@
         for(int i = 0; i < 4; i++){
             vec4 key = colorKeys[i];
             float time = key.x;
-            if(colorAge <= time){
+            if(colorAge < time){
                 if(i == 0){
                     value.rgb = colorKeys[0].yzw;
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined conditional statements for better accuracy in particle color and alpha transitions over their lifetime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->