### PR TITLE
 Fix axis not effect when component changed && set `connectedAnchor` should not effect when `automaticConnectedAnchor` is `true`

### DIFF
--- a/packages/core/src/physics/joint/HingeJoint.ts
+++ b/packages/core/src/physics/joint/HingeJoint.ts
@@ -142,8 +142,9 @@ export class HingeJoint extends Joint {
     super(entity);
     this._onMotorChanged = this._onMotorChanged.bind(this);
     this._onLimitsChanged = this._onLimitsChanged.bind(this);
+    this._onAxisChanged = this._onAxisChanged.bind(this);
     //@ts-ignore
-    this._axis._onValueChanged = this._setAxis.bind(this);
+    this._axis._onValueChanged = this._onAxisChanged;
   }
 
   /**
@@ -200,12 +201,12 @@ export class HingeJoint extends Joint {
   }
 
   @ignoreClone
-  private _setAxis(): void {
+  private _onAxisChanged(): void {
     //@ts-ignore
     this._axis._onValueChanged = null;
     this._axis.normalize();
     (<IHingeJoint>this._nativeJoint)?.setAxis(this._axis);
     //@ts-ignore
-    this._axis._onValueChanged = this._setAxis.bind(this);
+    this._axis._onValueChanged = this._onAxisChanged;
   }
 }

--- a/packages/core/src/physics/joint/HingeJoint.ts
+++ b/packages/core/src/physics/joint/HingeJoint.ts
@@ -25,7 +25,7 @@ export class HingeJoint extends Joint {
   private _velocity = 0;
 
   /**
-   * The anchor rotation.
+   * The Direction of the axis around which the hingeJoint.
    */
   get axis(): Vector3 {
     return this._axis;
@@ -35,7 +35,6 @@ export class HingeJoint extends Joint {
     const axis = this._axis;
     if (value !== axis) {
       axis.copyFrom(value);
-      (<IHingeJoint>this._nativeJoint)?.setAxis(axis);
     }
   }
 
@@ -143,6 +142,8 @@ export class HingeJoint extends Joint {
     super(entity);
     this._onMotorChanged = this._onMotorChanged.bind(this);
     this._onLimitsChanged = this._onLimitsChanged.bind(this);
+    //@ts-ignore
+    this._axis._onValueChanged = this._setAxis.bind(this);
   }
 
   /**
@@ -196,5 +197,15 @@ export class HingeJoint extends Joint {
         (<IHingeJoint>this._nativeJoint).setHardLimit(limits.min, limits.max, limits.contactDistance);
       }
     }
+  }
+
+  @ignoreClone
+  private _setAxis(): void {
+    //@ts-ignore
+    this._axis._onValueChanged = null;
+    this._axis.normalize();
+    (<IHingeJoint>this._nativeJoint)?.setAxis(this._axis);
+    //@ts-ignore
+    this._axis._onValueChanged = this._setAxis.bind(this);
   }
 }

--- a/packages/core/src/physics/joint/Joint.ts
+++ b/packages/core/src/physics/joint/Joint.ts
@@ -70,15 +70,7 @@ export abstract class Joint extends Component {
    * The connectedAnchor is automatically calculated, if you want to set it manually, please set automaticConnectedAnchor to false
    */
   get connectedAnchor(): Vector3 {
-    const connectedColliderAnchor = this._connectedColliderInfo.anchor;
-    if (this._automaticConnectedAnchor) {
-      //@ts-ignore
-      connectedColliderAnchor._onValueChanged = null;
-      this._calculateConnectedAnchor(false);
-      //@ts-ignore
-      connectedColliderAnchor._onValueChanged = this._handleConnectedAnchorChanged;
-    }
-    return connectedColliderAnchor;
+    return this._connectedColliderInfo.anchor;
   }
 
   set connectedAnchor(value: Vector3) {
@@ -234,7 +226,7 @@ export abstract class Joint extends Component {
     }
   }
 
-  private _calculateConnectedAnchor(syncNative: boolean = true): void {
+  private _calculateConnectedAnchor(): void {
     const colliderInfo = this._colliderInfo;
     const connectedColliderInfo = this._connectedColliderInfo;
     const { worldPosition: selfPos } = this.entity.transform;
@@ -256,7 +248,7 @@ export abstract class Joint extends Component {
     }
     // @ts-ignore
     connectedAnchor._onValueChanged = this._handleConnectedAnchorChanged;
-    syncNative && this._updateActualAnchor(AnchorOwner.Connected);
+    this._updateActualAnchor(AnchorOwner.Connected);
   }
 
   @ignoreClone

--- a/packages/physics-physx/src/joint/PhysXHingeJoint.ts
+++ b/packages/physics-physx/src/joint/PhysXHingeJoint.ts
@@ -34,7 +34,6 @@ export class PhysXHingeJoint extends PhysXJoint implements IHingeJoint {
     const xAxis = PhysXHingeJoint._xAxis;
     const axisRotationQuaternion = this._axisRotationQuaternion;
     xAxis.set(1, 0, 0);
-    value.normalize();
     const angle = Math.acos(Vector3.dot(xAxis, value));
     Vector3.cross(xAxis, value, xAxis);
     Quaternion.rotationAxisAngle(xAxis, angle, axisRotationQuaternion);

--- a/tests/src/core/physics/HingeJoint.test.ts
+++ b/tests/src/core/physics/HingeJoint.test.ts
@@ -60,8 +60,8 @@ describe("HingeJoint", function () {
     joint.automaticConnectedAnchor = true;
     joint.connectedCollider = boxEntity2.getComponent(DynamicCollider);
     joint.anchor = new Vector3(0.5, 0, 0);
-    joint.axis = new Vector3(0, 1, 0);
-
+    joint.axis.x = 0;
+    joint.axis.y = 1;
     expect(formatValue(joint.angle)).eq(0);
 
     collider2.applyTorque(new Vector3(0, 1000, 0));

--- a/tests/src/core/physics/Joint.test.ts
+++ b/tests/src/core/physics/Joint.test.ts
@@ -97,6 +97,8 @@ describe("Joint", function () {
     expect(consoleWarnSpy).toBeCalledTimes(1);
     joint.connectedAnchor.y = 3;
     expect(consoleWarnSpy).toBeCalledTimes(2);
+    joint.automaticConnectedAnchor = false;
+    joint.automaticConnectedAnchor = true;
     expect(joint.connectedAnchor).deep.include({ x: 4, y: 4, z: 4 });
 
     // @ts-ignore

--- a/tests/src/core/physics/Joint.test.ts
+++ b/tests/src/core/physics/Joint.test.ts
@@ -95,6 +95,9 @@ describe("Joint", function () {
     joint.automaticConnectedAnchor = true;
     joint.connectedAnchor = new Vector3(1, 1, 1);
     expect(consoleWarnSpy).toBeCalledTimes(1);
+    joint.connectedAnchor.y = 3;
+    expect(consoleWarnSpy).toBeCalledTimes(2);
+    expect(joint.connectedAnchor).deep.include({ x: 4, y: 4, z: 4 });
 
     // @ts-ignore
     engine.sceneManager.activeScene.physics._update(1 / 60);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Improvements**
  - Enhanced hinge joint axis handling for better consistency and normalization.
  - Streamlined management of connected anchors in joint components, improving clarity and control.

- **Bug Fixes**
  - Adjusted behavior of hinge joint to accommodate non-normalized vectors, ensuring accurate calculations.

- **Tests**
  - Added comprehensive checks for joint behavior regarding the `automaticConnectedAnchor` property.

Note: These changes primarily enhance the physics system's functionality and may not directly impact most end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->