### PR TITLE
Fix `SkinnedRenderer.boundingBox` updates are not timely

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -172,7 +172,7 @@ export class Renderer extends Component implements IComponentCustomClone {
     this._addResourceReferCount(this.shaderData, 1);
 
     this._onTransformChanged = this._onTransformChanged.bind(this);
-    this._attachTransform(entity.transform);
+    this._setTransform(entity.transform);
 
     shaderData.enableMacro(Renderer._receiveShadowMacro);
     shaderData.setVector4(Renderer._rendererLayerProperty, this._rendererLayer);
@@ -366,7 +366,7 @@ export class Renderer extends Component implements IComponentCustomClone {
   protected override _onDestroy(): void {
     super._onDestroy();
 
-    this._attachTransform(null);
+    this._setTransform(null);
     this._addResourceReferCount(this.shaderData, -1);
 
     const materials = this._materials;
@@ -465,7 +465,7 @@ export class Renderer extends Component implements IComponentCustomClone {
   /**
    * @internal
    */
-  protected _attachTransform(transform: Transform): void {
+  protected _setTransform(transform: Transform): void {
     this._transform?._updateFlagManager.removeListener(this._onTransformChanged);
     transform?._updateFlagManager.addListener(this._onTransformChanged);
     this._transform = transform;

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -265,7 +265,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
         }
         break;
       case SkinUpdateFlag.RootBoneChanged:
-        this._attachTransform((<Entity>value).transform);
+        this._setTransform((<Entity>value).transform);
         this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
         break;
     }

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -265,7 +265,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
         }
         break;
       case SkinUpdateFlag.RootBoneChanged:
-        this._attachTransform((value as Entity).transform);
+        this._attachTransform((<Entity>value).transform);
         this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
         break;
     }

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -120,7 +120,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
    * @internal
    */
   override _updateTransformShaderData(context: RenderContext, onlyMVP: boolean, batched: boolean): void {
-    const worldMatrix = (this.skin?.rootBone ?? this.entity).transform.worldMatrix;
+    const worldMatrix = this._transform.worldMatrix;
     if (onlyMVP) {
       this._updateProjectionRelatedShaderData(context, worldMatrix, batched);
     } else {
@@ -219,7 +219,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   protected override _updateBounds(worldBounds: BoundingBox): void {
     const rootBone = this.skin?.rootBone;
     if (rootBone) {
-      BoundingBox.transform(this._localBounds, rootBone.transform.worldMatrix, worldBounds);
+      BoundingBox.transform(this._localBounds, this._transform.worldMatrix, worldBounds);
     } else {
       super._updateBounds(worldBounds);
     }
@@ -265,6 +265,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
         }
         break;
       case SkinUpdateFlag.RootBoneChanged:
+        this._attachTransform((value as Entity).transform);
         this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
         break;
     }

--- a/tests/src/core/SkinnedMeshRenderer.test.ts
+++ b/tests/src/core/SkinnedMeshRenderer.test.ts
@@ -72,8 +72,10 @@ describe("SkinnedMeshRenderer", async () => {
       new Matrix(1, 0, 0, -1, 0, 0, 0, -1, 0, 0, -2, -1).invert()
     ];
 
+    const position = new Vector3();
     const modelMesh = new ModelMesh(engine);
     const entity = rootEntity.createChild("SkinEntity");
+    entity.transform.position = position;
     const rootBone = entity.createChild("RootBone");
     rootBone.createChild("Joint0");
     rootBone.createChild("Joint1");
@@ -84,6 +86,8 @@ describe("SkinnedMeshRenderer", async () => {
 
     skinnedMR.skin = skin;
     engine.update();
+    expect(skinnedMR.bounds.min).to.deep.eq(position);
+    expect(skinnedMR.bounds.max).to.deep.eq(position);
 
     // Test that the skin is set correctly.
     expect(skinnedMR.skin).to.be.equal(skin);
@@ -94,10 +98,14 @@ describe("SkinnedMeshRenderer", async () => {
 
     // Test that the rootBone is set correctly.
     expect(skinnedMR.rootBone).to.be.equal(rootBone0);
+
+    position.set(1, 0, 0);
+    rootBone0.transform.position = position;
+    expect(skinnedMR.bounds.min).to.deep.eq(position);
+    expect(skinnedMR.bounds.max).to.deep.eq(position);
   });
 
   it("clone", () => {
-    // @ts-ignore
     const modelMesh = new ModelMesh(engine);
 
     const positions = [new Vector3(0, 0, 0), new Vector3(0, 1, 0), new Vector3(1, 1, 0)];


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced transformation handling in the Renderer, improving encapsulation and performance.
	- Streamlined world matrix access in the SkinnedMeshRenderer for better clarity and efficiency.

- **Bug Fixes**
	- Fixed issues related to root bone changes, ensuring correct transform associations during skinning updates.
	- Improved accuracy of bounding box calculations in the SkinnedMeshRenderer by validating against updated positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->