### PR TITLE
Fix evaluate value error when switch layer state && get target value error in stateMachine callback and animation event

### DIFF
--- a/docs/en/animation/animatorController.md
+++ b/docs/en/animation/animatorController.md
@@ -137,7 +137,7 @@ To overlay animations, add the desired animation state to another layer and set 
 You can set the animation data of the animator controller using the [animatorController](/apis/core/#Animator-animatorController) property. A default AnimatorController will be automatically added when a GLTF model is loaded.
 
 ```typescript
-animator.animatorController = new AnimatorController();
+animator.animatorController = new AnimatorController(engine);
 ```
 
 #### Reusing Animation Data

--- a/docs/zh/animation/animatorController.md
+++ b/docs/zh/animation/animatorController.md
@@ -135,7 +135,7 @@ animator.play("walkThenRun");
 你可以通过 [animatorController](/apis/core/#Animator-animatorController)  属性来设置动画控制器的动画数据，加载完成的 GLTF 模型会自动添加一个默认的 AnimatorController。
 
 ```typescript
-animator.animatorController = new AnimatorController()；
+animator.animatorController = new AnimatorController(engine)；
 ```
 
 #### 复用动画数据

--- a/e2e/case/animator-customAnimationClip.ts
+++ b/e2e/case/animator-customAnimationClip.ts
@@ -68,7 +68,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
       const animator = defaultSceneRoot.getComponent(Animator);
 
       const sceneAnimator = rootEntity.addComponent(Animator);
-      sceneAnimator.animatorController = new AnimatorController();
+      sceneAnimator.animatorController = new AnimatorController(engine);
       const layer = new AnimatorControllerLayer("base");
       sceneAnimator.animatorController.addLayer(layer);
       const stateMachine = (layer.stateMachine = new AnimatorStateMachine());

--- a/e2e/case/animator-customBlendShape.ts
+++ b/e2e/case/animator-customBlendShape.ts
@@ -72,7 +72,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
   modelMesh.uploadData(false);
 
   const animator = meshEntity.addComponent(Animator);
-  animator.animatorController = new AnimatorController();
+  animator.animatorController = new AnimatorController(engine);
   const layer = new AnimatorControllerLayer("base");
   animator.animatorController.addLayer(layer);
   const stateMachine = (layer.stateMachine = new AnimatorStateMachine());

--- a/e2e/case/animator-multiSubMeshBlendShape.ts
+++ b/e2e/case/animator-multiSubMeshBlendShape.ts
@@ -49,7 +49,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
       defaultSceneRoot.transform.rotation = new Vector3(-90, -0, 0);
       const animator = entity.addComponent(Animator);
 
-      animator.animatorController = new AnimatorController();
+      animator.animatorController = new AnimatorController(engine);
       const layer = new AnimatorControllerLayer("base");
       animator.animatorController.addLayer(layer);
       const stateMachine = (layer.stateMachine = new AnimatorStateMachine());

--- a/examples/animation-customAnimationClip.ts
+++ b/examples/animation-customAnimationClip.ts
@@ -22,7 +22,7 @@ import {
   SystemInfo,
   Transform,
   Vector3,
-  WebGLEngine,
+  WebGLEngine
 } from "@galacean/engine";
 
 Logger.enable();
@@ -63,9 +63,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
   spotLightEntity2.transform.setRotation(-60, 0, 0);
 
   engine.resourceManager
-    .load<GLTFResource>(
-      "https://gw.alipayobjects.com/os/bmw-prod/ca50859b-d736-4a3e-9fc3-241b0bd2afef.gltf"
-    )
+    .load<GLTFResource>("https://gw.alipayobjects.com/os/bmw-prod/ca50859b-d736-4a3e-9fc3-241b0bd2afef.gltf")
     .then((gltfResource) => {
       const { defaultSceneRoot } = gltfResource;
       defaultSceneRoot.transform.setScale(0.05, 0.05, 0.05);
@@ -73,16 +71,14 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
     });
 
   engine.resourceManager
-    .load<GLTFResource>(
-      "https://gw.alipayobjects.com/os/OasisHub/244228a7-361c-4c63-a790-dd9e19d12e78/data.gltf"
-    )
+    .load<GLTFResource>("https://gw.alipayobjects.com/os/OasisHub/244228a7-361c-4c63-a790-dd9e19d12e78/data.gltf")
     .then((gltfResource) => {
       const { defaultSceneRoot, animations = [] } = gltfResource;
       rootEntity.addChild(defaultSceneRoot);
       const animator = defaultSceneRoot.getComponent(Animator);
 
       const sceneAnimator = rootEntity.addComponent(Animator);
-      sceneAnimator.animatorController = new AnimatorController();
+      sceneAnimator.animatorController = new AnimatorController(engine);
       const layer = new AnimatorControllerLayer("base");
       sceneAnimator.animatorController.addLayer(layer);
       const stateMachine = (layer.stateMachine = new AnimatorStateMachine());
@@ -183,49 +179,14 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
       spotLight2RotateCurve.addKey(key14);
       spotLight2RotateCurve.addKey(key15);
 
-      sceneClip.addCurveBinding(
-        "/light_wrap/spotLight1",
-        SpotLight,
-        "color",
-        colorCurve
-      );
-      sceneClip.addCurveBinding(
-        "/light_wrap/spotLight1",
-        Transform,
-        "rotation",
-        spotLight1RotateCurve
-      );
-      sceneClip.addCurveBinding(
-        "/light_wrap/spotLight2",
-        Transform,
-        "rotation",
-        spotLight2RotateCurve
-      );
-      sceneClip.addCurveBinding(
-        "/light_wrap/spotLight2",
-        SpotLight,
-        "color",
-        color2Curve
-      );
-      sceneClip.addCurveBinding(
-        "/light_wrap",
-        Transform,
-        "rotation",
-        rotateCurve
-      );
+      sceneClip.addCurveBinding("/light_wrap/spotLight1", SpotLight, "color", colorCurve);
+      sceneClip.addCurveBinding("/light_wrap/spotLight1", Transform, "rotation", spotLight1RotateCurve);
+      sceneClip.addCurveBinding("/light_wrap/spotLight2", Transform, "rotation", spotLight2RotateCurve);
+      sceneClip.addCurveBinding("/light_wrap/spotLight2", SpotLight, "color", color2Curve);
+      sceneClip.addCurveBinding("/light_wrap", Transform, "rotation", rotateCurve);
       // curve can be reused
-      sceneClip.addCurveBinding(
-        "/camera_wrap",
-        Transform,
-        "rotation",
-        rotateCurve
-      );
-      sceneClip.addCurveBinding(
-        "/camera_wrap/camera",
-        Camera,
-        "fieldOfView",
-        fovCurve
-      );
+      sceneClip.addCurveBinding("/camera_wrap", Transform, "rotation", rotateCurve);
+      sceneClip.addCurveBinding("/camera_wrap/camera", Camera, "fieldOfView", fovCurve);
 
       sceneAnimator.play("sceneAnim", 0);
       animator.play(animations[0].name, 0);

--- a/examples/animation-sprite.ts
+++ b/examples/animation-sprite.ts
@@ -22,7 +22,7 @@ import {
   Animator,
   Texture2D,
   Rect,
-  InterpolationType,
+  InterpolationType
 } from "@galacean/engine";
 
 // Create engine
@@ -46,14 +46,13 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
   engine.resourceManager
     .load<SpriteAtlas>({
       url: "https://gw.alipayobjects.com/os/bmw-prod/da0bccd4-020a-41d5-82e0-a04f4413d9a6.atlas",
-      type: AssetType.SpriteAtlas,
+      type: AssetType.SpriteAtlas
     })
     .then((atlas) => {
       const spriteEntity = rootEntity.createChild();
       spriteEntity.transform.position = new Vector3();
       spriteEntity.transform.scale.set(100 / 32, 100 / 32, 100 / 32);
-      spriteEntity.addComponent(SpriteRenderer).sprite =
-      atlas.getSprite("npcs-11");
+      spriteEntity.addComponent(SpriteRenderer).sprite = atlas.getSprite("npcs-11");
 
       const spriteCurve = new AnimationRefCurve();
       for (let i = 0; i < 10; ++i) {
@@ -67,7 +66,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
       atlasState.clip = spriteClip;
 
       const animator = spriteEntity.addComponent(Animator);
-      const animatorController = new AnimatorController();
+      const animatorController = new AnimatorController(engine);
       animator.animatorController = animatorController;
       animatorController.addLayer(layer);
       animator.play(atlasState.name);
@@ -77,7 +76,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
   engine.resourceManager
     .load<Texture2D>({
       url: "https://gw.alipayobjects.com/mdn/rms_7c464e/afts/img/A*9nsHSpx28rAAAAAAAAAAAAAAARQnAQ",
-      type: AssetType.Texture2D,
+      type: AssetType.Texture2D
     })
     .then((texture) => {
       const spriteEntity = rootEntity.createChild("Sprite");
@@ -94,21 +93,15 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
         spriteCurve.addKey(key);
       }
       const spriteClip = new AnimationClip("sprite");
-      spriteClip.addCurveBinding(
-        "",
-        SpriteRenderer,
-        "sprite.region",
-        spriteCurve
-      );
+      spriteClip.addCurveBinding("", SpriteRenderer, "sprite.region", spriteCurve);
       regionState.clip = spriteClip;
 
       const animator = spriteEntity.addComponent(Animator);
-      const animatorController = new AnimatorController();
+      const animatorController = new AnimatorController(engine);
       animator.animatorController = animatorController;
       animatorController.addLayer(layer);
       animator.play(regionState.name);
     });
 
-  
   engine.run();
 });

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -739,7 +739,7 @@ export class Animator extends Component {
     if (needSwitchLayerState) {
       this._preparePlayOwner(layerData, destState);
       if (dstPlayDataFinished) {
-        // need newest value when finished
+        // Need newest value when finished
         this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
 
         this._fireAnimationEventsAndCallScripts(
@@ -896,7 +896,7 @@ export class Animator extends Component {
     if (needSwitchLayerState) {
       this._preparePlayOwner(layerData, state);
       if (destPlayDataFinished) {
-        // need newest value when finished
+        // Need newest value when finished
         this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
 
         this._fireAnimationEventsAndCallScripts(

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -726,70 +726,40 @@ export class Animator extends Component {
     srcPlayData.update(srcCostTime);
     destPlayData.update(destCostTime);
 
-    const dstPlayDataFinished = destPlayData.playState === AnimatorStatePlayState.Finished;
-
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    // For precision problem, loose judgment, expect to crossFade
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
-    const needSwitchLayerState = crossWeight === 1.0;
+    const crossFadeFinished = crossWeight === 1.0;
 
-    let fired = false;
-
-    if (needSwitchLayerState) {
+    if (crossFadeFinished) {
       this._preparePlayOwner(layerData, destState);
-      if (dstPlayDataFinished) {
-        // Need newest value when finished
-        this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
-
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          srcPlayData,
-          srcState,
-          lastSrcClipTime,
-          lastSrcPlayState,
-          Math.abs(srcCostTime)
-        );
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          destPlayData,
-          destState,
-          lastDestClipTime,
-          lastDstPlayState,
-          Math.abs(destCostTime)
-        );
-
-        fired = true;
-      }
-
-      this._updateCrossFadeData(layerData);
-    }
-
-    // For precision problem, strict judgment, expect not to update
-    const remainDeltaTime = deltaTime - costTime;
-    if (needSwitchLayerState && remainDeltaTime > MathUtil.zeroTolerance) {
-      this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
       this._evaluateState(layerData, weight, additive, aniUpdate);
+    }
 
-      if (!fired) {
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          srcPlayData,
-          srcState,
-          lastSrcClipTime,
-          lastSrcPlayState,
-          Math.abs(srcCostTime)
-        );
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          destPlayData,
-          destState,
-          lastDestClipTime,
-          lastDstPlayState,
-          Math.abs(destCostTime)
-        );
-      }
+    this._fireAnimationEventsAndCallScripts(
+      layerIndex,
+      srcPlayData,
+      srcState,
+      lastSrcClipTime,
+      lastSrcPlayState,
+      Math.abs(srcCostTime)
+    );
+
+    this._fireAnimationEventsAndCallScripts(
+      layerIndex,
+      destPlayData,
+      destState,
+      lastDestClipTime,
+      lastDstPlayState,
+      Math.abs(destCostTime)
+    );
+
+    if (crossFadeFinished) {
+      this._updateCrossFadeData(layerData);
+      const remainDeltaTime = deltaTime - costTime;
+      remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 
@@ -808,7 +778,7 @@ export class Animator extends Component {
 
     const transitionDuration = destState._getDuration() * layerData.crossFadeTransition.duration;
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
     const finished = destPlayData.playState === AnimatorStatePlayState.Finished;
 
@@ -887,48 +857,30 @@ export class Animator extends Component {
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
     // For precision problem, loose judgment, expect to crossFade
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
-    const needSwitchLayerState = crossWeight === 1.0;
+    const crossFadeFinished = crossWeight === 1.0;
 
-    let fired = false;
-
-    if (needSwitchLayerState) {
+    if (crossFadeFinished) {
       this._preparePlayOwner(layerData, state);
-      if (destPlayDataFinished) {
-        // Need newest value when finished
-        this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
-
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          destPlayData,
-          state,
-          lastDestClipTime,
-          lastPlayState,
-          Math.abs(destCostTime)
-        );
-        fired = true;
-      }
-
-      this._updateCrossFadeData(layerData);
-    }
-
-    // For precision problem, strict judgment, expect not to update
-    const remainDeltaTime = deltaTime - costTime;
-    if (needSwitchLayerState && remainDeltaTime > MathUtil.zeroTolerance) {
-      this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
       this._evaluateState(layerData, weight, additive, aniUpdate);
+    }
 
-      !fired &&
-        this._fireAnimationEventsAndCallScripts(
-          layerIndex,
-          destPlayData,
-          state,
-          lastDestClipTime,
-          lastPlayState,
-          Math.abs(destCostTime)
-        );
+    this._fireAnimationEventsAndCallScripts(
+      layerIndex,
+      destPlayData,
+      state,
+      lastDestClipTime,
+      lastPlayState,
+      Math.abs(destCostTime)
+    );
+
+    if (crossFadeFinished) {
+      this._updateCrossFadeData(layerData);
+      const remainDeltaTime = deltaTime - costTime;
+      remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -853,10 +853,7 @@ export class Animator extends Component {
 
     destPlayData.update(destCostTime);
 
-    const destPlayDataFinished = destPlayData.playState === AnimatorStatePlayState.Finished;
-
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    // For precision problem, loose judgment, expect to crossFade
     (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -618,7 +618,6 @@ export class Animator extends Component {
     costTime = Math.abs(costTime);
 
     const { eventHandlers } = srcPlayData.stateData;
-    //@todo: srcState is missing the judgment of the most recent period."
     eventHandlers.length && this._fireAnimationEvents(srcPlayData, eventHandlers, lastClipTime, clipTime, costTime);
 
     if (lastPlayState === AnimatorStatePlayState.UnStarted) {
@@ -722,8 +721,9 @@ export class Animator extends Component {
 
     srcPlayData.update(srcCostTime);
     destPlayData.update(destCostTime);
-    // For precision problem, loose judgment, expect to crossFade
+
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
+    // For precision problem, loose judgment, expect to crossFade
     (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
 
     const willSwitchState = crossWeight === 1.0;

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -1,4 +1,3 @@
-import { MathUtil } from "@galacean/engine-math";
 import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { Component } from "../Component";
 import { Entity } from "../Entity";

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -11,7 +11,6 @@ import { AnimatorController } from "./AnimatorController";
 import { AnimatorControllerLayer } from "./AnimatorControllerLayer";
 import { AnimatorControllerParameter } from "./AnimatorControllerParameter";
 import { AnimatorState } from "./AnimatorState";
-import { AnimatorStateMachine } from "./AnimatorStateMachine";
 import { AnimatorStateTransition } from "./AnimatorStateTransition";
 import { KeyframeValueType } from "./Keyframe";
 import { AnimatorConditionMode } from "./enums/AnimatorConditionMode";

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -527,25 +527,6 @@ export class Animator extends Component {
     }
   }
 
-  private _evaluateState(layerData: AnimatorLayerData, weight: number, additive: boolean, aniUpdate: boolean) {
-    const { srcPlayData, destPlayData } = layerData;
-
-    switch (layerData.layerState) {
-      case LayerState.Playing:
-        this._evaluatePlayingState(srcPlayData, weight, additive, aniUpdate);
-        break;
-      case LayerState.FixedCrossFading:
-        this._evaluateCrossFadeFromPoseState(layerData, destPlayData, weight, additive, aniUpdate);
-        break;
-      case LayerState.CrossFading:
-        this._evaluateCrossFadeState(layerData, srcPlayData, destPlayData, weight, additive, aniUpdate);
-        break;
-      case LayerState.Finished:
-        this._evaluateFinishedState(srcPlayData, weight, additive, aniUpdate);
-        break;
-    }
-  }
-
   private _updatePlayingState(
     layerIndex: number,
     layerData: AnimatorLayerData,
@@ -626,20 +607,12 @@ export class Animator extends Component {
 
     costTime = Math.abs(costTime);
 
-    if (needSwitchLayerState) {
-      this._evaluatePlayingState(srcPlayData, weight, additive, aniUpdate);
-      this._fireAnimationEventsAndCallScripts(layerIndex, srcPlayData, state, lastClipTime, lastPlayState, costTime);
+    this._evaluatePlayingState(srcPlayData, weight, additive, aniUpdate);
+    this._fireAnimationEventsAndCallScripts(layerIndex, srcPlayData, state, lastClipTime, lastPlayState, costTime);
 
+    if (needSwitchLayerState) {
       const remainDeltaTime = deltaTime - costTime;
       this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
-    } else {
-      if (layerFinished) {
-        this._evaluatePlayingState(srcPlayData, weight, additive, aniUpdate);
-      } else {
-        this._evaluateState(layerData, weight, additive, aniUpdate);
-      }
-
-      this._fireAnimationEventsAndCallScripts(layerIndex, srcPlayData, state, lastClipTime, lastPlayState, costTime);
     }
   }
 
@@ -734,7 +707,7 @@ export class Animator extends Component {
       this._preparePlayOwner(layerData, destState);
       this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
-      this._evaluateState(layerData, weight, additive, aniUpdate);
+      this._evaluateCrossFadeState(layerData, srcPlayData, destPlayData, weight, additive, aniUpdate);
     }
 
     this._fireAnimationEventsAndCallScripts(
@@ -861,7 +834,7 @@ export class Animator extends Component {
       this._preparePlayOwner(layerData, state);
       this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
-      this._evaluateState(layerData, weight, additive, aniUpdate);
+      this._evaluateCrossFadeFromPoseState(layerData, destPlayData, weight, additive, aniUpdate);
     }
 
     this._fireAnimationEventsAndCallScripts(
@@ -966,7 +939,7 @@ export class Animator extends Component {
     if (transition) {
       this._updateState(layerIndex, layerData, layer, deltaTime, aniUpdate);
     } else {
-      this._evaluateState(layerData, weight, additive, aniUpdate);
+      this._evaluateFinishedState(playData, weight, additive, aniUpdate);
     }
   }
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -54,7 +54,7 @@ export class Animator extends Component {
   @ignoreClone
   private _animationEventHandlerPool = new ClearableObjectPool(AnimationEventHandler);
   @ignoreClone
-  private _parametersValeMap: Record<string, AnimatorControllerParameterValueType> = Object.create(null);
+  private _parametersValueMap: Record<string, AnimatorControllerParameterValueType> = Object.create(null);
 
   @ignoreClone
   private _tempAnimatorStateInfo: IAnimatorStateInfo = { layerIndex: -1, state: null };
@@ -232,7 +232,7 @@ export class Animator extends Component {
   getParameterValue(name: string): AnimatorControllerParameterValueType {
     const parameter = this._animatorController?._parametersMap[name];
     if (parameter) {
-      return this._parametersValeMap[name] ?? parameter.value;
+      return this._parametersValueMap[name] ?? parameter.value;
     }
     return undefined;
   }
@@ -245,7 +245,7 @@ export class Animator extends Component {
   setParameterValue(name: string, value: AnimatorControllerParameterValueType) {
     const parameter = this._animatorController?._parametersMap[name];
     if (parameter && parameter.value !== value) {
-      this._parametersValeMap[name] = value;
+      this._parametersValueMap[name] = value;
     }
   }
 
@@ -288,7 +288,7 @@ export class Animator extends Component {
 
     this._animatorLayersData.length = 0;
     this._curveOwnerPool = Object.create(null);
-    this._parametersValeMap = Object.create(null);
+    this._parametersValueMap = Object.create(null);
     this._animationEventHandlerPool.clear();
 
     if (this._controllerUpdateFlag) {

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -755,7 +755,7 @@ export class Animator extends Component {
           destPlayData,
           destState,
           lastDestClipTime,
-          lastSrcPlayState,
+          lastDstPlayState,
           Math.abs(destCostTime)
         );
 
@@ -786,7 +786,7 @@ export class Animator extends Component {
           destPlayData,
           destState,
           lastDestClipTime,
-          lastSrcPlayState,
+          lastDstPlayState,
           Math.abs(destCostTime)
         );
       }

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -522,10 +522,9 @@ export class Animator extends Component {
       case LayerState.CrossFading:
         this._updateCrossFadeState(layerIndex, layerData, layer, weight, additive, deltaTime, aniUpdate);
         break;
-      case LayerState.FixedCrossFading: {
+      case LayerState.FixedCrossFading:
         this._updateCrossFadeFromPoseState(layerIndex, layerData, layer, weight, additive, deltaTime, aniUpdate);
         break;
-      }
     }
   }
 

--- a/packages/core/src/animation/AnimatorCondition.ts
+++ b/packages/core/src/animation/AnimatorCondition.ts
@@ -1,4 +1,4 @@
-import { AnimatorControllerParameterValueType } from "./AnimatorControllerParameter";
+import { AnimatorControllerParameterValue } from "./AnimatorControllerParameter";
 import { AnimatorConditionMode } from "./enums/AnimatorConditionMode";
 
 /**
@@ -10,5 +10,5 @@ export class AnimatorCondition {
   /** The name of the parameter used in the condition. */
   parameterName: string;
   /** The AnimatorParameter's threshold value for the condition to be true. */
-  threshold?: AnimatorControllerParameterValueType;
+  threshold?: AnimatorControllerParameterValue;
 }

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -62,12 +62,12 @@ export class AnimatorController extends ReferResource {
    */
   addParameter(parameter: AnimatorControllerParameter): AnimatorControllerParameter;
 
-  addParameter(param: AnimatorControllerParameter | string, value?: AnimatorControllerParameterValue) {
+  addParameter(param: AnimatorControllerParameter | string, defaultValue?: AnimatorControllerParameterValue) {
     if (typeof param === "string") {
       const name = param;
       param = new AnimatorControllerParameter();
       param.name = name;
-      param.defaultValue = value;
+      param.defaultValue = defaultValue;
     }
     this._parametersMap[param.name] = param;
     this._parameters.push(param);

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -1,5 +1,5 @@
 import { BoolUpdateFlag } from "../BoolUpdateFlag";
-import { AnimatorControllerParameter, AnimatorControllerParameterValueType } from "./AnimatorControllerParameter";
+import { AnimatorControllerParameter, AnimatorControllerParameterValue } from "./AnimatorControllerParameter";
 import { UpdateFlagManager } from "../UpdateFlagManager";
 import { AnimatorControllerLayer } from "./AnimatorControllerLayer";
 import { ReferResource } from "../asset/ReferResource";
@@ -34,6 +34,17 @@ export class AnimatorController extends ReferResource {
     return this._parameters;
   }
 
+  /**
+   * Create an AnimatorController.
+   * @param engine - Engine to which the animatorController belongs
+   */
+  constructor(engine: Engine);
+
+  /**
+   * @deprecated
+   */
+  constructor();
+
   constructor(engine?: Engine) {
     engine && super(engine);
   }
@@ -41,9 +52,9 @@ export class AnimatorController extends ReferResource {
   /**
    * Add a parameter to the controller.
    * @param name - The name of the parameter
-   * @param initialValue - The initial value of the parameter
+   * @param defaultValue - The default value of the parameter
    */
-  addParameter(name: string, initialValue?: AnimatorControllerParameterValueType): AnimatorControllerParameter;
+  addParameter(name: string, defaultValue?: AnimatorControllerParameterValue): AnimatorControllerParameter;
 
   /**
    * Add a parameter to the controller.
@@ -51,12 +62,12 @@ export class AnimatorController extends ReferResource {
    */
   addParameter(parameter: AnimatorControllerParameter): AnimatorControllerParameter;
 
-  addParameter(param: AnimatorControllerParameter | string, value?: AnimatorControllerParameterValueType) {
+  addParameter(param: AnimatorControllerParameter | string, value?: AnimatorControllerParameterValue) {
     if (typeof param === "string") {
       const name = param;
       param = new AnimatorControllerParameter();
       param.name = name;
-      param.value = value;
+      param.defaultValue = value;
     }
     this._parametersMap[param.name] = param;
     this._parameters.push(param);

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -2,11 +2,13 @@ import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { AnimatorControllerParameter, AnimatorControllerParameterValueType } from "./AnimatorControllerParameter";
 import { UpdateFlagManager } from "../UpdateFlagManager";
 import { AnimatorControllerLayer } from "./AnimatorControllerLayer";
+import { ReferResource } from "../asset/ReferResource";
+import { Engine } from "../Engine";
 
 /**
  * Store the data for Animator playback.
  */
-export class AnimatorController {
+export class AnimatorController extends ReferResource {
   /** @internal */
   _parameters: AnimatorControllerParameter[] = [];
   /** @internal */
@@ -30,6 +32,10 @@ export class AnimatorController {
    */
   get parameters(): Readonly<AnimatorControllerParameter[]> {
     return this._parameters;
+  }
+
+  constructor(engine?: Engine) {
+    engine && super(engine);
   }
 
   /**

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -41,9 +41,9 @@ export class AnimatorController extends ReferResource {
   /**
    * Add a parameter to the controller.
    * @param name - The name of the parameter
-   * @param value - The value of the parameter
+   * @param initialValue - The initial value of the parameter
    */
-  addParameter(name: string, value?: AnimatorControllerParameterValueType): AnimatorControllerParameter;
+  addParameter(name: string, initialValue?: AnimatorControllerParameterValueType): AnimatorControllerParameter;
 
   /**
    * Add a parameter to the controller.
@@ -81,18 +81,6 @@ export class AnimatorController extends ReferResource {
    */
   getParameter(name: string): AnimatorControllerParameter {
     return this._parametersMap[name] || null;
-  }
-
-  /**
-   * Set the value of the given parameter.
-   * @param name - The name of the parameter
-   * @param value - The value of the parameter
-   */
-  setParameterValue(name: string, value: AnimatorControllerParameterValueType) {
-    const parameter = this._parametersMap[name];
-    if (parameter && parameter.value !== value) {
-      parameter.value = value;
-    }
   }
 
   /**

--- a/packages/core/src/animation/AnimatorControllerParameter.ts
+++ b/packages/core/src/animation/AnimatorControllerParameter.ts
@@ -1,4 +1,4 @@
-export type AnimatorControllerParameterValueType = number | string | boolean;
+export type AnimatorControllerParameterValue = number | string | boolean;
 
 /**
  * Used to communicate between scripting and the controller, parameters can be set in scripting and used by the controller.
@@ -6,6 +6,6 @@ export type AnimatorControllerParameterValueType = number | string | boolean;
 export class AnimatorControllerParameter {
   /** The name of the parameter. */
   name: string;
-  /** The initial value of the parameter. */
-  value: AnimatorControllerParameterValueType;
+  /** The default value of the parameter. */
+  defaultValue: AnimatorControllerParameterValue;
 }

--- a/packages/core/src/animation/AnimatorControllerParameter.ts
+++ b/packages/core/src/animation/AnimatorControllerParameter.ts
@@ -6,6 +6,6 @@ export type AnimatorControllerParameterValueType = number | string | boolean;
 export class AnimatorControllerParameter {
   /** The name of the parameter. */
   name: string;
-  /** The value of the parameter. */
+  /** The initial value of the parameter. */
   value: AnimatorControllerParameterValueType;
 }

--- a/packages/core/src/animation/AnimatorStateTransition.ts
+++ b/packages/core/src/animation/AnimatorStateTransition.ts
@@ -1,4 +1,4 @@
-import { AnimatorControllerParameterValueType } from "./AnimatorControllerParameter";
+import { AnimatorControllerParameterValue } from "./AnimatorControllerParameter";
 import { AnimatorConditionMode } from "./enums/AnimatorConditionMode";
 import { AnimatorCondition } from "./AnimatorCondition";
 import { AnimatorState } from "./AnimatorState";
@@ -61,7 +61,7 @@ export class AnimatorStateTransition {
   addCondition(
     mode: AnimatorConditionMode,
     parameterName: string,
-    threshold?: AnimatorControllerParameterValueType
+    threshold?: AnimatorControllerParameterValue
   ): AnimatorCondition;
 
   /**
@@ -73,7 +73,7 @@ export class AnimatorStateTransition {
   addCondition(
     param: AnimatorConditionMode | AnimatorCondition,
     parameterName?: string,
-    threshold?: AnimatorControllerParameterValueType
+    threshold?: AnimatorControllerParameterValue
   ): AnimatorCondition {
     if (typeof param === "object") {
       this._conditions.push(param);

--- a/packages/core/src/animation/internal/AnimatorStatePlayData.ts
+++ b/packages/core/src/animation/internal/AnimatorStatePlayData.ts
@@ -49,7 +49,7 @@ export class AnimatorStatePlayData {
     if (state.wrapMode === WrapMode.Loop) {
       time = duration ? time % duration : 0;
     } else {
-      if (Math.abs(time) > duration) {
+      if (Math.abs(time) >= duration) {
         time = time < 0 ? -duration : duration;
         this.playState = AnimatorStatePlayState.Finished;
       }

--- a/packages/loader/src/AnimatorControllerLoader.ts
+++ b/packages/loader/src/AnimatorControllerLoader.ts
@@ -10,7 +10,7 @@ import {
   AnimatorStateTransition,
   AnimatorState,
   AnimatorConditionMode,
-  AnimatorControllerParameterValueType,
+  AnimatorControllerParameterValue,
   WrapMode,
   AnimatorControllerParameter
 } from "@galacean/engine-core";
@@ -102,7 +102,7 @@ class AnimatorControllerLoader extends Loader<AnimatorController> {
           parameters.forEach((parameterData) => {
             const parameter = new AnimatorControllerParameter();
             parameter.name = parameterData.name;
-            parameter.value = parameterData.value;
+            parameter.defaultValue = parameterData.defaultValue;
             animatorController.addParameter(parameter);
           });
           Promise.all(promises).then((clipData) => {
@@ -164,5 +164,5 @@ interface ITransitionData {
 interface IConditionData {
   mode: AnimatorConditionMode;
   parameterName: string;
-  threshold?: AnimatorControllerParameterValueType;
+  threshold?: AnimatorControllerParameterValue;
 }

--- a/packages/loader/src/AnimatorControllerLoader.ts
+++ b/packages/loader/src/AnimatorControllerLoader.ts
@@ -24,7 +24,7 @@ class AnimatorControllerLoader extends Loader<AnimatorController> {
         type: "json"
       })
         .then((data) => {
-          const animatorController = new AnimatorController();
+          const animatorController = new AnimatorController(resourceManager.engine);
           const { layers, parameters } = data;
           const promises = [];
           layers.forEach((layerData, layerIndex: number) => {

--- a/packages/loader/src/gltf/parser/GLTFAnimatorControllerParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFAnimatorControllerParser.ts
@@ -15,13 +15,15 @@ export class GLTFAnimatorControllerParser extends GLTFParser {
     }
 
     return context.get<AnimationClip>(GLTFParserType.Animation).then((animations) => {
-      const animatorController = this._createAnimatorController(animations);
+      const animatorController = this._createAnimatorController(context, animations);
       return Promise.resolve(animatorController);
     });
   }
 
-  private _createAnimatorController(animations: AnimationClip[]): AnimatorController {
-    const animatorController = new AnimatorController();
+  private _createAnimatorController(context: GLTFParserContext, animations: AnimationClip[]): AnimatorController {
+    const { glTFResource } = context;
+    const engine = glTFResource.engine;
+    const animatorController = new AnimatorController(engine);
     const layer = new AnimatorControllerLayer("layer");
     const animatorStateMachine = new AnimatorStateMachine();
     animatorController.addLayer(layer);

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -415,7 +415,7 @@ describe("Animator test", function () {
     animator.update(0.001);
     expect(animator.getCurrentAnimatorState(0).name).to.eq("Run");
 
-    animator.animatorController.setParameterValue("playerSpeed", 0.4);
+    animator.setParameterValue("playerSpeed", 0.4);
     // @ts-ignore
     animator.engine.time._frameCount++;
     animator.update(runToWalkTime - 0.001);
@@ -425,7 +425,7 @@ describe("Animator test", function () {
     animator.update(0.001);
     expect(animator.getCurrentAnimatorState(0).name).to.eq("Walk");
 
-    animator.animatorController.setParameterValue("playerSpeed", 0);
+    animator.setParameterValue("playerSpeed", 0);
     // @ts-ignore
     animator.engine.time._frameCount++;
     animator.update(anyToIdleTime - 0.001);
@@ -537,7 +537,7 @@ describe("Animator test", function () {
     animator.update(0.001);
     expect(animator.getCurrentAnimatorState(0).name).to.eq("Run");
 
-    animator.animatorController.setParameterValue("playerSpeed", 0.4);
+    animator.setParameterValue("playerSpeed", 0.4);
     // @ts-ignore
     animator.engine.time._frameCount++;
     animator.update(runToWalkTime - 0.001);
@@ -547,7 +547,7 @@ describe("Animator test", function () {
     animator.update(0.001);
     expect(animator.getCurrentAnimatorState(0).name).to.eq("Walk");
 
-    animator.animatorController.setParameterValue("playerSpeed", 0);
+    animator.setParameterValue("playerSpeed", 0);
     // @ts-ignore
     animator.engine.time._frameCount++;
     animator.update(anyToIdleTime - 0.001);

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -601,7 +601,6 @@ describe("Animator test", function () {
 
     animator.animatorController = animatorController;
     let enterRotation;
-    let updateRotation;
     let exitRotation;
     state1.addStateMachineScript(
       class extends StateMachineScript {
@@ -619,7 +618,6 @@ describe("Animator test", function () {
     animator.engine.time._frameCount++;
     animator.update(3);
     expect(enterRotation).to.eq(90);
-    expect(updateRotation).to.eq(90);
     expect(exitRotation).to.eq(90);
     expect(animator.entity.transform.rotation.x).to.eq(0);
     expect(animator.entity.transform.position.x).to.eq(5);

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -15,7 +15,8 @@ import {
   Transform,
   AnimatorController,
   WrapMode,
-  StateMachineScript
+  StateMachineScript,
+  AnimatorState
 } from "@galacean/engine-core";
 import { GLTFResource } from "@galacean/engine-loader";
 import { Quaternion } from "@galacean/engine-math";
@@ -600,11 +601,15 @@ describe("Animator test", function () {
 
     animator.animatorController = animatorController;
     let enterRotation;
+    let updateRotation;
     let exitRotation;
     state1.addStateMachineScript(
       class extends StateMachineScript {
         onStateEnter(animator) {
           enterRotation = animator.entity.transform.rotation.x;
+        }
+        onStateUpdate(animator) {
+          updateRotation = animator.entity.transform.rotation.x;
         }
         onStateExit(animator) {
           exitRotation = animator.entity.transform.rotation.x;
@@ -617,6 +622,7 @@ describe("Animator test", function () {
     animator.engine.time._frameCount++;
     animator.update(3);
     expect(enterRotation).to.eq(90);
+    expect(updateRotation).to.eq(90);
     expect(exitRotation).to.eq(90);
     expect(animator.entity.transform.rotation.x).to.eq(0);
     expect(animator.entity.transform.position.x).to.eq(5);

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -601,15 +601,11 @@ describe("Animator test", function () {
 
     animator.animatorController = animatorController;
     let enterRotation;
-    let updateRotation;
     let exitRotation;
     state1.addStateMachineScript(
       class extends StateMachineScript {
         onStateEnter(animator) {
           enterRotation = animator.entity.transform.rotation.x;
-        }
-        onStateUpdate(animator) {
-          updateRotation = animator.entity.transform.rotation.x;
         }
         onStateExit(animator) {
           exitRotation = animator.entity.transform.rotation.x;
@@ -622,7 +618,6 @@ describe("Animator test", function () {
     animator.engine.time._frameCount++;
     animator.update(3);
     expect(enterRotation).to.eq(90);
-    expect(updateRotation).to.eq(90);
     expect(exitRotation).to.eq(90);
     expect(animator.entity.transform.rotation.x).to.eq(0);
     expect(animator.entity.transform.position.x).to.eq(5);

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -601,6 +601,7 @@ describe("Animator test", function () {
 
     animator.animatorController = animatorController;
     let enterRotation;
+    let updateRotation;
     let exitRotation;
     state1.addStateMachineScript(
       class extends StateMachineScript {
@@ -618,6 +619,7 @@ describe("Animator test", function () {
     animator.engine.time._frameCount++;
     animator.update(3);
     expect(enterRotation).to.eq(90);
+    expect(updateRotation).to.eq(90);
     expect(exitRotation).to.eq(90);
     expect(animator.entity.transform.rotation.x).to.eq(0);
     expect(animator.entity.transform.position.x).to.eq(5);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- `AnimatorController` now requires an `engine` parameter during instantiation, enhancing its integration with the rendering engine and potentially improving animation management.

- **Documentation**
	- Updated documentation to reflect changes in the `AnimatorController` instantiation, providing clarity on the new requirement for the `engine` parameter.

- **Bug Fixes**
	- Adjusted instantiation in various examples and cases to ensure compatibility with the new `AnimatorController` constructor, preventing potential errors in existing implementations.

- **Tests**
	- Introduced new test cases to evaluate state transitions and ensure the animator correctly applies animation curves during updates, enhancing the reliability of the animation system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->