### PR TITLE
Fix animate property is not effect when reference changed

### DIFF
--- a/e2e/case/animator-referenceAndProperty.ts
+++ b/e2e/case/animator-referenceAndProperty.ts
@@ -1,0 +1,121 @@
+/**
+ * @title Animation Reference And Property
+ * @category Animation
+ */
+
+import {
+  AnimationClip,
+  AnimationColorCurve,
+  AnimationFloatCurve,
+  AnimationRefCurve,
+  Animator,
+  AnimatorController,
+  AnimatorControllerLayer,
+  BlinnPhongMaterial,
+  Camera,
+  Color,
+  DirectLight,
+  Keyframe,
+  Logger,
+  Material,
+  MeshRenderer,
+  PBRMaterial,
+  PrimitiveMesh,
+  RenderFace,
+  Transform,
+  Vector3,
+  WebGLEngine
+} from "@galacean/engine";
+import { OrbitControl } from "@galacean/engine-toolkit";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+Logger.enable();
+WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
+  engine.canvas.resizeByClientSize(2);
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+
+  // camera
+  const cameraEntity = rootEntity.createChild("camera_node");
+  cameraEntity.transform.position = new Vector3(0, 1, 5);
+  const camera = cameraEntity.addComponent(Camera);
+  cameraEntity.addComponent(OrbitControl).target = new Vector3(0, 1, 0);
+
+  const lightNode = rootEntity.createChild("light_node");
+  lightNode.addComponent(DirectLight).intensity = 0.6;
+  lightNode.transform.lookAt(new Vector3(0, 0, 1));
+  lightNode.transform.rotate(new Vector3(0, 90, 0));
+
+  const material = new BlinnPhongMaterial(engine);
+  material.renderFace = RenderFace.Double;
+  material.baseColor = new Color(1, 0, 0, 1);
+
+  const material2 = new PBRMaterial(engine);
+  material2.renderFace = RenderFace.Double;
+  material2.baseColor = new Color(0, 1, 0, 1);
+
+  const entity = rootEntity.createChild("mesh");
+  const { transform } = entity;
+  transform.setPosition(0, 1, 0);
+  transform.setRotation(0, 0, 0);
+  const meshRenderer = entity.addComponent(MeshRenderer);
+  meshRenderer.mesh = PrimitiveMesh.createCuboid(engine);
+  meshRenderer.setMaterial(material);
+
+  const animator = entity.addComponent(Animator);
+  const controller = new AnimatorController(engine);
+  const layer = new AnimatorControllerLayer("base");
+  controller.addLayer(layer);
+  const stateMachine = layer.stateMachine;
+  const cubeState = stateMachine.addState("material");
+  const cubeClip = (cubeState.clip = new AnimationClip("material"));
+
+  const materialCurve = new AnimationRefCurve();
+  const key1 = new Keyframe<Material>();
+  key1.time = 0;
+  key1.value = material;
+  const key2 = new Keyframe<Material>();
+  key2.time = 1;
+  key2.value = material2;
+  const key3 = new Keyframe<Material>();
+  key3.time = 2;
+  key3.value = material;
+  materialCurve.addKey(key1);
+  materialCurve.addKey(key2);
+  materialCurve.addKey(key3);
+
+  const colorCurve = new AnimationColorCurve();
+  const key6 = new Keyframe<Color>();
+  key6.time = 0;
+  key6.value = new Color(1, 0, 0, 1);
+  const key7 = new Keyframe<Color>();
+  key7.time = 1;
+  key7.value = new Color(0.5, 0.5, 0.5, 1);
+  const key8 = new Keyframe<Color>();
+  key8.time = 2;
+  key8.value = new Color(1, 0, 0, 1);
+  colorCurve.addKey(key6);
+  colorCurve.addKey(key7);
+  colorCurve.addKey(key8);
+
+  const rotateCurve = new AnimationFloatCurve();
+  const key9 = new Keyframe<number>();
+  key9.time = 0;
+  key9.value = 0;
+  const key10 = new Keyframe<number>();
+  key10.time = 2;
+  key10.value = 360;
+  rotateCurve.addKey(key9);
+  rotateCurve.addKey(key10);
+
+  cubeClip.addCurveBinding("", MeshRenderer, "getMaterial().baseColor", colorCurve);
+  cubeClip.addCurveBinding("", MeshRenderer, "setMaterial($value)", "getMaterial()", materialCurve);
+  cubeClip.addCurveBinding("", Transform, "rotation.y", rotateCurve);
+  animator.animatorController = controller;
+  animator.play("material");
+  animator.speed = 0.5;
+
+  updateForE2E(engine, 130);
+
+  initScreenshot(engine, camera);
+});

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -69,6 +69,11 @@ export const E2E_CONFIG = {
       category: "Animator",
       caseFileName: "animator-stateMachine",
       threshold: 0.1
+    },
+    referenceAndProperty: {
+      category: "Animator",
+      caseFileName: "animator-referenceAndProperty",
+      threshold: 0.1
     }
   },
   GLTF: {

--- a/e2e/fixtures/originImage/Animator_animator-referenceAndProperty.jpg
+++ b/e2e/fixtures/originImage/Animator_animator-referenceAndProperty.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d8ff1307881657731eb7e0abd6f1e721f3086b27480c9dfb7145cf4b1f4cfb5
+size 20528

--- a/packages/core/src/animation/AnimationClipCurveBinding.ts
+++ b/packages/core/src/animation/AnimationClipCurveBinding.ts
@@ -4,6 +4,7 @@ import { KeyframeValueType } from "./Keyframe";
 import { AnimationCurve } from "./animationCurve";
 import { IAnimationCurveCalculator } from "./animationCurve/interfaces/IAnimationCurveCalculator";
 import { AnimationCurveLayerOwner } from "./internal/AnimationCurveLayerOwner";
+import { AnimationPropertyReferenceManager } from "./internal/AnimationPropertyReferenceManager";
 import { AnimationCurveOwner } from "./internal/animationCurveOwner/AnimationCurveOwner";
 
 /**
@@ -33,14 +34,28 @@ export class AnimationClipCurveBinding {
   /** The animation curve. */
   curve: AnimationCurve<KeyframeValueType>;
 
+  /** @internal */
+  _pathLength: number;
   private _tempCurveOwner: Record<number, AnimationCurveOwner<KeyframeValueType>> = {};
 
   /**
    * @internal
    */
-  _createCurveOwner(entity: Entity, component: Component): AnimationCurveOwner<KeyframeValueType> {
+  _createCurveOwner(
+    referenceManager: AnimationPropertyReferenceManager,
+    entity: Entity,
+    component: Component
+  ): AnimationCurveOwner<KeyframeValueType> {
     const curveType = (<unknown>this.curve.constructor) as IAnimationCurveCalculator<KeyframeValueType>;
-    const owner = new AnimationCurveOwner(entity, this.type, component, this.property, this.getProperty, curveType);
+    const owner = new AnimationCurveOwner(
+      referenceManager,
+      entity,
+      this.type,
+      component,
+      this.property,
+      this.getProperty,
+      curveType
+    );
     curveType._initializeOwner(owner);
     owner.saveDefaultValue();
     return owner;
@@ -62,10 +77,14 @@ export class AnimationClipCurveBinding {
   /**
    * @internal
    */
-  _getTempCurveOwner(entity: Entity, component: Component): AnimationCurveOwner<KeyframeValueType> {
+  _getTempCurveOwner(
+    referenceManager: AnimationPropertyReferenceManager,
+    entity: Entity,
+    component: Component
+  ): AnimationCurveOwner<KeyframeValueType> {
     const { instanceId } = entity;
     if (!this._tempCurveOwner[instanceId]) {
-      this._tempCurveOwner[instanceId] = this._createCurveOwner(entity, component);
+      this._tempCurveOwner[instanceId] = this._createCurveOwner(referenceManager, entity, component);
     }
     return this._tempCurveOwner[instanceId];
   }

--- a/packages/core/src/animation/animationCurve/AnimationFloatArrayCurve.ts
+++ b/packages/core/src/animation/animationCurve/AnimationFloatArrayCurve.ts
@@ -19,7 +19,7 @@ export class AnimationFloatArrayCurve extends AnimationCurve<Float32Array> {
    * @internal
    */
   static _initializeOwner(owner: AnimationCurveOwner<Float32Array>): void {
-    const size = owner.referenceTargetValue.length;
+    const size = owner._assembler.getTargetValue().length;
     owner.defaultValue = new Float32Array(size);
     owner.fixedPoseValue = new Float32Array(size);
     owner.baseEvaluateData.value = new Float32Array(size);
@@ -30,7 +30,7 @@ export class AnimationFloatArrayCurve extends AnimationCurve<Float32Array> {
    * @internal
    */
   static _initializeLayerOwner(owner: AnimationCurveLayerOwner): void {
-    const size = (<Float32Array>owner.curveOwner.referenceTargetValue).length;
+    const size = (<Float32Array>owner.curveOwner._assembler.getTargetValue()).length;
     owner.finalValue = new Float32Array(size);
   }
 

--- a/packages/core/src/animation/internal/AnimationPropertyReference.ts
+++ b/packages/core/src/animation/internal/AnimationPropertyReference.ts
@@ -1,5 +1,8 @@
 import { AnimationPropertyReferenceManager } from "./AnimationPropertyReferenceManager";
 
+/**
+ * @internal
+ */
 export abstract class AnimationPropertyReference {
   manager: AnimationPropertyReferenceManager;
   parseFlag: MountedParseFlag;
@@ -38,6 +41,9 @@ export abstract class AnimationPropertyReference {
   abstract setValue(value: any): void;
 }
 
+/**
+ * @internal
+ */
 export class ComponentReference extends AnimationPropertyReference {
   getValue() {
     return this.value;
@@ -48,6 +54,9 @@ export class ComponentReference extends AnimationPropertyReference {
   }
 }
 
+/**
+ * @internal
+ */
 export class PropertyReference extends AnimationPropertyReference {
   property: string;
 
@@ -81,6 +90,9 @@ export class PropertyReference extends AnimationPropertyReference {
   }
 }
 
+/**
+ * @internal
+ */
 export class MethodReference extends AnimationPropertyReference {
   methodName: string;
   args: any[];
@@ -121,6 +133,9 @@ export class MethodReference extends AnimationPropertyReference {
   }
 }
 
+/**
+ * @internal
+ */
 export class ArrayReference extends AnimationPropertyReference {
   property: string;
   arrayIndex: number;
@@ -152,6 +167,9 @@ export class ArrayReference extends AnimationPropertyReference {
   }
 }
 
+/**
+ * @internal
+ */
 export enum MountedParseFlag {
   Get = 0x1,
   Set = 0x2,

--- a/packages/core/src/animation/internal/AnimationPropertyReference.ts
+++ b/packages/core/src/animation/internal/AnimationPropertyReference.ts
@@ -1,0 +1,159 @@
+import { AnimationPropertyReferenceManager } from "./AnimationPropertyReferenceManager";
+
+export abstract class AnimationPropertyReference {
+  manager: AnimationPropertyReferenceManager;
+  parseFlag: MountedParseFlag;
+  invDependencies = new Array<number>();
+  value: any;
+  index: number;
+
+  private _parent: AnimationPropertyReference;
+  private _dirty = true;
+
+  get dirty(): boolean {
+    return this._dirty;
+  }
+
+  set dirty(value: boolean) {
+    this._dirty = value;
+    if (value) {
+      for (let i = 0; i < this.invDependencies.length; i++) {
+        const index = this.invDependencies[i];
+        const reference = this.manager.animationPropertyReferences[index];
+        reference.dirty = true;
+      }
+    }
+  }
+
+  get parent(): AnimationPropertyReference {
+    return this._parent;
+  }
+
+  set parent(dependence: AnimationPropertyReference) {
+    this._parent = dependence;
+    dependence.invDependencies.push(this.index);
+  }
+
+  abstract getValue(): any;
+  abstract setValue(value: any): void;
+}
+
+export class ComponentReference extends AnimationPropertyReference {
+  getValue() {
+    return this.value;
+  }
+
+  setValue(value: any) {
+    this.value = value;
+  }
+}
+
+export class PropertyReference extends AnimationPropertyReference {
+  property: string;
+
+  constructor(propertyStr: string) {
+    super();
+    this.property = propertyStr;
+  }
+
+  getValue() {
+    const dependence = this.parent;
+
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+
+    if (this.dirty) {
+      this.value = dependence.value[this.property];
+      this.dirty = false;
+    }
+    return this.value;
+  }
+
+  setValue(value: any) {
+    const dependence = this.parent;
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+
+    this.value = dependence.value[this.property] = value;
+    this.dirty = true;
+  }
+}
+
+export class MethodReference extends AnimationPropertyReference {
+  methodName: string;
+  args: any[];
+  replaceValueIndex: number;
+
+  constructor(propertyStr: string) {
+    super();
+    this.methodName = propertyStr.slice(0, propertyStr.indexOf("("));
+    this.args = propertyStr
+      .match(/\w+\(([^)]*)\)/)[1]
+      .split(",")
+      .map((arg) => arg.trim().replace(/['"]+/g, ""))
+      .filter((arg) => arg !== "");
+    this.replaceValueIndex = this.args.indexOf("$value");
+  }
+
+  getValue() {
+    const dependence = this.parent;
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+    this.value = dependence.value[this.methodName].apply(dependence.value, this.args);
+    this.dirty = false;
+    return this.value;
+  }
+
+  setValue(value: any) {
+    const dependence = this.parent;
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+    const args = this.args;
+    if (this.replaceValueIndex >= 0) {
+      args[this.replaceValueIndex] = value;
+    }
+    dependence.value[this.methodName].apply(dependence.value, args);
+    this.dirty = true;
+  }
+}
+
+export class ArrayReference extends AnimationPropertyReference {
+  property: string;
+  arrayIndex: number;
+
+  constructor(propertyStr: string) {
+    super();
+    const indexPos = propertyStr.indexOf("[");
+    this.property = propertyStr.slice(0, indexPos);
+    this.arrayIndex = parseInt(propertyStr.slice(indexPos + 1, -1));
+  }
+
+  getValue() {
+    const dependence = this.parent;
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+    this.value = dependence.value[this.property][this.arrayIndex];
+    this.dirty = false;
+    return this.value;
+  }
+
+  setValue(value: any) {
+    const dependence = this.parent;
+    if (dependence.dirty) {
+      dependence.getValue();
+    }
+    dependence.value[this.property][this.arrayIndex] = value;
+    this.dirty = true;
+  }
+}
+
+export enum MountedParseFlag {
+  Get = 0x1,
+  Set = 0x2,
+  Both = 0x3
+}

--- a/packages/core/src/animation/internal/AnimationPropertyReferenceManager.ts
+++ b/packages/core/src/animation/internal/AnimationPropertyReferenceManager.ts
@@ -1,0 +1,82 @@
+import { Component } from "../../Component";
+import {
+  AnimationPropertyReference,
+  ArrayReference,
+  ComponentReference,
+  MethodReference,
+  MountedParseFlag,
+  PropertyReference
+} from "./AnimationPropertyReference";
+
+/**
+ * @internal
+ */
+export class AnimationPropertyReferenceManager {
+  animationPropertyReferences: AnimationPropertyReference[] = [];
+
+  private _referenceIndexMap: Map<string | Component, AnimationPropertyReference> = new Map();
+  private _subProperties = new Array<string>();
+
+  addReference(component: Component, propertyStr: string, parseFlag: MountedParseFlag): AnimationPropertyReference {
+    const instanceId = component.instanceId;
+
+    let reference: AnimationPropertyReference;
+
+    const existedReference = this._referenceIndexMap.get(component);
+    if (existedReference) {
+      reference = existedReference;
+    } else {
+      reference = new ComponentReference();
+      reference.manager = this;
+      reference.value = component;
+    }
+
+    const properties = propertyStr.split(".");
+    const endIndex = properties.length - 1;
+
+    const subProperties = this._subProperties;
+    subProperties.length = 0;
+
+    for (let i = 0; i <= endIndex; i++) {
+      const property = properties[i];
+      subProperties.push(property);
+      const uniqueKey = `${instanceId}-${subProperties.join(".")}`;
+      const existReference = this._referenceIndexMap.get(uniqueKey);
+      if (existReference) {
+        reference = existReference;
+        continue;
+      }
+
+      const parent = reference;
+
+      if (property.indexOf("[") > -1) {
+        // is array
+        reference = new ArrayReference(property);
+      } else if (property.endsWith(")")) {
+        // is method
+        reference = new MethodReference(property);
+      } else {
+        // is property
+        reference = new PropertyReference(property);
+      }
+
+      reference.manager = this;
+      reference.index = this.animationPropertyReferences.length;
+      reference.parent = parent;
+
+      // Get the value once when initializing to improve runtime performance
+      if (parseFlag & MountedParseFlag.Get) {
+        reference.getValue();
+      }
+      this._referenceIndexMap.set(uniqueKey, reference);
+      this.animationPropertyReferences.push(reference);
+    }
+
+    return reference;
+  }
+
+  clear() {
+    this.animationPropertyReferences.length = 0;
+    this._referenceIndexMap.clear();
+  }
+}

--- a/packages/core/src/animation/internal/AnimationPropertyReferenceManager.ts
+++ b/packages/core/src/animation/internal/AnimationPropertyReferenceManager.ts
@@ -14,7 +14,7 @@ import {
 export class AnimationPropertyReferenceManager {
   animationPropertyReferences: AnimationPropertyReference[] = [];
 
-  private _referenceIndexMap: Map<string | Component, AnimationPropertyReference> = new Map();
+  private _referenceIndexMap: Map<string | number, AnimationPropertyReference> = new Map();
   private _subProperties = new Array<string>();
 
   addReference(component: Component, propertyStr: string, parseFlag: MountedParseFlag): AnimationPropertyReference {
@@ -22,13 +22,14 @@ export class AnimationPropertyReferenceManager {
 
     let reference: AnimationPropertyReference;
 
-    const existedReference = this._referenceIndexMap.get(component);
+    const existedReference = this._referenceIndexMap.get(instanceId);
     if (existedReference) {
       reference = existedReference;
     } else {
       reference = new ComponentReference();
       reference.manager = this;
       reference.value = component;
+      this._referenceIndexMap.set(instanceId, reference);
     }
 
     const properties = propertyStr.split(".");

--- a/packages/core/src/animation/internal/animationCurveOwner/assembler/UniversalAnimationCurveOwnerAssembler.ts
+++ b/packages/core/src/animation/internal/animationCurveOwner/assembler/UniversalAnimationCurveOwnerAssembler.ts
@@ -8,20 +8,18 @@ import { IAnimationCurveOwnerAssembler } from "./IAnimationCurveOwnerAssembler";
  * @internal
  */
 export class UniversalAnimationCurveOwnerAssembler implements IAnimationCurveOwnerAssembler<KeyframeValueType> {
-  getReference: AnimationPropertyReference;
-  setReference: AnimationPropertyReference;
-  referenceManager: AnimationPropertyReferenceManager;
+  private _getReference: AnimationPropertyReference;
+  private _setReference: AnimationPropertyReference;
 
   initialize(owner: AnimationCurveOwner<KeyframeValueType>): void {
     const { referenceManager } = owner;
-    this.referenceManager = referenceManager;
 
     if (owner.getProperty) {
-      this.getReference = referenceManager.addReference(owner.component, owner.getProperty, MountedParseFlag.Get);
-      this.setReference = referenceManager.addReference(owner.component, owner.property, MountedParseFlag.Set);
-      this.setReference.invDependencies.push(this.getReference.index);
+      this._getReference = referenceManager.addReference(owner.component, owner.getProperty, MountedParseFlag.Get);
+      this._setReference = referenceManager.addReference(owner.component, owner.property, MountedParseFlag.Set);
+      this._setReference.invDependencies.push(this._getReference.index);
     } else {
-      this.getReference = this.setReference = referenceManager.addReference(
+      this._getReference = this._setReference = referenceManager.addReference(
         owner.component,
         owner.property,
         MountedParseFlag.Both
@@ -30,10 +28,10 @@ export class UniversalAnimationCurveOwnerAssembler implements IAnimationCurveOwn
   }
 
   getTargetValue(): KeyframeValueType {
-    return this.getReference.getValue();
+    return this._getReference.getValue();
   }
 
   setTargetValue(value: KeyframeValueType): void {
-    this.setReference.setValue(value);
+    this._setReference.setValue(value);
   }
 }

--- a/packages/core/src/animation/internal/animationCurveOwner/assembler/UniversalAnimationCurveOwnerAssembler.ts
+++ b/packages/core/src/animation/internal/animationCurveOwner/assembler/UniversalAnimationCurveOwnerAssembler.ts
@@ -1,4 +1,6 @@
 import { KeyframeValueType } from "../../../Keyframe";
+import { AnimationPropertyReference, MountedParseFlag } from "../../AnimationPropertyReference";
+import { AnimationPropertyReferenceManager } from "../../AnimationPropertyReferenceManager";
 import { AnimationCurveOwner } from "../AnimationCurveOwner";
 import { IAnimationCurveOwnerAssembler } from "./IAnimationCurveOwnerAssembler";
 
@@ -6,142 +8,32 @@ import { IAnimationCurveOwnerAssembler } from "./IAnimationCurveOwnerAssembler";
  * @internal
  */
 export class UniversalAnimationCurveOwnerAssembler implements IAnimationCurveOwnerAssembler<KeyframeValueType> {
-  private _getMounted: Record<string, KeyframeValueType | Function>;
-  private _setMounted: Record<string, KeyframeValueType | Function>;
-
-  private _getType: HandleType;
-  private _setType: HandleType;
-
-  private _getValueName: string;
-  private _setValueName: string;
-
-  private _getArgs: any[];
-  private _setArgs: any[];
-  private _replaceValueIndex: number;
-
-  private _getArrayIndex: number;
-  private _setArrayIndex: number;
+  getReference: AnimationPropertyReference;
+  setReference: AnimationPropertyReference;
+  referenceManager: AnimationPropertyReferenceManager;
 
   initialize(owner: AnimationCurveOwner<KeyframeValueType>): void {
-    let mounted = owner.component;
-
-    const setProperties = owner.property.split(".");
+    const { referenceManager } = owner;
+    this.referenceManager = referenceManager;
 
     if (owner.getProperty) {
-      const getProperties = owner.getProperty.split(".");
-      this._initializeMounted(mounted, getProperties, MountedParseFlag.Get);
-      this._initializeMounted(mounted, setProperties, MountedParseFlag.Set);
+      this.getReference = referenceManager.addReference(owner.component, owner.getProperty, MountedParseFlag.Get);
+      this.setReference = referenceManager.addReference(owner.component, owner.property, MountedParseFlag.Set);
+      this.setReference.invDependencies.push(this.getReference.index);
     } else {
-      this._initializeMounted(mounted, setProperties, MountedParseFlag.Both);
+      this.getReference = this.setReference = referenceManager.addReference(
+        owner.component,
+        owner.property,
+        MountedParseFlag.Both
+      );
     }
   }
 
   getTargetValue(): KeyframeValueType {
-    switch (this._getType) {
-      case HandleType.Array:
-        return this._getMounted[this._getArrayIndex] as KeyframeValueType;
-      case HandleType.Method:
-        return (this._getMounted[this._getValueName] as Function).apply(this._getMounted, this._getArgs);
-      case HandleType.Property:
-        return this._getMounted[this._getValueName] as KeyframeValueType;
-    }
+    return this.getReference.getValue();
   }
 
   setTargetValue(value: KeyframeValueType): void {
-    switch (this._setType) {
-      case HandleType.Array:
-        this._setMounted[this._setArrayIndex] = value;
-        break;
-      case HandleType.Method:
-        const args = this._setArgs;
-        args[this._replaceValueIndex] = value;
-        (this._setMounted[this._setValueName] as Function).apply(this._setMounted, args);
-        break;
-      case HandleType.Property:
-        this._setMounted[this._setValueName] = value;
-        break;
-    }
+    this.setReference.setValue(value);
   }
-
-  private _initializeMounted(mounted: any, properties: string[], parseFlag: MountedParseFlag): void {
-    const endIndex = properties.length - 1;
-    for (let i = 0; i < endIndex; i++) {
-      const property = properties[i];
-      if (property.indexOf("[") > -1) {
-        // is array
-        const indexPos = property.indexOf("[");
-        mounted = mounted[property.slice(0, indexPos)];
-        mounted = mounted[parseInt(property.slice(indexPos + 1, -1))];
-      } else if (property.endsWith(")")) {
-        // is method
-        const methodName = property.slice(0, property.indexOf("("));
-        const args = property
-          .match(/\w+\(([^)]*)\)/)[1]
-          .split(",")
-          .map((arg) => arg.trim().replace(/['"]+/g, ""))
-          .filter((arg) => arg !== "");
-        mounted = mounted[methodName].apply(mounted, args);
-      } else {
-        // is property
-        mounted = mounted[property];
-      }
-    }
-
-    const property = properties[endIndex];
-
-    let handleType: HandleType;
-    let arrayIndex: number;
-    let methodName: string;
-    let args: any[];
-
-    if (property.indexOf("[") > -1) {
-      const indexPos = property.indexOf("[");
-      handleType = HandleType.Array;
-      mounted = mounted[property.slice(0, indexPos)];
-      arrayIndex = parseInt(property.slice(indexPos + 1, -1));
-    } else if (property.endsWith(")")) {
-      methodName = property.slice(0, property.indexOf("("));
-      args = property
-        .match(/\w+\(([^)]*)\)/)[1]
-        .split(",")
-        .map((arg) => arg.trim().replace(/['"]+/g, ""))
-        .filter((arg) => arg !== "");
-      handleType = HandleType.Method;
-      if (parseFlag & MountedParseFlag.Set) {
-        const index = args.indexOf("$value");
-        this._replaceValueIndex = index > -1 ? index : args.length;
-      }
-    } else {
-      handleType = HandleType.Property;
-    }
-
-    if (parseFlag & MountedParseFlag.Set) {
-      this._setMounted = mounted;
-      this._setType = handleType;
-      this._setArrayIndex = arrayIndex;
-      this._setValueName = property;
-      methodName && (this._setValueName = methodName);
-      this._setArgs = args;
-    }
-    if (parseFlag & MountedParseFlag.Get) {
-      this._getMounted = mounted;
-      this._getType = handleType;
-      this._getArrayIndex = arrayIndex;
-      this._getValueName = property;
-      methodName && (this._getValueName = methodName);
-      this._getArgs = args;
-    }
-  }
-}
-
-enum HandleType {
-  Property,
-  Method,
-  Array
-}
-
-enum MountedParseFlag {
-  Get = 0x1,
-  Set = 0x2,
-  Both = 0x3
 }

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -137,7 +137,7 @@ describe("Animator test", function () {
     animator.update(5);
     const curveOwner = srcPlayData.stateData.curveLayerOwner[0].curveOwner;
     const initValue = curveOwner.defaultValue;
-    const currentValue = curveOwner.referenceTargetValue;
+    const currentValue = curveOwner._assembler.getTargetValue();
     expect(Quaternion.equals(initValue, currentValue)).to.eq(true);
 
     animator.cullingMode = 0;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an animation system for material properties and transformations in a 3D engine.
	- Enhanced configurability for animator cases with new configuration entries.

- **Bug Fixes**
	- Improved efficiency in animation sampling and property reference management.

- **Refactor**
	- Streamlined logic for managing animation property references and curve bindings.

- **Tests**
	- Updated tests to encapsulate value retrieval for curve owners, enhancing maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->