### PR TITLE
Fix animation time error because of speed and precision && fix: animatorParameter rename bug

### DIFF
--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -606,7 +606,7 @@ export class Animator extends Component {
     if (transition) {
       // actualCostTime = playCostTime / playSpeed
       const remainDeltaTime = deltaTime - playCostTime / playSpeed;
-      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 
@@ -725,7 +725,7 @@ export class Animator extends Component {
     if (crossFadeFinished) {
       this._updateCrossFadeData(layerData);
       const remainDeltaTime = deltaTime - actualCostTime;
-      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 
@@ -838,7 +838,7 @@ export class Animator extends Component {
     if (crossFadeFinished) {
       this._updateCrossFadeData(layerData);
       const remainDeltaTime = deltaTime - actualCostTime;
-      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -608,8 +608,7 @@ export class Animator extends Component {
 
     if (needSwitchLayerState) {
       const remainDeltaTime = deltaTime - costTime / actualSpeed;
-      remainDeltaTime > MathUtil.zeroTolerance &&
-        this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 
@@ -696,7 +695,7 @@ export class Animator extends Component {
     destPlayData.update(destCostTime);
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;
 
@@ -728,8 +727,7 @@ export class Animator extends Component {
     if (crossFadeFinished) {
       this._updateCrossFadeData(layerData);
       const remainDeltaTime = deltaTime - costTime;
-      remainDeltaTime > MathUtil.zeroTolerance &&
-        this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 
@@ -821,7 +819,7 @@ export class Animator extends Component {
     destPlayData.update(destCostTime);
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;
 
@@ -844,8 +842,7 @@ export class Animator extends Component {
     if (crossFadeFinished) {
       this._updateCrossFadeData(layerData);
       const remainDeltaTime = deltaTime - costTime;
-      remainDeltaTime > MathUtil.zeroTolerance &&
-        this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -608,7 +608,8 @@ export class Animator extends Component {
 
     if (needSwitchLayerState) {
       const remainDeltaTime = deltaTime - costTime / actualSpeed;
-      this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
+      remainDeltaTime > MathUtil.zeroTolerance &&
+        this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }
   }
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -703,7 +703,7 @@ export class Animator extends Component {
       this._preparePlayOwner(layerData, destState);
       this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
-      this._evaluateCrossFadeState(layerData, srcPlayData, destPlayData, weight, additive, aniUpdate);
+      this._evaluateCrossFadeState(layerData, srcPlayData, destPlayData, weight, crossWeight, additive, aniUpdate);
     }
 
     this._fireAnimationEventsAndCallScripts(
@@ -737,6 +737,7 @@ export class Animator extends Component {
     srcPlayData: AnimatorStatePlayData,
     destPlayData: AnimatorStatePlayData,
     weight: number,
+    crossWeight: number,
     additive: boolean,
     aniUpdate: boolean
   ) {
@@ -744,10 +745,6 @@ export class Animator extends Component {
     const { _curveBindings: srcCurves } = srcPlayData.state.clip;
     const { state: destState } = destPlayData;
     const { _curveBindings: destCurves } = destState.clip;
-
-    const transitionDuration = destState._getDuration() * layerData.crossFadeTransition.duration;
-    let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
 
     const finished = destPlayData.playState === AnimatorStatePlayState.Finished;
 
@@ -823,7 +820,7 @@ export class Animator extends Component {
     destPlayData.update(destCostTime);
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;
 
@@ -831,7 +828,7 @@ export class Animator extends Component {
       this._preparePlayOwner(layerData, state);
       this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
-      this._evaluateCrossFadeFromPoseState(layerData, destPlayData, weight, additive, aniUpdate);
+      this._evaluateCrossFadeFromPoseState(layerData, destPlayData, weight, crossWeight, additive, aniUpdate);
     }
 
     this._fireAnimationEventsAndCallScripts(
@@ -855,16 +852,13 @@ export class Animator extends Component {
     layerData: AnimatorLayerData,
     destPlayData: AnimatorStatePlayData,
     weight: number,
+    crossWeight: number,
     additive: boolean,
     aniUpdate: boolean
   ) {
     const { crossLayerOwnerCollection } = layerData;
     const { state } = destPlayData;
     const { _curveBindings: curveBindings } = state.clip;
-
-    const duration = state._getDuration() * layerData.crossFadeTransition.duration;
-    let crossWeight = Math.abs(destPlayData.frameTime) / duration;
-    (crossWeight >= 1.0 - MathUtil.zeroTolerance || duration === 0) && (crossWeight = 1.0);
 
     const { clipTime: destClipTime, playState } = destPlayData;
     const finished = playState === AnimatorStatePlayState.Finished;

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -595,18 +595,15 @@ export class Animator extends Component {
       srcPlayData.update(playCostTime - playDeltaTime);
     } else {
       playCostTime = playDeltaTime;
-    }
-
-    const needSwitchLayerState = !!transition;
-    const layerFinished = !needSwitchLayerState && srcPlayData.playState === AnimatorStatePlayState.Finished;
-    if (layerFinished) {
-      layerData.layerState = LayerState.Finished;
+      if (srcPlayData.playState === AnimatorStatePlayState.Finished) {
+        layerData.layerState = LayerState.Finished;
+      }
     }
 
     this._evaluatePlayingState(srcPlayData, weight, additive, aniUpdate);
     this._fireAnimationEventsAndCallScripts(layerIndex, srcPlayData, state, lastClipTime, lastPlayState, playCostTime);
 
-    if (needSwitchLayerState) {
+    if (transition) {
       // actualCostTime = playCostTime / playSpeed
       const remainDeltaTime = deltaTime - playCostTime / playSpeed;
       remainDeltaTime >= 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -604,7 +604,7 @@ export class Animator extends Component {
     this._fireAnimationEventsAndCallScripts(layerIndex, srcPlayData, state, lastClipTime, lastPlayState, playCostTime);
 
     if (transition) {
-      // actualCostTime = playCostTime / playSpeed
+      // Remove speed factor, use actual cost time
       const remainDeltaTime = deltaTime - playCostTime / playSpeed;
       remainDeltaTime > 0 && this._updateState(layerIndex, layerData, layer, remainDeltaTime, aniUpdate);
     }

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -695,7 +695,7 @@ export class Animator extends Component {
     destPlayData.update(destCostTime);
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;
 
@@ -819,7 +819,7 @@ export class Animator extends Component {
     destPlayData.update(destCostTime);
 
     let crossWeight = Math.abs(destPlayData.frameTime) / transitionDuration;
-    (crossWeight >= 1.0 || transitionDuration === 0) && (crossWeight = 1.0);
+    (crossWeight >= 1.0 - MathUtil.zeroTolerance || transitionDuration === 0) && (crossWeight = 1.0);
 
     const crossFadeFinished = crossWeight === 1.0;
 

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -54,35 +54,29 @@ export class AnimatorController extends ReferResource {
    * @param name - The name of the parameter
    * @param defaultValue - The default value of the parameter
    */
-  addParameter(name: string, defaultValue?: AnimatorControllerParameterValue): AnimatorControllerParameter;
-
-  /**
-   * Add a parameter to the controller.
-   * @param parameter - The parameter
-   */
-  addParameter(parameter: AnimatorControllerParameter): AnimatorControllerParameter;
-
-  addParameter(param: AnimatorControllerParameter | string, defaultValue?: AnimatorControllerParameterValue) {
-    if (typeof param === "string") {
-      const name = param;
-      param = new AnimatorControllerParameter();
-      param.name = name;
-      param.defaultValue = defaultValue;
+  addParameter(name: string, defaultValue?: AnimatorControllerParameterValue) {
+    if (this._parametersMap[name]) {
+      console.warn(`Parameter ${name} already exists.`);
+      return null;
     }
+    const param = new AnimatorControllerParameter();
+    param.name = name;
+    param.defaultValue = defaultValue;
     param._onNameChanged = (oldName, newName) => {
       delete this._parametersMap[oldName];
       this._parametersMap[newName] = param as AnimatorControllerParameter;
     };
-    this._parametersMap[param.name] = param;
+    this._parametersMap[name] = param;
     this._parameters.push(param);
     return param;
   }
 
   /**
-   * Remove a parameter from the controller.
-   * @param parameter - The parameter
+   * Remove a parameter from the controller by name.
+   * @param name - The parameter name
    */
-  removeParameter(parameter: AnimatorControllerParameter) {
+  removeParameter(name: string) {
+    const parameter = this._parametersMap[name];
     const index = this._parameters.indexOf(parameter);
     if (index !== -1) {
       this._parameters.splice(index, 1);

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -69,6 +69,10 @@ export class AnimatorController extends ReferResource {
       param.name = name;
       param.defaultValue = defaultValue;
     }
+    param._onNameChanged = (oldName, newName) => {
+      delete this._parametersMap[oldName];
+      this._parametersMap[newName] = param as AnimatorControllerParameter;
+    };
     this._parametersMap[param.name] = param;
     this._parameters.push(param);
     return param;

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -54,7 +54,7 @@ export class AnimatorController extends ReferResource {
    * @param name - The name of the parameter
    * @param defaultValue - The default value of the parameter
    */
-  addParameter(name: string, defaultValue?: AnimatorControllerParameterValue) {
+  addParameter(name: string, defaultValue?: AnimatorControllerParameterValue): AnimatorControllerParameter {
     if (this._parametersMap[name]) {
       console.warn(`Parameter ${name} already exists.`);
       return null;

--- a/packages/core/src/animation/AnimatorControllerParameter.ts
+++ b/packages/core/src/animation/AnimatorControllerParameter.ts
@@ -1,11 +1,30 @@
+import { AnimatorController } from "./AnimatorController";
+
 export type AnimatorControllerParameterValue = number | string | boolean;
 
 /**
  * Used to communicate between scripting and the controller, parameters can be set in scripting and used by the controller.
  */
 export class AnimatorControllerParameter {
-  /** The name of the parameter. */
-  name: string;
   /** The default value of the parameter. */
   defaultValue: AnimatorControllerParameterValue;
+
+  /** @internal */
+  _onNameChanged: (oldName: string, newName: string) => void = null;
+
+  private _name: string;
+
+  /** The name of the parameter. */
+  get name(): string {
+    return this._name;
+  }
+
+  set name(name: string) {
+    if (this._name === name) {
+      return;
+    }
+    const oldName = this._name;
+    this._name = name;
+    this._onNameChanged?.(oldName, name);
+  }
 }

--- a/packages/core/src/animation/AnimatorControllerParameter.ts
+++ b/packages/core/src/animation/AnimatorControllerParameter.ts
@@ -1,5 +1,3 @@
-import { AnimatorController } from "./AnimatorController";
-
 export type AnimatorControllerParameterValue = number | string | boolean;
 
 /**

--- a/packages/core/src/animation/AnimatorControllerParameter.ts
+++ b/packages/core/src/animation/AnimatorControllerParameter.ts
@@ -14,7 +14,9 @@ export class AnimatorControllerParameter {
 
   private _name: string;
 
-  /** The name of the parameter. */
+  /**
+   * The name of the parameter.
+   */
   get name(): string {
     return this._name;
   }

--- a/packages/loader/src/AnimatorControllerLoader.ts
+++ b/packages/loader/src/AnimatorControllerLoader.ts
@@ -100,10 +100,7 @@ class AnimatorControllerLoader extends Loader<AnimatorController> {
             animatorController.addLayer(layer);
           });
           parameters.forEach((parameterData) => {
-            const parameter = new AnimatorControllerParameter();
-            parameter.name = parameterData.name;
-            parameter.defaultValue = parameterData.defaultValue;
-            animatorController.addParameter(parameter);
+            animatorController.addParameter(parameterData.name, parameterData.defaultValue);
           });
           Promise.all(promises).then((clipData) => {
             clipData.forEach((data) => {

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -325,6 +325,8 @@ describe("Animator test", function () {
     animator.animatorController.addParameter("playerSpeed", 1);
     const stateMachine = animator.animatorController.layers[0].stateMachine;
     const idleState = animator.findAnimatorState("Survey");
+    const idleSpeed = 2;
+    idleState.speed = idleSpeed;
     idleState.clearTransitions();
     const walkState = animator.findAnimatorState("Walk");
     walkState.clearTransitions();
@@ -344,7 +346,9 @@ describe("Animator test", function () {
     idleState.addTransition(toWalkTransition);
     idleToWalkTime =
       //@ts-ignore
-      toWalkTransition.exitTime * idleState._getDuration() + toWalkTransition.duration * walkState._getDuration();
+      (toWalkTransition.exitTime * idleState._getDuration()) / idleSpeed +
+      //@ts-ignore
+      toWalkTransition.duration * walkState._getDuration();
 
     const exitTransition = idleState.addExitTransition();
     exitTransition.addCondition(AnimatorConditionMode.Equals, "playerSpeed", 0);
@@ -370,7 +374,7 @@ describe("Animator test", function () {
       //@ts-ignore
       (toIdleTransition.exitTime - toRunTransition.duration) * walkState._getDuration() +
       //@ts-ignore
-      toIdleTransition.duration * idleState._getDuration();
+      (toIdleTransition.duration * idleState._getDuration()) / idleSpeed;
 
     // to run state
     const runToWalkTransition = new AnimatorStateTransition();
@@ -395,7 +399,7 @@ describe("Animator test", function () {
       // @ts-ignore
       (anyTransition.exitTime - toIdleTransition.duration) * walkState._getDuration() +
       // @ts-ignore
-      anyTransition.duration * idleState._getDuration();
+      (anyTransition.duration * idleState._getDuration()) / idleSpeed;
 
     // @ts-ignore
     animator.engine.time._frameCount++;
@@ -447,6 +451,8 @@ describe("Animator test", function () {
     stateMachine._anyStateTransitions.length = 0;
 
     const idleState = animator.findAnimatorState("Survey");
+    const idleSpeed = 2;
+    idleState.speed = idleSpeed;
     idleState.clearTransitions();
     const walkState = animator.findAnimatorState("Walk");
     walkState.clearTransitions();
@@ -466,7 +472,9 @@ describe("Animator test", function () {
     idleState.addTransition(toWalkTransition);
     idleToWalkTime =
       //@ts-ignore
-      (1 - toWalkTransition.exitTime) * idleState._getDuration() + toWalkTransition.duration * walkState._getDuration();
+      ((1 - toWalkTransition.exitTime) * idleState._getDuration()) / idleSpeed +
+      //@ts-ignore
+      toWalkTransition.duration * walkState._getDuration();
 
     const exitTransition = idleState.addExitTransition();
     exitTransition.addCondition(AnimatorConditionMode.Equals, "playerSpeed", 0);
@@ -492,7 +500,7 @@ describe("Animator test", function () {
       //@ts-ignore
       (1 - toIdleTransition.exitTime - toRunTransition.duration) * walkState._getDuration() +
       //@ts-ignore
-      toIdleTransition.duration * idleState._getDuration();
+      (toIdleTransition.duration * idleState._getDuration()) / idleSpeed;
 
     // to run state
     const runToWalkTransition = new AnimatorStateTransition();
@@ -517,7 +525,7 @@ describe("Animator test", function () {
       // @ts-ignore
       (1 - anyTransition.exitTime - toIdleTransition.duration) * walkState._getDuration() +
       // @ts-ignore
-      anyTransition.duration * idleState._getDuration();
+      (anyTransition.duration * idleState._getDuration()) / idleSpeed;
 
     // @ts-ignore
     animator.engine.time._frameCount++;

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -630,4 +630,16 @@ describe("Animator test", function () {
     expect(animator.entity.transform.rotation.x).to.eq(0);
     expect(animator.entity.transform.position.x).to.eq(5);
   });
+
+  it("parameter rename", () => {
+    animator.animatorController.addParameter("oldName", 1);
+    const param = animator.getParameter("oldName");
+    param.name = "newName";
+    const value = animator.getParameterValue("newName");
+    expect(value).to.eq(1);
+    const newParam = animator.animatorController.addParameter("oldName", 2);
+    expect(newParam.defaultValue).to.eq(2);
+    const newParam2 = animator.animatorController.addParameter("oldName", 2);
+    expect(newParam2).to.eq(null);
+  });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced animation timing and state management for smoother transitions.
	- Added dynamic parameter name renaming functionality in the AnimatorController.
	- Streamlined parameter addition process for improved efficiency and readability.

- **Bug Fixes**
	- Improved precision of cross-fade calculations to reduce transition errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->