### PR TITLE
Fix animator play backwards error and onStateExit not triggered when crossFade finished and actualDeltaTime error

### DIFF
--- a/e2e/case/animator-play-backwards.ts
+++ b/e2e/case/animator-play-backwards.ts
@@ -1,0 +1,38 @@
+/**
+ * @title Animation Play
+ * @category Animation
+ */
+import { Animator, Camera, DirectLight, GLTFResource, Logger, Vector3, WebGLEngine } from "@galacean/engine";
+import { OrbitControl } from "@galacean/engine-toolkit";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+Logger.enable();
+WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
+  engine.canvas.resizeByClientSize(2);
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+
+  // camera
+  const cameraEntity = rootEntity.createChild("camera_node");
+  cameraEntity.transform.position = new Vector3(0, 1, 5);
+  const camera = cameraEntity.addComponent(Camera);
+  cameraEntity.addComponent(OrbitControl).target = new Vector3(0, 1, 0);
+
+  const lightNode = rootEntity.createChild("light_node");
+  lightNode.addComponent(DirectLight).intensity = 0.6;
+  lightNode.transform.lookAt(new Vector3(0, 0, 1));
+  lightNode.transform.rotate(new Vector3(0, 90, 0));
+
+  engine.resourceManager
+    .load<GLTFResource>("https://gw.alipayobjects.com/os/bmw-prod/5e3c1e4e-496e-45f8-8e05-f89f2bd5e4a4.glb")
+    .then((gltfResource) => {
+      const { defaultSceneRoot } = gltfResource;
+      rootEntity.addChild(defaultSceneRoot);
+      const animator = defaultSceneRoot.getComponent(Animator);
+      animator.findAnimatorState("walk").speed = -1;
+      animator.play("walk");
+      updateForE2E(engine);
+
+      initScreenshot(engine, camera);
+    });
+});

--- a/e2e/case/animator-play-backwards.ts
+++ b/e2e/case/animator-play-backwards.ts
@@ -1,5 +1,5 @@
 /**
- * @title Animation Play
+ * @title Animation Play Backwards
  * @category Animation
  */
 import { Animator, Camera, DirectLight, GLTFResource, Logger, Vector3, WebGLEngine } from "@galacean/engine";

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -45,6 +45,11 @@ export const E2E_CONFIG = {
       caseFileName: "animator-play",
       threshold: 0.1
     },
+    playBackWards: {
+      category: "Animator",
+      caseFileName: "animator-play-backwards",
+      threshold: 0.1
+    },
     playBeforeActive: {
       category: "Animator",
       caseFileName: "animator-play-beforeActive",

--- a/e2e/fixtures/originImage/Animator_animator-play-backwards.jpg
+++ b/e2e/fixtures/originImage/Animator_animator-play-backwards.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36fa8a4c41fd548074285a07586e41f1f44493120ab00e7f6206a5cf33975ed2
+size 44841

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -1451,7 +1451,6 @@ export class Animator extends Component {
       this._callAnimatorScriptOnEnter(state, layerIndex);
     }
     if (lastPlayState !== AnimatorStatePlayState.Finished && playData.playState === AnimatorStatePlayState.Finished) {
-      playData.playState = AnimatorStatePlayState.Finished;
       this._callAnimatorScriptOnExit(state, layerIndex);
     } else {
       this._callAnimatorScriptOnUpdate(state, layerIndex);

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -696,6 +696,7 @@ export class Animator extends Component {
     const crossFadeFinished = crossWeight === 1.0;
 
     if (crossFadeFinished) {
+      srcPlayData.playState = AnimatorStatePlayState.Finished;
       this._preparePlayOwner(layerData, destState);
       this._evaluatePlayingState(destPlayData, weight, additive, aniUpdate);
     } else {
@@ -708,8 +709,7 @@ export class Animator extends Component {
       srcState,
       lastSrcClipTime,
       lastSrcPlayState,
-      srcPlayCostTime,
-      crossFadeFinished
+      srcPlayCostTime
     );
 
     this._fireAnimationEventsAndCallScripts(
@@ -1442,8 +1442,7 @@ export class Animator extends Component {
     state: AnimatorState,
     lastClipTime: number,
     lastPlayState: AnimatorStatePlayState,
-    deltaTime: number,
-    exitByCrossfadeFinish?: boolean
+    deltaTime: number
   ) {
     const { eventHandlers } = playData.stateData;
     eventHandlers.length && this._fireAnimationEvents(playData, eventHandlers, lastClipTime, deltaTime);
@@ -1451,10 +1450,7 @@ export class Animator extends Component {
     if (lastPlayState === AnimatorStatePlayState.UnStarted) {
       this._callAnimatorScriptOnEnter(state, layerIndex);
     }
-    if (
-      lastPlayState !== AnimatorStatePlayState.Finished &&
-      (exitByCrossfadeFinish || playData.playState === AnimatorStatePlayState.Finished)
-    ) {
+    if (lastPlayState !== AnimatorStatePlayState.Finished && playData.playState === AnimatorStatePlayState.Finished) {
       playData.playState = AnimatorStatePlayState.Finished;
       this._callAnimatorScriptOnExit(state, layerIndex);
     } else {

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -684,7 +684,7 @@ export class Animator extends Component {
           : dstPlayDeltaTime;
     }
 
-    const actualCostTime = dstPlaySpeed === 0 ? 0 : dstPlayCostTime / dstPlaySpeed;
+    const actualCostTime = dstPlaySpeed === 0 ? deltaTime : dstPlayCostTime / dstPlaySpeed;
     const srcPlayCostTime = actualCostTime * srcPlaySpeed;
 
     srcPlayData.update(srcPlayCostTime);
@@ -809,7 +809,7 @@ export class Animator extends Component {
           : playDeltaTime;
     }
 
-    const actualCostTime = playSpeed === 0 ? 0 : dstPlayCostTime / playSpeed;
+    const actualCostTime = playSpeed === 0 ? deltaTime : dstPlayCostTime / playSpeed;
 
     destPlayData.update(dstPlayCostTime);
 

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -548,27 +548,25 @@ export class Animator extends Component {
     srcPlayData.update(playDeltaTime);
 
     const { clipTime, isForwards } = srcPlayData;
+    const { transitions } = state;
+    const { anyStateTransitions } = layer.stateMachine;
+
     const transition =
-      this._applyTransitionsByCondition(
-        layerIndex,
-        layerData,
-        layer,
-        state,
-        layer.stateMachine.anyStateTransitions,
-        aniUpdate
-      ) ||
-      this._applyStateTransitions(
-        layerIndex,
-        layerData,
-        layer,
-        isForwards,
-        srcPlayData,
-        state.transitions,
-        lastClipTime,
-        clipTime,
-        playDeltaTime,
-        aniUpdate
-      );
+      (anyStateTransitions.length &&
+        this._applyTransitionsByCondition(layerIndex, layerData, layer, state, anyStateTransitions, aniUpdate)) ||
+      (transitions.length &&
+        this._applyStateTransitions(
+          layerIndex,
+          layerData,
+          layer,
+          isForwards,
+          srcPlayData,
+          transitions,
+          lastClipTime,
+          clipTime,
+          playDeltaTime,
+          aniUpdate
+        ));
 
     let playCostTime: number;
     if (transition) {
@@ -899,28 +897,25 @@ export class Animator extends Component {
     playData.updateOrientation(actualDeltaTime);
 
     const { clipTime, isForwards } = playData;
+    const { transitions } = state;
+    const { anyStateTransitions } = layer.stateMachine;
 
     const transition =
-      this._applyTransitionsByCondition(
-        layerIndex,
-        layerData,
-        layer,
-        state,
-        stateMachine.anyStateTransitions,
-        aniUpdate
-      ) ||
-      this._applyStateTransitions(
-        layerIndex,
-        layerData,
-        layer,
-        isForwards,
-        playData,
-        state.transitions,
-        clipTime,
-        clipTime,
-        actualDeltaTime,
-        aniUpdate
-      );
+      (anyStateTransitions.length &&
+        this._applyTransitionsByCondition(layerIndex, layerData, layer, state, anyStateTransitions, aniUpdate)) ||
+      (transitions.length &&
+        this._applyStateTransitions(
+          layerIndex,
+          layerData,
+          layer,
+          isForwards,
+          playData,
+          transitions,
+          clipTime,
+          clipTime,
+          actualDeltaTime,
+          aniUpdate
+        ));
 
     if (transition) {
       this._updateState(layerIndex, layerData, layer, deltaTime, aniUpdate);

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -708,7 +708,8 @@ export class Animator extends Component {
       srcState,
       lastSrcClipTime,
       lastSrcPlayState,
-      srcPlayCostTime
+      srcPlayCostTime,
+      crossFadeFinished
     );
 
     this._fireAnimationEventsAndCallScripts(
@@ -1441,7 +1442,8 @@ export class Animator extends Component {
     state: AnimatorState,
     lastClipTime: number,
     lastPlayState: AnimatorStatePlayState,
-    deltaTime: number
+    deltaTime: number,
+    exitByCrossfadeFinish?: boolean
   ) {
     const { eventHandlers } = playData.stateData;
     eventHandlers.length && this._fireAnimationEvents(playData, eventHandlers, lastClipTime, deltaTime);
@@ -1449,7 +1451,11 @@ export class Animator extends Component {
     if (lastPlayState === AnimatorStatePlayState.UnStarted) {
       this._callAnimatorScriptOnEnter(state, layerIndex);
     }
-    if (lastPlayState !== AnimatorStatePlayState.Finished && playData.playState === AnimatorStatePlayState.Finished) {
+    if (
+      lastPlayState !== AnimatorStatePlayState.Finished &&
+      (exitByCrossfadeFinish || playData.playState === AnimatorStatePlayState.Finished)
+    ) {
+      playData.playState = AnimatorStatePlayState.Finished;
       this._callAnimatorScriptOnExit(state, layerIndex);
     } else {
       this._callAnimatorScriptOnUpdate(state, layerIndex);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new animator functionality for 3D scene playback in reverse, enhancing user interaction with the animation.
  - Added a configuration option for specifying playback scenarios, allowing for more flexible animation settings.

- **Bug Fixes**
  - Improved transition logic in the animation framework for better performance and clarity.

- **Tests**
  - Extended the test suite to validate animator state transitions and script interactions, ensuring robustness in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->