### PR TITLE
[Docs] fix glTF doc link error

### DIFF
--- a/docs/zh/graphics/model/glTF.md
+++ b/docs/zh/graphics/model/glTF.md
@@ -41,17 +41,20 @@ glTF 拥有非常多的特性，官网提供了大量的[示例](https://github.
 
 Galacean 目前支持以下 glTF 插件，若 glTF 文件中包含相应插件，则会自动加载相应功能：
 
-| 插件                                                                                                                                                               | 功能                                                                                                                                                                                                  |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [KHR_draco_mesh_compression](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_draco_mesh_compression.ts)                   | 支持 Draco 压缩模型，节省显存                                                                                                                                                                         |
-| [KHR_lights_punctual](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_lights_punctual.ts)                                 | 支持多光源组合，会解析成引擎的光源，详见[光照教程](/docs/graphics/light/light/)                                                                                                                             |
-| [KHR_materials_pbrSpecularGlossiness](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_materials_pbrSpecularGlossiness.ts) | 支持 PBR [高光-光泽度工作流](/apis/core/#PBRSpecularMaterial)                                                                                                                                          |
-| [KHR_materials_unlit](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_materials_unlit.ts)                                 | 支持 [Unlit 材质](/docs/graphics/shader/builtins/unlit/)                                                                                                                                                       |
-| [KHR_materials_variants](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_materials_variants.ts)                           | 允许渲染器存在多个材质，然后通过 [setMaterial](/apis/core/#Renderer-setMaterial) 接口进行材质切换                                                                                                      |
-| [KHR_mesh_quantization](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_mesh_quantization.ts)                             | 支持[顶点数据压缩](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization#extending-mesh-attributes)，节省显存，如顶点数据一般都是浮点数，此插件可以保存为整型 |
-| [KHR_texture_transform](https://github.com/oasis-engine/engine/blob/main/packages/loader/src/gltf/extensions/KHR_texture_transform.ts)                             | 支持纹理的缩放位移变换，可以参考 [TilingOffset](https://oasisengine.cn/#/examples/latest/tiling-offset) 案例                                                                                          |
-| [KHR_materials_clearcoat](https://github.com/ant-galaxy/oasis-engine/blob/main/packages/loader/src/gltf/extensions/KHR_materials_clearcoat.ts)                     | 支持材质的透明清漆度拓展，可以参考 [Clearcoat](https://oasisengine.cn/#/examples/latest/pbr-clearcoat) 案例                                                                                           |
-| [GALACEAN_materials_remap](https://github.com/ant-galaxy/oasis-engine/blob/main/packages/loader/src/gltf/extensions/GALACEAN_materials_remap.ts)                   | 支持编辑器材质映射                                                                                                                                                                                    |
+| 插件 | 功能 |
+| :-- | :-- |
+| [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression) | 支持 Draco 压缩模型，节省显存 |
+| [KHR_texture_basisu](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu) | 支持 KTX2 纹理压缩，节省显存 |
+| [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual) | 支持多光源组合，会解析成引擎的光源，详见[光照教程](/docs/graphics/light/light/) |
+| [KHR_materials_pbrSpecularGlossiness](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness) | 支持 PBR [高光-光泽度工作流](/apis/core/#PBRSpecularMaterial) |
+| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) | 支持 [Unlit 材质](/docs/graphics/shader/builtins/unlit/) |
+| [KHR_materials_variants](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants) | 允许渲染器存在多个材质，然后通过 [setMaterial](/apis/core/#Renderer-setMaterial) 接口进行材质切换 |
+| [KHR_mesh_quantization](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_mesh_quantization) | 支持[顶点数据压缩](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization#extending-mesh-attributes)，节省显存，如顶点数据一般都是浮点数，此插件可以保存为整型 |
+| [KHR_texture_transform](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform) | 支持纹理的缩放位移变换，可以参考 [TilingOffset](/embed/tiling-offset) 案例 |
+| [KHR_materials_clearcoat](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_clearcoat) | 支持材质的透明清漆度拓展，可以参考 [Clearcoat](/embed/pbr-clearcoat) 案例 |
+| [KHR_materials_ior](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_ior) | 支持材质的折射率设置 |
+| [KHR_materials_anisotropy](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_anisotropy) | 支持材质的各向异性设置，可以参考 [各向异性](/embed/pbr-anisotropy) 案例 |
+| [GALACEAN_materials_remap](https://github.com/galacean/engine/blob/main/packages/loader/src/gltf/extensions/GALACEAN_materials_remap.ts) | 支持编辑器材质映射 |
 
 ### 插件拓展
 

--- a/docs/zh/graphics/shader/shaderAPI.mdx
+++ b/docs/zh/graphics/shader/shaderAPI.mdx
@@ -153,7 +153,7 @@ float f2 = pow2(0.5);
 
 ### Common
 
-提供了`PI` 等常用宏，`gammaToLinear`、`pow2` 等通用方法，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/Common.glsl)。
+提供了`PI` 等常用宏，`gammaToLinear`、`pow2` 等通用方法，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/Common.glsl)。
 
 ### Fog
 
@@ -217,7 +217,7 @@ mat3 getTBNByDerivatives(vec2 uv, vec3 normal, vec3 position, bool isFrontFacing
 
 ### Shadow
 
-提供了阴影相关的函数，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/Shadow.glsl)。
+提供了阴影相关的函数，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/Shadow.glsl)。
 
 ```glsl
 // 获取级联阴影所属层级，比如级联数量设为4，则返回 0～3
@@ -254,15 +254,15 @@ void calculateBlendShape(Attributes attributes, inout vec4 position, inout vec3 
 
 ### AttributesPBR
 
-封装了 PBR 所需要的所有 Attribute 变量，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/AttributesPBR.glsl)。
+封装了 PBR 所需要的所有 Attribute 变量，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/AttributesPBR.glsl)。
 
 ### VaryingsPBR
 
-封装了 PBR 所需要的所有 Varyings 变量，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/VaryingsPBR.glsl)。
+封装了 PBR 所需要的所有 Varyings 变量，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/VaryingsPBR.glsl)。
 
 ### LightDirectPBR
 
-封装了基于 BRDF 光照模型的直接光计算，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/LightDirectPBR.glsl)。
+封装了基于 BRDF 光照模型的直接光计算，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/LightDirectPBR.glsl)。
 
 一般来说，直接调用即可：
 
@@ -289,7 +289,7 @@ float clearCoatLobe(Varyings varyings, SurfaceData surfaceData, BRDFData brdfDat
 
 ### LightInDirectPBR
 
-封装了基于 BRDF 光照模型的[环境光](/docs/graphics/light/ambient)计算，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/LightInDirectPBR.glsl)。
+封装了基于 BRDF 光照模型的[环境光](/docs/graphics/light/ambient)计算，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/LightInDirectPBR.glsl)。
 
 一般来说，直接调用即可：
 
@@ -312,7 +312,7 @@ float evaluateClearCoatIBL(Varyings varyings, SurfaceData surfaceData, BRDFData 
 
 ### VertexPBR
 
-PBR 顶点着色器所需要的一些方法，比如获取 TilingOffset 之后的 UV 坐标，获取骨骼、BS运算过后的世界坐标、法线、切线等，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/VertexPBR.glsl)。
+PBR 顶点着色器所需要的一些方法，比如获取 TilingOffset 之后的 UV 坐标，获取骨骼、BS运算过后的世界坐标、法线、切线等，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/VertexPBR.glsl)。
 
 ```glsl showLineNumbers {2, 4}
 Varyings varyings;
@@ -337,11 +337,11 @@ gl_Position = renderer_MVPMat * vertexInputs.positionOS;
 
 ### BRDF
 
-PBR 光照模型关键文件，封装了 BRDF 相关的通用计算函数， 以及用于后续光照模型计算的 `SurfaceData` 结构体和 `BRDFData` 结构体，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/BRDF.glsl)。
+PBR 光照模型关键文件，封装了 BRDF 相关的通用计算函数， 以及用于后续光照模型计算的 `SurfaceData` 结构体和 `BRDFData` 结构体，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/BRDF.glsl)。
 
 ### FragmentPBR
 
-包含了大量 CPU 传过来的金属度、粗糙度、贴图等变量，通过 `getSurfaceData` 初始化 `SurfaceData` 结构体，详见[源码](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/FragmentPBR.glsl)。
+包含了大量 CPU 传过来的金属度、粗糙度、贴图等变量，通过 `getSurfaceData` 初始化 `SurfaceData` 结构体，详见[源码](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/FragmentPBR.glsl)。
 
 ```glsl showLineNumbers
 BRDFData brdfData;
@@ -355,4 +355,4 @@ initBRDFData(surfaceData, brdfData);
 
 ### 最后
 
-除了关键 API 的功能和调用方式，关于整个文件的组织方式可以参考官网的 [ForwardPassPBR](https://github.com/galacean/engine-toolkit/blob/dev/1.3/packages/shaderlab/src/shaders/shadingPBR/ForwardPassPBR.glsl)。
+除了关键 API 的功能和调用方式，关于整个文件的组织方式可以参考官网的 [ForwardPassPBR](https://github.com/galacean/engine-toolkit/blob/main/packages/shaderlab/src/shaders/shadingPBR/ForwardPassPBR.glsl)。

--- a/docs/zh/interface/inspector.md
+++ b/docs/zh/interface/inspector.md
@@ -22,7 +22,7 @@ label: Basics/Interface
 
 ### 实体检查器
 
-实体检查器是最常用的检查器，它的属性包含了当前实体的组件列表。你可以很方便地修改某个组件的属性，也可以通过 **Add Component** 按钮方便地添加任何引擎内置的组件和自定义的脚本组件。实体检查器也包含当前实体的基本信息，比如 `Transform`、`Layer` 等。详见[实体](/engine/docs/core/entity)。
+实体检查器是最常用的检查器，它的属性包含了当前实体的组件列表。你可以很方便地修改某个组件的属性，也可以通过 **Add Component** 按钮方便地添加任何引擎内置的组件和自定义的脚本组件。实体检查器也包含当前实体的基本信息，比如 `Transform`、`Layer` 等。详见[实体](/docs/core/entity)。
 
 <img src="https://gw.alipayobjects.com/zos/OasisHub/bb8e0881-c716-4fc2-89c0-d7b4b01d668d/image-20240318175043180.png" style="zoom:50%;" />
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Restructured and updated the plugin feature table for better clarity in glTF documentation.
	- Added new plugins: `KHR_texture_basisu`, `KHR_materials_ior`, and `KHR_materials_anisotropy`, enhancing engine functionality.
	- Updated URLs in the shader API documentation to point to the latest version on the main branch.
	- Adjusted hyperlink reference in the Entity Inspector documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->