### PR TITLE
Fix glTF scene root not mark as template

### DIFF
--- a/packages/loader/src/gltf/parser/GLTFSceneParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSceneParser.ts
@@ -34,6 +34,8 @@ export class GLTFSceneParser extends GLTFParser {
       sceneRoot = context.get<Entity>(GLTFParserType.Entity, sceneNodes[0]);
     } else {
       sceneRoot = new Entity(engine, "GLTF_ROOT");
+      // @ts-ignore
+      sceneRoot._markAsTemplate(glTFResource);
       for (let i = 0; i < sceneNodes.length; i++) {
         const childEntity = context.get<Entity>(GLTFParserType.Entity, sceneNodes[i]);
         sceneRoot.addChild(childEntity);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to mark the `sceneRoot` as a template during instantiation, enhancing its handling in rendering processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->