### PR TITLE
Fix SkinnedRenderer.boundingBox updates are not timely

### DIFF
--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -128,7 +128,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 
   override _updateShaderData(context: RenderContext, onlyMVP: boolean): void {
     const { entity, skin } = this;
-    const worldMatrix = (skin?.rootBone ?? entity).transform.worldMatrix;
+    const worldMatrix = this._transform.worldMatrix;
 
     if (onlyMVP) {
       this._updateMVPShaderData(context, worldMatrix);
@@ -223,7 +223,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   protected override _updateBounds(worldBounds: BoundingBox): void {
     const rootBone = this.skin?.rootBone;
     if (rootBone) {
-      BoundingBox.transform(this._localBounds, rootBone.transform.worldMatrix, worldBounds);
+      BoundingBox.transform(this._localBounds, this._transform.worldMatrix, worldBounds);
     } else {
       super._updateBounds(worldBounds);
     }
@@ -269,6 +269,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
         }
         break;
       case SkinUpdateFlag.RootBoneChanged:
+        this._setTransform((<Entity>value).transform);
         this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
         break;
     }

--- a/tests/src/core/SkinnedMeshRenderer.test.ts
+++ b/tests/src/core/SkinnedMeshRenderer.test.ts
@@ -72,8 +72,10 @@ describe("SkinnedMeshRenderer", async () => {
       new Matrix(1, 0, 0, -1, 0, 0, 0, -1, 0, 0, -2, -1).invert()
     ];
 
+    const position = new Vector3();
     const modelMesh = new ModelMesh(engine);
     const entity = rootEntity.createChild("SkinEntity");
+    entity.transform.position = position;
     const rootBone = entity.createChild("RootBone");
     rootBone.createChild("Joint0");
     rootBone.createChild("Joint1");
@@ -84,6 +86,8 @@ describe("SkinnedMeshRenderer", async () => {
 
     skinnedMR.skin = skin;
     engine.update();
+    expect(skinnedMR.bounds.min).to.deep.eq(position);
+    expect(skinnedMR.bounds.max).to.deep.eq(position);
 
     // Test that the skin is set correctly.
     expect(skinnedMR.skin).to.be.equal(skin);
@@ -94,6 +98,11 @@ describe("SkinnedMeshRenderer", async () => {
 
     // Test that the rootBone is set correctly.
     expect(skinnedMR.rootBone).to.be.equal(rootBone0);
+
+    position.set(1, 0, 0);
+    rootBone0.transform.position = position;
+    expect(skinnedMR.bounds.min).to.deep.eq(position);
+    expect(skinnedMR.bounds.max).to.deep.eq(position);
   });
 
   it("clone", () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced handling of entity transforms in the Renderer, simplifying listener management and improving performance.
  - Standardized access to the world matrix in SkinnedMeshRenderer, ensuring consistent behavior during rendering and bounding box updates.

- **Bug Fixes**
  - Improved test coverage for SkinnedMeshRenderer by verifying the bounding box reflects the entity and root bone positions accurately.

- **Refactor**
  - Streamlined transformation logic within the Renderer and SkinnedMeshRenderer for better encapsulation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->