### PR TITLE
Delete priority of material

### DIFF
--- a/packages/core/src/material/Material.ts
+++ b/packages/core/src/material/Material.ts
@@ -18,8 +18,6 @@ export class Material extends ReferResource implements IClone {
   _shader: Shader;
   /** @internal */
   _renderStates: RenderState[] = []; // todo: later will as a part of shaderData when shader effect frame is OK, that is more powerful and flexible.
-  /** @internal */
-  _priority: number = 0; // todo: temporary resolution of submesh rendering order issue.
 
   private _shaderData: ShaderData = new ShaderData(ShaderDataGroup.Material);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `_priority` property from the `Material` class, enhancing the management of rendering order for submeshes.

- **Refactor**
	- Streamlined the internal state management of the `Material` class while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->