### PR TITLE
Fix error when the animationEvent loses the callback function with the given name

### DIFF
--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -406,7 +406,7 @@ export class Animator extends Component {
         handlers.length = 0;
         for (let j = scriptCount - 1; j >= 0; j--) {
           const script = scripts[j];
-          const handler = <Function>script[funcName].bind(script);
+          const handler = <Function>script[funcName]?.bind(script);
           handler && handlers.push(handler);
         }
         eventHandlers.push(eventHandler);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the animation event system to prevent runtime errors when binding functions.
  
- **Refactor**
	- Enhanced the robustness of the `Animator` class without altering its fundamental behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->