### PR TITLE
Fix `spriteDisableBatching` tag failure

### DIFF
--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -117,8 +117,6 @@ export class Engine extends EventDispatcher {
   /* @internal */
   _shaderProgramPools: ShaderProgramPool[] = [];
   /** @internal */
-  _canSpriteBatch: boolean = true;
-  /** @internal */
   _fontMap: Record<string, Font> = {};
   /** @internal @todo: temporary solution */
   _macroCollection: ShaderMacroCollection = new ShaderMacroCollection();

--- a/packages/core/src/RenderPipeline/BatchUtils.ts
+++ b/packages/core/src/RenderPipeline/BatchUtils.ts
@@ -1,11 +1,17 @@
 import { SpriteMask, SpriteMaskInteraction, SpriteRenderer } from "../2d";
+import { ShaderTagKey } from "../shader";
 import { SubRenderElement } from "./SubRenderElement";
 
 /**
  * @internal
  */
 export class BatchUtils {
+  protected static _disableBatchTag: ShaderTagKey = ShaderTagKey.getByName("spriteDisableBatching");
+
   static canBatchSprite(elementA: SubRenderElement, elementB: SubRenderElement): boolean {
+    if (elementB.shaderPasses[0].getTagValue(BatchUtils._disableBatchTag) === true) {
+      return false;
+    }
     if (elementA.subChunk.chunk !== elementB.subChunk.chunk) {
       return false;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sprite batching logic allowing for more control over rendering based on shader tags.
	- Introduced a mechanism to disable sprite batching through shader properties.
  
- **Bug Fixes**
	- Removed obsolete property that could cause confusion regarding sprite batching management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->