### PR TITLE
Add function copy to vector link object for vector

### DIFF
--- a/packages/math/src/Color.ts
+++ b/packages/math/src/Color.ts
@@ -259,6 +259,19 @@ export class Color implements IClone<Color>, ICopy<ColorLike, Color> {
   }
 
   /**
+   * Copy to color like object.
+   * @param target - Color like object.
+   * @returns This Color like object
+   */
+  copyTo(target: ColorLike): ColorLike {
+    target.r = this._r;
+    target.g = this._g;
+    target.b = this._b;
+    target.a = this._a;
+    return target;
+  }
+
+  /**
    * Copy from array like object.
    * @param source - Array like object
    * @param offset - The start offset

--- a/packages/math/src/ICopy.ts
+++ b/packages/math/src/ICopy.ts
@@ -7,4 +7,10 @@ export interface ICopy<S, T> {
    * @returns This object
    */
   copyFrom(source: S): T;
+
+  /**
+   * Copy to target object.
+   * @returns This target object
+   */
+  copyTo?(target: S): S;
 }

--- a/packages/math/src/Quaternion.ts
+++ b/packages/math/src/Quaternion.ts
@@ -731,6 +731,19 @@ export class Quaternion implements IClone<Quaternion>, ICopy<QuaternionLike, Qua
   }
 
   /**
+   * Copy this quaternion to the specified quaternion.
+   * @param target - The specified quaternion
+   * @returns This specified quaternion
+   */
+  copyTo(target: QuaternionLike): QuaternionLike {
+    target.x = this._x;
+    target.y = this._y;
+    target.z = this._z;
+    target.w = this._w;
+    return target;
+  }
+
+  /**
    * Copy the value of this quaternion from an array.
    * @param array - The array
    * @param offset - The start offset of the array

--- a/packages/math/src/Vector2.ts
+++ b/packages/math/src/Vector2.ts
@@ -353,6 +353,17 @@ export class Vector2 implements IClone<Vector2>, ICopy<Vector2Like, Vector2> {
   }
 
   /**
+   * Copy to vector2 like object.
+   * @param target - Vector2 like object
+   * @returns This Vector2 like object
+   */
+  copyTo(target: Vector2Like): Vector2Like {
+    target.x = this._x;
+    target.y = this._y;
+    return target;
+  }
+
+  /**
    * Copy the value of this vector from an array.
    * @param array - The array
    * @param offset - The start offset of the array

--- a/packages/math/src/Vector3.ts
+++ b/packages/math/src/Vector3.ts
@@ -562,6 +562,18 @@ export class Vector3 implements IClone<Vector3>, ICopy<Vector3Like, Vector3> {
   }
 
   /**
+   * Copy to vector3 like object.
+   * @param target - Vector3 like object
+   * @returns This Vector3 like object
+   */
+  copyTo(target: Vector3Like): Vector3Like {
+    target.x = this._x;
+    target.y = this._y;
+    target.z = this._z;
+    return target;
+  }
+
+  /**
    * Copy the value of this vector from an array.
    * @param array - The array
    * @param offset - The start offset of the array

--- a/packages/math/src/Vector4.ts
+++ b/packages/math/src/Vector4.ts
@@ -478,6 +478,19 @@ export class Vector4 implements IClone<Vector4>, ICopy<Vector4Like, Vector4> {
   }
 
   /**
+   * Copy to vector4 like object.
+   * @param target - Vector4 like object
+   * @returns This Vector4 like object
+   */
+  copyTo(target: Vector4Like): Vector4Like {
+    target.x = this._x;
+    target.y = this._y;
+    target.z = this._z;
+    target.w = this._w;
+    return target;
+  }
+
+  /**
    * Copy the value of this vector by an array.
    * @param array - The array
    * @param offset - The start offset of the array

--- a/tests/src/math/Color.test.ts
+++ b/tests/src/math/Color.test.ts
@@ -58,6 +58,14 @@ describe("Color test", () => {
     expect(Color.equals(a, out)).to.eq(true);
   });
 
+  it("copyTo", () => {
+    const a = new Color(1, 0, 0, 1);
+    const out = new Color();
+
+    a.copyTo(out);
+    expect(Color.equals(a, out)).to.eq(true);
+  });
+
   it("copyFromArray", () => {
     const a = new Color();
     const b = new Color(0, 0, 1, 1);

--- a/tests/src/math/Quaternion.test.ts
+++ b/tests/src/math/Quaternion.test.ts
@@ -261,6 +261,13 @@ describe("Quaternion test", () => {
     expect(toString(a)).to.eq(toString(out));
   });
 
+  it("copyTo", () => {
+    const a = new Quaternion(3, 4, 5, 0);
+    const out = new Quaternion();
+    a.copyTo(out);
+    expect(toString(a)).to.eq(toString(out));
+  });
+
   it("conjugate", () => {
     const a = new Quaternion(1, 1, 1, 1);
     expect(toString(a.conjugate())).to.eq("quat(-1, -1, -1, 1)");

--- a/tests/src/math/Vector2.test.ts
+++ b/tests/src/math/Vector2.test.ts
@@ -148,6 +148,13 @@ describe("Vector2 test", () => {
     expect(toString(a)).to.eq(toString(out));
   });
 
+  it("copyTo", () => {
+    const a = new Vector2(3, 4);
+    const out = new Vector2();
+    a.copyTo(out);
+    expect(toString(a)).to.eq(toString(out));
+  });
+
   it("add", () => {
     const a = new Vector2(3, 4);
     const ret = new Vector2(1, 2);

--- a/tests/src/math/Vector3.test.ts
+++ b/tests/src/math/Vector3.test.ts
@@ -176,6 +176,13 @@ describe("Vector3 test", () => {
     expect(toString(a)).to.eq(toString(out));
   });
 
+  it("copyTo", () => {
+    const a = new Vector3(3, 4, 5);
+    const out = new Vector3();
+    a.copyTo(out);
+    expect(toString(a)).to.eq(toString(out));
+  });
+
   it("add", () => {
     const a = new Vector3(3, 4, 5);
     const ret = new Vector3(1, 2, 4);

--- a/tests/src/math/Vector4.test.ts
+++ b/tests/src/math/Vector4.test.ts
@@ -158,6 +158,13 @@ describe("Vector4 test", () => {
     expect(toString(a)).to.eq(toString(out));
   });
 
+  it("copyTo", () => {
+    const a = new Vector4(3, 4, 5, 0);
+    const out = new Vector4();
+    a.copyTo(out);
+    expect(toString(a)).to.eq(toString(out));
+  });
+
   it("add", () => {
     const a = new Vector4(3, 4, 5, 1);
     const ret = new Vector4(1, 2, 4, 1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `copyTo` method in the `Vector2`, `Vector3`, `Vector4`, `Color`, and `Quaternion` classes, allowing users to copy values to target objects.
  
- **Tests**
	- Added test cases for the `copyTo` method in `Vector2`, `Vector3`, `Vector4`, `Color`, and `Quaternion` to ensure functionality and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->