### PR TITLE
Fix last line commets skip bug

### DIFF
--- a/packages/shader-lab/src/common/BaseScanner.ts
+++ b/packages/shader-lab/src/common/BaseScanner.ts
@@ -101,7 +101,7 @@ export default class BaseScanner {
       const start = this.curPosition;
       this.advance(2);
       // single line comments
-      while (this.getCurChar() !== "\n") this._advance();
+      while (this.getCurChar() !== "\n" && !this.isEnd()) this._advance();
       this.skipCommentsAndSpace();
       return ShaderLab.createRange(start, this.curPosition);
     } else if (this.peek(2) === "/*") {

--- a/tests/src/shader-lab/shaders/demo.shader
+++ b/tests/src/shader-lab/shaders/demo.shader
@@ -99,6 +99,14 @@ Shader "Water" {
           gl_FragColor = linearToGamma(gl_FragColor);
         #endif
 
+
+#define MATERIAL_ENABLE_SS_REFRACTION
+
+        #ifdef MATERIAL_ENABLE_SS_REFRACTION 
+
+    // last lint comment
+#endif
+
         // For testing only (macro)
         #if SCENE_SHADOW_TYPE == 2 || defined(XX_Macro)
           gl_FragColor = linearToGamma(gl_FragColor);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

ShaderLab will be trapped in loop when try to skip last line comments like below:
```

#define MATERIAL_ENABLE_SS_REFRACTION

        #ifdef MATERIAL_ENABLE_SS_REFRACTION 

    // last lint comment, not end with line break.
#endif
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for skipping comments to prevent out-of-bounds access in the scanner functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->