### PR TITLE
Fix `SpriteMask` clone bug

### DIFF
--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -28,6 +28,7 @@ export class SpriteMask extends Renderer {
   @assignmentClone
   influenceLayers: number = SpriteMaskLayer.Everything;
   /** @internal */
+  @ignoreClone
   _renderElement: RenderElement;
 
   /** @internal */


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `@ignoreClone` decorator to enhance cloning behavior for the `SpriteMask` class, ensuring that the `_renderElement` property is excluded from cloning operations.
  
- **Improvements**
	- Enhanced control over instance duplication and state management, potentially improving performance and preventing unintended effects during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->