### PR TITLE
Fix sub asset promise error

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -185,12 +185,11 @@ export class ResourceManager {
   _onSubAssetSuccess<T>(assetBaseURL: string, assetSubPath: string, value: T): void {
     const subPromiseCallback = this._subAssetPromiseCallbacks[assetBaseURL]?.[assetSubPath];
     if (subPromiseCallback) {
-      // Already resolved
       subPromiseCallback.resolve(value);
     } else {
       // Pending
       (this._subAssetPromiseCallbacks[assetBaseURL] ||= {})[assetSubPath] = {
-        resolve: value
+        resolvedValue: value
       };
     }
   }
@@ -198,15 +197,14 @@ export class ResourceManager {
   /**
    * @internal
    */
-  _onSubAssetFail(assetBaseURL: string, assetSubPath: string, value: (reason: any) => void): void {
+  _onSubAssetFail(assetBaseURL: string, assetSubPath: string, value: Error): void {
     const subPromiseCallback = this._subAssetPromiseCallbacks[assetBaseURL]?.[assetSubPath];
     if (subPromiseCallback) {
-      // Already rejected
       subPromiseCallback.reject(value);
     } else {
       // Pending
       (this._subAssetPromiseCallbacks[assetBaseURL] ||= {})[assetSubPath] = {
-        reject: value
+        rejectedValue: value
       };
     }
   }
@@ -352,7 +350,6 @@ export class ResourceManager {
     let assetURL = assetBaseURL;
     if (queryPath) {
       assetURL += "?q=" + paths.shift();
-
       let index: string;
       while ((index = paths.shift())) {
         assetURL += `[${index}]`;
@@ -425,21 +422,21 @@ export class ResourceManager {
   ): AssetPromise<T> {
     const loadingPromises = this._loadingPromises;
     const subPromiseCallback = this._subAssetPromiseCallbacks[assetBaseURL]?.[assetSubPath];
-    const resolvedValue = subPromiseCallback?.resolve;
-    const rejectedValue = subPromiseCallback?.reject;
+    const resolvedValue = subPromiseCallback?.resolvedValue;
+    const rejectedValue = subPromiseCallback?.rejectedValue;
 
+    // Already resolved or rejected
     if (resolvedValue || rejectedValue) {
       return new AssetPromise<T>((resolve, reject) => {
         if (resolvedValue) {
-          // Already resolved
           resolve(resolvedValue);
         } else if (rejectedValue) {
-          // Already rejected
           reject(rejectedValue);
         }
       });
     }
 
+    // Pending
     const promise = new AssetPromise<T>((resolve, reject) => {
       (this._subAssetPromiseCallbacks[assetBaseURL] ||= {})[assetSubPath] = {
         resolve,
@@ -447,7 +444,6 @@ export class ResourceManager {
       };
     });
 
-    // Pending
     loadingPromises[assetURL] = promise;
 
     promise.then(
@@ -609,7 +605,11 @@ type SubAssetPromiseCallbacks<T> = Record<
     // sub asset url, ie. "textures[0]"
     string,
     {
-      resolve?: T | PromiseLike<T>;
+      // Already resolved or rejected
+      resolvedValue?: T;
+      rejectedValue?: Error;
+      // Pending
+      resolve?: (value: T) => void;
       reject?: (reason: any) => void;
     }
   >


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### Other information:
1. does not cache the loadingPromise of subAsset. `loadingPromises[assetURL] = null;`
2. but store the resolve. `{resolve:(T)=>void}`
3. request sub asset again
4. resolve the invalid value. `if(resolve){ resolve((T)=>void)}`
![image](https://github.com/user-attachments/assets/1a0253fc-ee9b-4a92-b6ba-0f518b230ee7)

