### PR TITLE
Delete MAX_VERTEX_COUNT from PrimitiveChunkManager

### DIFF
--- a/packages/core/src/RenderPipeline/PrimitiveChunkManager.ts
+++ b/packages/core/src/RenderPipeline/PrimitiveChunkManager.ts
@@ -6,14 +6,11 @@ import { SubPrimitiveChunk } from "./SubPrimitiveChunk";
  * @internal
  */
 export class PrimitiveChunkManager {
-  /** The maximum number of vertex. */
-  static MAX_VERTEX_COUNT = 4096;
-
   primitiveChunks = new Array<PrimitiveChunk>();
 
   constructor(
     public engine: Engine,
-    public maxVertexCount = PrimitiveChunkManager.MAX_VERTEX_COUNT
+    public maxVertexCount = 4096
   ) {}
 
   allocateSubChunk(vertexCount: number): SubPrimitiveChunk {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified initialization of `maxVertexCount` by removing the static property, enhancing code readability and maintainability.
  
- **Bug Fixes**
	- None reported in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->