### PR TITLE
Don't break lerp effect in post-processing local mode

### DIFF
--- a/packages/core/src/postProcess/PostProcessManager.ts
+++ b/packages/core/src/postProcess/PostProcessManager.ts
@@ -106,8 +106,11 @@ export class PostProcessManager {
         }
 
         // Post process has no influence, ignore it
-        if (closestDistance <= blendDistance && blendDistance > 0) {
-          interpFactor = 1 - closestDistance / blendDistance;
+        if (closestDistance <= blendDistance) {
+          interpFactor = 1;
+          if (blendDistance > 0) {
+            interpFactor = 1 - closestDistance / blendDistance;
+          }
         }
       }
 

--- a/packages/core/src/postProcess/PostProcessManager.ts
+++ b/packages/core/src/postProcess/PostProcessManager.ts
@@ -70,8 +70,9 @@ export class PostProcessManager {
       }
 
       const isGlobal = postProcess.isGlobal;
-      let interpFactor = 1; // Global default value
+      let interpFactor = 1; // default value in global mode
       if (!isGlobal) {
+        interpFactor = 0; // default value in local mode
         const currentColliders = PostProcessManager._tempColliders;
         const cameraPosition = camera.entity.transform.worldPosition;
         const blendDistance = postProcess.blendDistance;
@@ -102,15 +103,10 @@ export class PostProcessManager {
           Logger.warn(
             `No collider shape found in the entity:"${postProcess.entity.name}", the local mode of post process will not take effect.`
           );
-          continue;
         }
 
         // Post process has no influence, ignore it
-        if (closestDistance > blendDistance) {
-          continue;
-        }
-
-        if (blendDistance > 0) {
+        if (closestDistance <= blendDistance && blendDistance > 0) {
           interpFactor = 1 - closestDistance / blendDistance;
         }
       }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved post-processing logic for more accurate effect blending.
	- Enhanced handling of interpolation factors in global and local modes.
	- Refined conditions for applying post-process effects based on proximity.
	- Adjusted loop behavior to allow further checks even without collider shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->