### PR TITLE
Fix animation error when set state startTime and transition duration is 0

### DIFF
--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -806,7 +806,7 @@ export class Animator extends Component {
       // The time that has been played
       const playedTime = stateDuration - lastDestClipTime;
       dstPlayCostTime =
-        // -actualDestDeltaTime: The time that will be played, negative are meant to make ite be a periods
+        // -actualDestDeltaTime: The time that will be played, negative are meant to make it be a periods
         // > transition: The time that will be played is enough to finish the transition
         playedTime - playDeltaTime > transitionDuration
           ? // Negative number is used to convert a time period into a reverse deltaTime.

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -895,7 +895,6 @@ export class Animator extends Component {
     deltaTime: number,
     aniUpdate: boolean
   ): void {
-    const { stateMachine } = layer;
     const playData = layerData.srcPlayData;
     const { state } = playData;
     const actualSpeed = state.speed * this.speed;

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -720,6 +720,7 @@ describe("Animator test", function () {
     //@ts-ignore
     stateMachine._anyStateTransitions.length = 0;
     const walkState = animator.findAnimatorState("Run");
+    // For test clipStartTime is not 0 and transition duration is 0
     walkState.clipStartTime = 0.5;
     walkState.addStateMachineScript(
       class extends StateMachineScript {
@@ -730,6 +731,7 @@ describe("Animator test", function () {
     );
     const transition = stateMachine.addAnyStateTransition(animator.findAnimatorState("Run"));
     transition.addCondition(AnimatorConditionMode.Equals, "playRun", 1);
+    // For test clipStartTime is not 0 and transition duration is 0
     transition.duration = 0;
     animator.setParameterValue("playRun", 1);
 
@@ -739,7 +741,7 @@ describe("Animator test", function () {
     animator.update(0.5);
 
     expect(layerData.srcPlayData.state.name).to.eq("Run");
-    // @ts-ignore
     expect(layerData.srcPlayData.frameTime).to.eq(0.5);
+    expect(layerData.srcPlayData.clipTime).to.eq(walkState.clip.length * 0.5 + 0.5);
   });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved animation transition handling for clearer and more efficient playback.
  - Enhanced test cases for the `Animator` component, focusing on component-based architecture and transition validations.

- **Bug Fixes**
  - Clarified logic for calculating play time during transitions, ensuring accurate playback timing.

- **Refactor**
  - Separated transition logic for better readability and maintainability in the animation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->