### PR TITLE
Clamp linear gamma at last output

### DIFF
--- a/packages/core/src/shaderlib/common.glsl
+++ b/packages/core/src/shaderlib/common.glsl
@@ -18,6 +18,7 @@ vec4 gammaToLinear(vec4 srgbIn){
 }
 
 vec4 linearToGamma(vec4 linearIn){
+	linearIn = max(linearIn, 0.0);
     return vec4( pow(linearIn.rgb, vec3(1.0 / 2.2)), linearIn.a);
 }
 

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -34,9 +34,7 @@ vec3 envBRDFApprox(vec3 specularColor,float roughness, float dotNV ) {
 
     vec2 AB = vec2( -1.04, 1.04 ) * a004 + r.zw;
 
-    // AB may less than 0 at high roughness, ref: https://github.com/galacean/engine/pull/2173
-    return max(specularColor * AB.x + AB.y, 0.0);
-
+    return specularColor * AB.x + AB.y;
 }
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
delete it when support sRGB
- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved `linearToGamma` function to ensure input values are clamped, enhancing stability.
  - Simplified `envBRDFApprox` function for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->