### PR TITLE
Spine support git clone branch in git action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git clone https://github.com/galacean/engine-toolkit.git
           git clone https://github.com/galacean/engine-lottie.git
-          git clone https://github.com/galacean/engine-spine.git
+          git clone https://github.com/galacean/engine-spine.git -b dev/4.2
 
       - name: Install and Link Engine and Build for Toolkit
         working-directory: ./engine-toolkit
@@ -120,6 +120,9 @@ jobs:
                 "${{ github.workspace }}/temp/@galacean/engine-toolkit/umd/browser.js",
                 "${{ github.workspace }}/temp/@galacean/engine-lottie/dist/browser.js",
                 "${{ github.workspace }}/temp/@galacean/engine-spine/dist/browser.js"
+              ],
+              "wasm": [
+                "${{ github.workspace }}/packages/physics-physx/libs/physx.release.wasm"
               ],
               "jsWASMLoader": [
                 "${{ github.workspace }}/packages/physics-physx/libs/physx.release.js"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration
	- Modified repository cloning process for `engine-spine`
	- Added WebAssembly file configuration in build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->