### PR TITLE
Add `shadowNearPlaneOffset` property in `DirectLight`

### DIFF
--- a/packages/core/src/lighting/DirectLight.ts
+++ b/packages/core/src/lighting/DirectLight.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix, Vector3 } from "@galacean/engine-math";
+import { Color, Vector3 } from "@galacean/engine-math";
 import { ColorSpace } from "../enums/ColorSpace";
 import { ShaderData } from "../shader";
 import { ShaderProperty } from "../shader/ShaderProperty";
@@ -21,6 +21,12 @@ export class DirectLight extends Light {
     shaderData.setFloatArray(DirectLight._directionProperty, data.direction);
   }
 
+  /**
+   * The offset distance in the opposite direction of light direction when generating shadows.
+   * @remarks Increasing this value can avoid the holes in the shadow caused by low polygon models.
+   */
+  shadowNearPlaneOffset = 0.1;
+
   private _reverseDirection: Vector3 = new Vector3();
 
   /**
@@ -36,13 +42,6 @@ export class DirectLight extends Light {
   get reverseDirection(): Vector3 {
     Vector3.scale(this.direction, -1, this._reverseDirection);
     return this._reverseDirection;
-  }
-
-  /**
-   * @internal
-   */
-  override get _shadowProjectionMatrix(): Matrix {
-    throw "Unknown!";
   }
 
   /**

--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -23,7 +23,11 @@ export abstract class Light extends Component {
   shadowBias = 1;
   /** Shadow mapping normal-based bias. */
   shadowNormalBias = 1;
-  /** Near plane value to use for shadow frustums. */
+
+  /**
+   * @deprecated
+   * Please use `shadowNearPlaneOffset` instead.
+   */
   shadowNearPlane = 0.1;
 
   /** @internal */
@@ -76,11 +80,6 @@ export abstract class Light extends Component {
     Matrix.invert(this.viewMatrix, this._inverseViewMat);
     return this._inverseViewMat;
   }
-
-  /**
-   * @internal
-   */
-  abstract get _shadowProjectionMatrix(): Matrix;
 
   /**
    * Light Color, include intensity.

--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix, Vector3 } from "@galacean/engine-math";
+import { Color, Vector3 } from "@galacean/engine-math";
 import { ColorSpace } from "../enums/ColorSpace";
 import { ShaderData } from "../shader";
 import { ShaderProperty } from "../shader/ShaderProperty";
@@ -31,13 +31,6 @@ export class PointLight extends Light {
    */
   get position(): Vector3 {
     return this.entity.transform.worldPosition;
-  }
-
-  /**
-   * @internal
-   */
-  override get _shadowProjectionMatrix(): Matrix {
-    throw "Unknown!";
   }
 
   /**

--- a/packages/core/src/lighting/SpotLight.ts
+++ b/packages/core/src/lighting/SpotLight.ts
@@ -64,16 +64,6 @@ export class SpotLight extends Light {
   /**
    * @internal
    */
-  override get _shadowProjectionMatrix(): Matrix {
-    const matrix = this._projectMatrix;
-    const fov = Math.min(Math.PI / 2, this.angle * 2 * Math.sqrt(2));
-    Matrix.perspective(fov, 1, this.shadowNearPlane, this.distance + this.shadowNearPlane, matrix);
-    return matrix;
-  }
-
-  /**
-   * @internal
-   */
   _appendData(lightIndex: number, data: ISpotLightShaderData): void {
     const cullingMaskStart = lightIndex * 2;
     const colorStart = lightIndex * 3;

--- a/packages/core/src/shadow/CascadedShadowCasterPass.ts
+++ b/packages/core/src/shadow/CascadedShadowCasterPass.ts
@@ -187,7 +187,7 @@ export class CascadedShadowCasterPass extends PipelinePass {
         lightSide,
         lightForward,
         j,
-        light.shadowNearPlane,
+        light.shadowNearPlaneOffset,
         shadowTileResolution,
         shadowSliceData,
         shadowMatrices


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `shadowNearPlaneOffset`, to enhance shadow generation and reduce artifacts in low polygon models.
  
- **Deprecations**
	- Marked the `shadowNearPlane` property as deprecated, advising users to transition to `shadowNearPlaneOffset`.

- **Bug Fixes**
	- Removed problematic getter methods that previously caused errors when accessed, improving overall stability in shadow calculations. 

These changes aim to enhance the lighting and shadow rendering capabilities within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->