### PR TITLE
Clear the `ShaderProgramPool` cached on the Engine object when destroy shaderPass

### DIFF
--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -345,7 +345,7 @@ export class Shader implements IReferable {
     for (let i = 0, n = subShaders.length; i < n; i++) {
       const passes = subShaders[i].passes;
       for (let j = 0, m = passes.length; j < m; j++) {
-        passes[j]._destroy();
+        passes[j]._clearShaderProgramPool();
       }
     }
 

--- a/packages/core/src/shader/ShaderPass.ts
+++ b/packages/core/src/shader/ShaderPass.ts
@@ -143,12 +143,15 @@ export class ShaderPass extends ShaderPart {
   /**
    * @internal
    */
-  _destroy(): void {
+  _clearShaderProgramPool(engine?: Engine): void {
     const shaderProgramPools = this._shaderProgramPools;
     for (let i = 0, n = shaderProgramPools.length; i < n; i++) {
       shaderProgramPools[i]._destroy();
     }
     shaderProgramPools.length = 0;
+    if (engine) {
+      delete engine._shaderProgramPools[this._shaderPassId];
+    }
   }
 
   /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- When `ShaderPass._destroy` is called, `ShaderPass._getShaderProgram` can still got the cached `ShaderProgram` from `Engine`. The PR fix it.
- Maybe `_clearShaderProgramPool` is a better name than `_destroy` under current situation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more efficient shader resource management process.
	- Simplified the instantiation of `ShaderPass` objects with a consolidated constructor.

- **Deprecations**
	- Marked `getMacroByName` and `getPropertyByName` methods as deprecated, encouraging users to adopt new access methods.

- **Bug Fixes**
	- Enhanced the functionality of shader program pool management in the `ShaderPass` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->