### PR TITLE
Support parse method result

### DIFF
--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -14,7 +14,7 @@ import {
   Scene,
   TonemappingEffect
 } from "@galacean/engine-core";
-import { IClassObject, IScene, ReflectionParser, SceneParser, SpecularMode } from "./resource-deserialize";
+import { IClass, IScene, ReflectionParser, SceneParser, SpecularMode } from "./resource-deserialize";
 
 @resourceLoader(AssetType.Scene, ["scene"], true)
 class SceneLoader extends Loader<Scene> {
@@ -146,7 +146,7 @@ class SceneLoader extends Loader<Scene> {
 
 ReflectionParser.registerCustomParseComponent(
   "TextRenderer",
-  async (instance: any, item: Omit<IClassObject, "class">) => {
+  async (instance: any, item: Omit<IClass, "class">) => {
     const { props } = item;
     if (!props.font) {
       // @ts-ignore

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -2,7 +2,6 @@ import {
   AssetPromise,
   AssetType,
   BackgroundMode,
-  BloomEffect,
   DiffuseMode,
   Font,
   Loader,
@@ -11,8 +10,7 @@ import {
   Mesh,
   resourceLoader,
   ResourceManager,
-  Scene,
-  TonemappingEffect
+  Scene
 } from "@galacean/engine-core";
 import { IClass, IScene, ReflectionParser, SceneParser, SpecularMode } from "./resource-deserialize";
 
@@ -144,14 +142,11 @@ class SceneLoader extends Loader<Scene> {
   }
 }
 
-ReflectionParser.registerCustomParseComponent(
-  "TextRenderer",
-  async (instance: any, item: Omit<IClass, "class">) => {
-    const { props } = item;
-    if (!props.font) {
-      // @ts-ignore
-      instance.font = Font.createFromOS(instance.engine, props.fontFamily || "Arial");
-    }
-    return instance;
+ReflectionParser.registerCustomParseComponent("TextRenderer", async (instance: any, item: Omit<IClass, "class">) => {
+  const { props } = item;
+  if (!props.font) {
+    // @ts-ignore
+    instance.font = Font.createFromOS(instance.engine, props.fontFamily || "Arial");
   }
-);
+  return instance;
+});

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -2,7 +2,7 @@ import { EngineObject, Entity, Loader } from "@galacean/engine-core";
 import type {
   IAssetRef,
   IBasicType,
-  ICanCallbackMethodObject,
+  ICanParseResultObject,
   IClassObject,
   IClassTypeObject,
   IComponentRef,
@@ -74,15 +74,15 @@ export class ReflectionParser {
   }
 
   parseMethod(instance: any, methodName: string, methodParams: IMethodParams) {
-    const isCanCallbackMethodObject = ReflectionParser._isCanCallbackMethodObject(methodParams);
-    const params = isCanCallbackMethodObject ? methodParams.params : methodParams;
+    const isCanParseResultObject = ReflectionParser._isCanParseResultObject(methodParams);
+    const params = isCanParseResultObject ? methodParams.params : methodParams;
 
     return Promise.all(params.map((param) => this.parseBasicType(param))).then((result) => {
-      const methodCallback = instance[methodName](...result);
-      if (isCanCallbackMethodObject && methodParams.callback) {
-        return this.parsePropsAndMethods(methodCallback, methodParams.callback);
+      const methodResult = instance[methodName](...result);
+      if (isCanParseResultObject && methodParams.result) {
+        return this.parsePropsAndMethods(methodResult, methodParams.result);
       } else {
-        return methodCallback;
+        return methodResult;
       }
     });
   }
@@ -187,7 +187,7 @@ export class ReflectionParser {
     return value["ownerId"] !== undefined && value["componentId"] !== undefined;
   }
 
-  private static _isCanCallbackMethodObject(value: any): value is ICanCallbackMethodObject {
+  private static _isCanParseResultObject(value: any): value is ICanParseResultObject {
     return Array.isArray(value?.params);
   }
 }

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -76,22 +76,21 @@ export class ReflectionParser {
       const methodCallback = instance[methodName](...result);
       // @todo: Only parse first param to adapter original data format
       const firstParam = methodParams?.[0] as IClassRealObject;
-      if (ReflectionParser._isRealClass(firstParam)) {
-        const callbackProps = firstParam?.callbackProps;
-        if (callbackProps) {
-          const promises = [];
-          for (let key in callbackProps) {
-            const value = callbackProps[key];
-            const promise = this.parseBasicType(value, methodCallback[key]).then((v) => {
-              if (methodCallback[key] !== v) {
-                methodCallback[key] = v;
-              }
-              return v;
-            });
-            promises.push(promise);
-          }
-          return Promise.all(promises);
+      const callbackProps = firstParam?.callbackProps;
+
+      if (firstParam && ReflectionParser._isRealClass(firstParam) && callbackProps) {
+        const promises = [];
+        for (let key in callbackProps) {
+          const value = callbackProps[key];
+          const promise = this.parseBasicType(value, methodCallback[key]).then((v) => {
+            if (methodCallback[key] !== v) {
+              methodCallback[key] = v;
+            }
+            return v;
+          });
+          promises.push(promise);
         }
+        return Promise.all(promises);
       } else {
         return methodCallback;
       }

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -4,6 +4,7 @@ import type {
   IBasicType,
   ICanCallbackMethodObject,
   IClassObject,
+  IClassTypeObject,
   IComponentRef,
   IEntity,
   IEntityRef,
@@ -170,7 +171,7 @@ export class ReflectionParser {
     return value["class"] !== undefined;
   }
 
-  private static _isClassType(value: any): value is IClassObject {
+  private static _isClassType(value: any): value is IClassTypeObject {
     return value["classType"] !== undefined;
   }
 

--- a/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
@@ -28,15 +28,15 @@ export interface IHierarchyFile {
   entities: Array<IEntity>;
 }
 
-export type ICanCallbackMethodObject = {
+export type ICanParseResultObject = {
   params: Array<IBasicType>;
-  callback?: {
+  result?: {
     methods?: { [methodName: string]: Array<IMethodParams> };
     props?: { [key: string]: IBasicType | IMethodParams };
   };
 };
 
-export type IMethodParams = Array<IBasicType> | ICanCallbackMethodObject;
+export type IMethodParams = Array<IBasicType> | ICanParseResultObject;
 
 export interface IBasicEntity {
   name?: string;

--- a/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
@@ -28,15 +28,12 @@ export interface IHierarchyFile {
   entities: Array<IEntity>;
 }
 
-export type ICanParseResultObject = {
+export type IMethod = {
   params: Array<IBasicType>;
-  result?: {
-    methods?: { [methodName: string]: Array<IMethodParams> };
-    props?: { [key: string]: IBasicType | IMethodParams };
-  };
+  result?: IInstance;
 };
 
-export type IMethodParams = Array<IBasicType> | ICanParseResultObject;
+export type IMethodParams = Array<IBasicType> | IMethod;
 
 export interface IBasicEntity {
   name?: string;
@@ -57,11 +54,9 @@ export interface IRefEntity extends IBasicEntity {
   assetRefId: string;
   key?: string;
   isClone?: boolean;
-  modifications: {
+  modifications: (IInstance & {
     target: IPrefabModifyTarget;
-    methods?: { [methodName: string]: Array<IMethodParams> };
-    props?: { [key: string]: IBasicType | IMethodParams };
-  }[];
+  })[];
   removedEntities: IPrefabModifyTarget[];
   removedComponents: IPrefabModifyTarget[];
 }
@@ -77,16 +72,19 @@ export interface IStrippedEntity extends IBasicEntity {
   prefabSource: { assetId: string; entityId: string };
 }
 
-export type IComponent = { id: string; refId?: string } & IClassObject;
+export type IComponent = { id: string; refId?: string } & IClass;
 
-export type IClassObject = {
+export type IClass = {
   class: string;
   constructParams?: Array<IBasicType>;
+} & IInstance;
+
+export interface IInstance {
   methods?: { [methodName: string]: Array<IMethodParams> };
   props?: { [key: string]: IBasicType | IMethodParams };
-};
+}
 
-export type IClassTypeObject = {
+export type IClassType = {
   classType: string;
 };
 
@@ -97,8 +95,8 @@ export type IBasicType =
   | null
   | undefined
   | IAssetRef
-  | IClassObject
-  | IClassTypeObject
+  | IClass
+  | IClassType
   | IMethodParams
   | IEntityRef;
 

--- a/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
@@ -78,6 +78,11 @@ export type IClassObject = {
   props?: { [key: string]: IBasicType | IMethodParams };
 };
 
+export type IClassRealObject = {
+  classReal: string;
+  callbackProps?: { [key: string]: IBasicType | IMethodParams };
+};
+
 export type IBasicType =
   | string
   | number
@@ -86,6 +91,7 @@ export type IBasicType =
   | undefined
   | IAssetRef
   | IClassObject
+  | IClassRealObject
   | IMethodParams
   | IEntityRef;
 

--- a/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
@@ -28,7 +28,15 @@ export interface IHierarchyFile {
   entities: Array<IEntity>;
 }
 
-export type IMethodParams = Array<IBasicType>;
+export type ICanCallbackMethodObject = {
+  params: Array<IBasicType>;
+  callback?: {
+    methods?: { [methodName: string]: Array<IMethodParams> };
+    props?: { [key: string]: IBasicType | IMethodParams };
+  };
+};
+
+export type IMethodParams = Array<IBasicType> | ICanCallbackMethodObject;
 
 export interface IBasicEntity {
   name?: string;
@@ -73,14 +81,13 @@ export type IComponent = { id: string; refId?: string } & IClassObject;
 
 export type IClassObject = {
   class: string;
-  constructParams?: IMethodParams;
+  constructParams?: Array<IBasicType>;
   methods?: { [methodName: string]: Array<IMethodParams> };
   props?: { [key: string]: IBasicType | IMethodParams };
 };
 
-export type IClassRealObject = {
-  classReal: string;
-  callbackProps?: { [key: string]: IBasicType | IMethodParams };
+export type IClassTypeObject = {
+  classType: string;
 };
 
 export type IBasicType =
@@ -91,7 +98,7 @@ export type IBasicType =
   | undefined
   | IAssetRef
   | IClassObject
-  | IClassRealObject
+  | IClassTypeObject
   | IMethodParams
   | IEntityRef;
 


### PR DESCRIPTION
engine don't support add `class` and parse callback props in loader, and only support add class as parameter such as colliderShape:
```
"methods": {
"addShape": [
[
{
"class": "BoxColliderShape",
"props": {
"isTrigger": false,
"size": {
"x": 10,
"y": 10,
"z": 10
},
"position": {
"x": 0,
"y": 0,
"z": 0
},
"rotation": {
"x": 0,
"y": 0,
"z": 0
}
}
}
]
]
}
```

now i need just add `Class` in engine parser, add parse some props on returned instance:
```ts
const effect = component.addEffect(BloomEffect);
effect.intensity.value = 1;
```


onSerialize data:
![image](https://github.com/user-attachments/assets/bc79495f-85dc-4957-a247-1312874b6720)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type system to support more complex class-like objects.
	- Introduced a new method to identify real class objects.

- **Improvements**
	- Refined parsing logic for method callbacks.
	- Updated type definitions to accommodate advanced class representations.
	- Improved handling of method parameters with new type definitions.
	- Updated type references in the SceneLoader for consistency with new class structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->