### PR TITLE
Fix renderQueueType error

### DIFF
--- a/e2e/case/shaderLab-renderState.ts
+++ b/e2e/case/shaderLab-renderState.ts
@@ -1,0 +1,122 @@
+/**
+ * @title ShaderLab RenderState
+ * @category Material
+ */
+
+import {
+  BlendFactor,
+  Camera,
+  Color,
+  CullMode,
+  Logger,
+  Material,
+  MeshRenderer,
+  PrimitiveMesh,
+  RenderQueueType,
+  Shader,
+  WebGLEngine
+} from "@galacean/engine";
+import { ShaderLab } from "@galacean/engine-shader-lab";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+const shaderLab = new ShaderLab();
+
+const shaderSource = `Shader "Test RenderState" {
+  SubShader "Default" {
+    Pass "0" {
+	DepthState {
+      WriteEnabled = depthWriteEnabled;
+    }
+    
+	BlendState {
+      Enabled = blendEnabled;
+      SourceColorBlendFactor = sourceColorBlendFactor;
+      DestinationColorBlendFactor = destinationColorBlendFactor;
+      SourceAlphaBlendFactor = sourceAlphaBlendFactor;
+      DestinationAlphaBlendFactor = destinationAlphaBlendFactor;
+    }
+    
+	RasterState{
+      CullMode = rasterStateCullMode;
+    }
+    // RenderQueueType = renderQueueType;
+	RenderQueueType = Transparent;
+      
+	mat4 renderer_MVPMat;
+    vec4 u_color;
+
+    struct a2v {
+      vec4 POSITION;
+    };
+
+    struct v2f {
+		vec4 test;
+    };
+
+    VertexShader = vert;
+    FragmentShader = frag;
+
+    v2f vert(a2v v) {
+      v2f o;
+
+      gl_Position = renderer_MVPMat * v.POSITION;
+      return o;
+    }
+
+    void frag(v2f i) {
+      gl_FragColor = u_color;
+    }
+}
+	}
+}`;
+
+Logger.enable();
+WebGLEngine.create({ canvas: "canvas", shaderLab }).then((engine) => {
+  engine.canvas.resizeByClientSize();
+
+  const shader = Shader.create(shaderSource);
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+
+  // camera
+  const cameraEntity = rootEntity.createChild("cameraNode");
+  cameraEntity.transform.setPosition(0, 0, 5);
+  const camera = cameraEntity.addComponent(Camera);
+
+  // sphere
+  {
+    const sphere = rootEntity.createChild("sphere");
+    sphere.transform.position.x = -1;
+    const renderer = sphere.addComponent(MeshRenderer);
+    renderer.mesh = PrimitiveMesh.createSphere(engine);
+    const material = new Material(engine, shader);
+    material.shaderData.setColor("u_color", new Color(1, 0, 0, 0.2));
+    renderer.setMaterial(material);
+  }
+
+  // Cuboid
+  {
+    const cuboid = rootEntity.createChild("sphere");
+    cuboid.transform.position.x = 1;
+    const renderer = cuboid.addComponent(MeshRenderer);
+    renderer.mesh = PrimitiveMesh.createCuboid(engine);
+    const material = new Material(engine, shader);
+    material.shaderData.setColor("u_color", new Color(1, 0, 0, 0.2));
+    renderer.setMaterial(material);
+
+    const shaderData = material.shaderData;
+    shaderData.setInt("depthWriteEnabled", 0);
+    shaderData.setInt("blendEnabled", 1);
+    shaderData.setInt("renderQueueType", RenderQueueType.Transparent);
+    shaderData.enableMacro("MATERIAL_IS_TRANSPARENT");
+    shaderData.setInt("sourceColorBlendFactor", BlendFactor.SourceAlpha);
+    shaderData.setInt("destinationColorBlendFactor", BlendFactor.OneMinusSourceAlpha);
+    shaderData.setInt("sourceAlphaBlendFactor", BlendFactor.One);
+    shaderData.setInt("destinationAlphaBlendFactor", BlendFactor.OneMinusSourceAlpha);
+    shaderData.setInt("rasterStateCullMode", CullMode.Off);
+  }
+
+  updateForE2E(engine);
+
+  initScreenshot(engine, camera);
+});

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -119,6 +119,11 @@ export const E2E_CONFIG = {
       category: "Material",
       caseFileName: "material-unlit",
       threshold: 0.2
+    },
+    "shaderLab-renderState": {
+      category: "Material",
+      caseFileName: "shaderLab-renderState",
+      threshold: 0.2
     }
   },
   Shadow: {
@@ -226,5 +231,5 @@ export const E2E_CONFIG = {
       caseFileName: "project-loader",
       threshold: 0.4
     }
-  },
+  }
 };

--- a/e2e/fixtures/originImage/Material_shaderLab-renderState.jpg
+++ b/e2e/fixtures/originImage/Material_shaderLab-renderState.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fd5c4fa17580e5c65bd3d8b6d02b0e38777d4079ed693b03d987b5b9ca255f6
+size 27526

--- a/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
+++ b/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
@@ -1,7 +1,6 @@
 import { Vector2 } from "@galacean/engine-math";
 import { Background } from "../Background";
 import { Camera } from "../Camera";
-import { Engine } from "../Engine";
 import { BackgroundMode } from "../enums/BackgroundMode";
 import { BackgroundTextureFillMode } from "../enums/BackgroundTextureFillMode";
 import { CameraClearFlags } from "../enums/CameraClearFlags";
@@ -270,8 +269,10 @@ export class BasicRenderPipeline {
       const shaderPass = shaderPasses[i];
       const renderState = shaderPass._renderState;
       if (renderState) {
-        renderState._applyRenderQueueByShaderData(shaderPass._renderStateDataMap, subRenderElement.material.shaderData);
-        renderQueueType = renderState.renderQueueType;
+        renderQueueType = renderState._getRenderQueueByShaderData(
+          shaderPass._renderStateDataMap,
+          subRenderElement.material.shaderData
+        );
       } else {
         renderQueueType = renderStates[i].renderQueueType;
       }

--- a/packages/core/src/RenderPipeline/RenderQueue.ts
+++ b/packages/core/src/RenderPipeline/RenderQueue.ts
@@ -99,13 +99,17 @@ export class RenderQueue {
         if (shaderPass.getTagValue(pipelineStageKey) !== pipelineStageTagValue) {
           continue;
         }
-        const renderState = shaderPass._renderState ?? renderStates[j];
 
-        if (shaderPass._renderState) {
-          renderState._applyRenderQueueByShaderData(shaderPass._renderStateDataMap, materialData);
+        let renderState = shaderPass._renderState;
+        let passQueueType: RenderQueueType;
+        if (renderState) {
+          passQueueType = renderState._getRenderQueueByShaderData(shaderPass._renderStateDataMap, materialData);
+        } else {
+          renderState = renderStates[j];
+          passQueueType = renderState.renderQueueType;
         }
 
-        if (renderState.renderQueueType !== renderQueueType) {
+        if (passQueueType !== renderQueueType) {
           continue;
         }
 

--- a/packages/core/src/RenderPipeline/RenderQueue.ts
+++ b/packages/core/src/RenderPipeline/RenderQueue.ts
@@ -99,8 +99,13 @@ export class RenderQueue {
         if (shaderPass.getTagValue(pipelineStageKey) !== pipelineStageTagValue) {
           continue;
         }
+        const renderState = shaderPass._renderState ?? renderStates[j];
 
-        if ((shaderPass._renderState ?? renderStates[j]).renderQueueType !== renderQueueType) {
+        if (shaderPass._renderState) {
+          renderState._applyRenderQueueByShaderData(shaderPass._renderStateDataMap, materialData);
+        }
+
+        if (renderState.renderQueueType !== renderQueueType) {
           continue;
         }
 
@@ -163,7 +168,6 @@ export class RenderQueue {
           }
         }
 
-        const renderState = shaderPass._renderState ?? renderStates[j];
         renderState._applyStates(
           engine,
           renderer.entity.transform._isFrontFaceInvert(),

--- a/packages/core/src/shader/state/RenderState.ts
+++ b/packages/core/src/shader/state/RenderState.ts
@@ -56,10 +56,15 @@ export class RenderState {
    * @internal
    * @todo Should merge when we can delete material render state
    */
-  _applyRenderQueueByShaderData(renderStateDataMap: Record<number, ShaderProperty>, shaderData: ShaderData): void {
+  _getRenderQueueByShaderData(
+    renderStateDataMap: Record<number, ShaderProperty>,
+    shaderData: ShaderData
+  ): RenderQueueType {
     const renderQueueType = renderStateDataMap[RenderStateElementKey.RenderQueueType];
-    if (renderQueueType !== undefined) {
-      this.renderQueueType = shaderData.getFloat(renderQueueType) ?? RenderQueueType.Opaque;
+    if (renderQueueType === undefined) {
+      return this.renderQueueType;
+    } else {
+      return shaderData.getFloat(renderQueueType) ?? RenderQueueType.Opaque;
     }
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug Fix.
### What is the current behavior? (You can also link to an open issue here)
ShaderPass's `renderQueueType` will be override by `BasicRenderPipeline.pushRenderElementByType`

### What is the new behavior (if this is a feature change)?
Should Correct true `renderQueueType` before render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced clarity and control flow in the rendering process, leading to more predictable behavior with shader passes.
	- Streamlined handling of render states for improved performance and maintainability.
	- Updated logic for determining render queue types, potentially improving rendering categorization.
- **Bug Fixes**
	- Simplified logic for applying render states to ensure accurate rendering outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->