### PR TITLE
Add iri/sheen/rafraction in glsl version

### DIFF
--- a/packages/core/src/shaderlib/common.glsl
+++ b/packages/core/src/shaderlib/common.glsl
@@ -2,6 +2,8 @@
 #define RECIPROCAL_PI 0.31830988618
 #define EPSILON 1e-6
 #define LOG2 1.442695
+#define HALF_MIN 6.103515625e-5  // 2^-14, the same value for 10, 11 and 16-bit: https://www.khronos.org/opengl/wiki/Small_Float_Formats
+#define HALF_EPS 4.8828125e-4    // 2^-11, machine epsilon: 1 + EPS = 1 (half of the ULP for 1.0f)
 
 #define saturate( a ) clamp( a, 0.0, 1.0 )
 
@@ -93,3 +95,9 @@ float remapDepthBufferLinear01(float z){
 
 	#define INVERSE_MAT(mat) inverseMat(mat)
 #endif
+
+
+vec3 safeNormalize(vec3 inVec) {
+    float dp3 = max(float(HALF_MIN), dot(inVec, inVec));
+    return inVec * inversesqrt(dp3);
+}

--- a/packages/core/src/shaderlib/extra/pbr.fs.glsl
+++ b/packages/core/src/shaderlib/extra/pbr.fs.glsl
@@ -1,6 +1,7 @@
 #define IS_METALLIC_WORKFLOW
 #include <common>
 #include <camera_declare>
+#include <transform_declare>
 
 #include <FogFragmentDeclaration>
 

--- a/packages/core/src/shaderlib/pbr/brdf.glsl
+++ b/packages/core/src/shaderlib/pbr/brdf.glsl
@@ -102,16 +102,14 @@ float D_GGX(float alpha, float dotNH ) {
     }
 #endif
 
-vec3 isotropicLobe(vec3 specularColor, float alpha, float dotNV, float dotNL, float dotNH, float dotLH) {
-	vec3 F = F_Schlick( specularColor, dotLH );
+float DG_GGX(float alpha, float dotNV, float dotNL, float dotNH) {
 	float D = D_GGX( alpha, dotNH );
 	float G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );
-
-	return F * ( G * D );
+    return G * D;
 }
 
 #ifdef MATERIAL_ENABLE_ANISOTROPY
-    vec3 anisotropicLobe(vec3 h, vec3 l, Geometry geometry, vec3 specularColor, float alpha, float dotNV, float dotNL, float dotNH, float dotLH) {
+    float DG_GGX_anisotropic(vec3 h, vec3 l, Geometry geometry, float alpha, float dotNV, float dotNL, float dotNH) {
         vec3 t = geometry.anisotropicT;
         vec3 b = geometry.anisotropicB;
         vec3 v = geometry.viewDir;
@@ -129,16 +127,104 @@ vec3 isotropicLobe(vec3 specularColor, float alpha, float dotNV, float dotNL, fl
         float ab = max(alpha * (1.0 - geometry.anisotropy), MIN_ROUGHNESS);
 
         // specular anisotropic BRDF
-    	vec3 F = F_Schlick( specularColor, dotLH );
         float D = D_GGX_Anisotropic(at, ab, dotTH, dotBH, dotNH);
         float G = G_GGX_SmithCorrelated_Anisotropic(at, ab, dotTV, dotBV, dotTL, dotBL, dotNV, dotNL);
 
-        return F * ( G * D );
+        return G * D;
+    }
+#endif
+
+#ifdef MATERIAL_ENABLE_IRIDESCENCE
+    vec3 iorToFresnel0(vec3 transmittedIOR, float incidentIOR) {
+        return pow((transmittedIOR - incidentIOR) / (transmittedIOR + incidentIOR),vec3(2.0));
+    } 
+
+    float iorToFresnel0(float transmittedIOR, float incidentIOR) {
+        return pow((transmittedIOR - incidentIOR) / (transmittedIOR + incidentIOR),2.0);
+    } 
+
+    // Assume air interface for top
+    // Note: We don't handle the case fresnel0 == 1
+    vec3 fresnelToIOR(vec3 f0){
+        vec3 sqrtF0 = sqrt(f0);
+        return (vec3(1.0) + sqrtF0) / (vec3(1.0) - sqrtF0);
+    }
+
+    // Fresnel equations for dielectric/dielectric interfaces.
+    // Ref: https://belcour.github.io/blog/research/publication/2017/05/01/brdf-thin-film.html
+    // Evaluation XYZ sensitivity curves in Fourier space
+    vec3 evalSensitivity(float opd, vec3 shift){
+        // Use Gaussian fits, given by 3 parameters: val, pos and var
+        float phase = 2.0 * PI * opd * 1.0e-9;
+        const vec3 val = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
+        const vec3 pos = vec3(1.6810e+06, 1.7953e+06, 2.2084e+06);
+        const vec3 var = vec3(4.3278e+09, 9.3046e+09, 6.6121e+09);
+        vec3 xyz = val * sqrt(2.0 * PI * var) * cos(pos * phase + shift) * exp(-var * pow2(phase));
+        xyz.x += 9.7470e-14 * sqrt(2.0 * PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift[0]) * exp(-4.5282e+09 * pow2(phase));
+        xyz /= 1.0685e-7;
+        // XYZ to RGB color space
+        const mat3 XYZ_TO_RGB = mat3( 3.2404542, -0.9692660,  0.0556434,
+                                     -1.5371385,  1.8760108, -0.2040259,
+                                     -0.4985314,  0.0415560,  1.0572252);
+        vec3 rgb = XYZ_TO_RGB * xyz;
+        return rgb;
+    }
+
+    vec3 evalIridescenceSpecular(float outsideIOR, float dotNV, float thinIOR, vec3 baseF0,float iridescenceThickness){ 
+        vec3 iridescence = vec3(1.0);
+        // Force iridescenceIOR -> outsideIOR when thinFilmThickness -> 0.0
+        float iridescenceIOR = mix( outsideIOR, thinIOR, smoothstep( 0.0, 0.03, iridescenceThickness ) );
+        // Evaluate the cosTheta on the base layer (Snell law)
+        float sinTheta2Sq = pow( outsideIOR / iridescenceIOR, 2.0) * (1.0 - pow( dotNV, 2.0));
+        float cosTheta2Sq = 1.0 - sinTheta2Sq;
+        // Handle total internal reflection
+        if (cosTheta2Sq < 0.0) {
+           return iridescence;
+        }
+        float cosTheta2 = sqrt(cosTheta2Sq);
+            
+        // First interface
+        float f0 = iorToFresnel0(iridescenceIOR, outsideIOR);
+        float reflectance = F_Schlick(f0, dotNV);
+        float t121 = 1.0 - reflectance;
+        float phi12 = 0.0;
+        // iridescenceIOR has limited greater than 1.0
+        // if (iridescenceIOR < outsideIOR) {phi12 = PI;} 
+        float phi21 = PI - phi12;
+        
+        // Second interface
+        vec3 baseIOR = fresnelToIOR(clamp(baseF0, 0.0, 0.9999)); // guard against 1.0
+        vec3 r1  = iorToFresnel0(baseIOR, iridescenceIOR);
+        vec3 r23 = F_Schlick(r1, cosTheta2);
+        vec3 phi23 =vec3(0.0);
+        if (baseIOR[0] < iridescenceIOR) {phi23[0] = PI;}
+        if (baseIOR[1] < iridescenceIOR) {phi23[1] = PI;}
+        if (baseIOR[2] < iridescenceIOR) {phi23[2] = PI;}
+        
+        // Phase shift
+        float opd = 2.0 * iridescenceIOR  * iridescenceThickness * cosTheta2;
+        vec3 phi = vec3(phi21) + phi23;
+        
+        // Compound terms
+        vec3 r123 = clamp(reflectance * r23, 1e-5, 0.9999);
+        vec3 sr123 = sqrt(r123);
+        vec3 rs = pow2(t121) * r23 / (vec3(1.0) - r123);
+        // Reflectance term for m = 0 (DC term amplitude)
+        vec3 c0 = reflectance + rs;
+        iridescence = c0;
+        // Reflectance term for m > 0 (pairs of diracs)
+        vec3 cm = rs - t121;
+        for (int m = 1; m <= 2; ++m) {
+             cm *= sr123;
+             vec3 sm = 2.0 * evalSensitivity(float(m) * opd, float(m) * phi);
+             iridescence += cm * sm;
+            }
+        return iridescence = max(iridescence, vec3(0.0)); 
     }
 #endif
 
 // GGX Distribution, Schlick Fresnel, GGX-Smith Visibility
-vec3 BRDF_Specular_GGX(vec3 incidentDirection, Geometry geometry, vec3 normal, vec3 specularColor, float roughness ) {
+vec3 BRDF_Specular_GGX(vec3 incidentDirection, Geometry geometry, Material material, vec3 normal, vec3 specularColor, float roughness ) {
 
 	float alpha = pow2( roughness ); // UE4's roughness
 
@@ -149,12 +235,18 @@ vec3 BRDF_Specular_GGX(vec3 incidentDirection, Geometry geometry, vec3 normal, v
 	float dotNH = saturate( dot( normal, halfDir ) );
 	float dotLH = saturate( dot( incidentDirection, halfDir ) );
 
-    #ifdef MATERIAL_ENABLE_ANISOTROPY
-        return anisotropicLobe(halfDir, incidentDirection, geometry, specularColor, alpha, dotNV, dotNL, dotNH, dotLH);
-    #else
-        return isotropicLobe(specularColor, alpha, dotNV, dotNL, dotNH, dotLH);
+    vec3 F = F_Schlick( specularColor, dotLH );
+    #ifdef MATERIAL_ENABLE_IRIDESCENCE
+        F = mix(F, material.iridescenceSpecularColor, material.iridescenceFactor);
     #endif
 
+    #ifdef MATERIAL_ENABLE_ANISOTROPY
+        float GD = DG_GGX_anisotropic(halfDir, incidentDirection, geometry, alpha, dotNV, dotNL, dotNH);
+    #else
+        float GD = DG_GGX(alpha, dotNV, dotNL, dotNH);
+    #endif
+
+    return F * GD;
 }
 
 vec3 BRDF_Diffuse_Lambert(vec3 diffuseColor ) {

--- a/packages/core/src/shaderlib/pbr/btdf.glsl
+++ b/packages/core/src/shaderlib/pbr/btdf.glsl
@@ -1,0 +1,37 @@
+#include <refraction>
+
+#ifdef MATERIAL_ENABLE_TRANSMISSION 
+    uniform sampler2D camera_OpaqueTexture;
+    vec3 evaluateTransmission(Geometry geometry, Material material) {
+        RefractionModelResult ray;
+        #if REFRACTION_MODE == 0  
+            // RefractionMode.Sphere
+            refractionModelSphere(-geometry.viewDir, geometry.position, geometry.normal, material.IOR, material.thickness, ray);
+        #elif REFRACTION_MODE == 1
+            // RefractionMode.Planar
+            refractionModelPlanar(-geometry.viewDir, geometry.position, geometry.normal, material.IOR, material.thickness, ray);
+        #endif
+
+        vec3 refractedRayExit = ray.positionExit;
+
+        // We calculate the screen space position of the refracted point
+        vec4 samplingPositionNDC = camera_ProjMat * camera_ViewMat * vec4( refractedRayExit, 1.0 );
+        vec2 refractionCoords = (samplingPositionNDC.xy / samplingPositionNDC.w) * 0.5 + 0.5;
+
+        // Sample the opaque texture to get the transmitted light
+        vec3 refractionTransmitted = texture2D(camera_OpaqueTexture, refractionCoords).rgb;
+        refractionTransmitted *= material.diffuseColor;
+         
+        // Use specularFGD as an approximation of the fresnel effect
+        // https://blog.selfshadow.com/publications/s2017-shading-course/imageworks/s2017_pbs_imageworks_slides_v2.pdf
+        refractionTransmitted *= (1.0 - material.envSpecularDFG);
+
+       #ifdef MATERIAL_HAS_THICKNESS
+            // Absorption coefficient from Disney: http://blog.selfshadow.com/publications/s2015-shading-course/burley/s2015_pbs_disney_bsdf_notes.pdf
+            vec3 transmittance = min(vec3(1.0), exp(-material.absorptionCoefficient * ray.transmissionLength));
+            refractionTransmitted *= transmittance;
+       #endif
+        
+    return refractionTransmitted;
+    }
+#endif

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -1,5 +1,14 @@
 #include <ShadowFragmentDeclaration>
 
+void sheenLobe(Geometry geometry, Material material, vec3 incidentDirection, vec3 attenuationIrradiance, inout vec3 diffuseColor, inout vec3 specularColor){
+    #ifdef MATERIAL_ENABLE_SHEEN
+        diffuseColor *= material.sheenScaling;
+        specularColor *= material.sheenScaling;
+
+        specularColor += attenuationIrradiance * sheenBRDF(incidentDirection, geometry, material.sheenColor, material.sheenRoughness);
+    #endif
+}
+
 void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Material material, inout ReflectedLight reflectedLight) {
     float attenuation = 1.0;
 
@@ -16,6 +25,9 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
 
     reflectedLight.directSpecular += attenuation * irradiance * BRDF_Specular_GGX( incidentDirection, geometry, geometry.normal, material.specularColor, material.roughness);
     reflectedLight.directDiffuse += attenuation * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+
+    // Sheen Lobe
+    sheenLobe(geometry, material, incidentDirection, attenuation * irradiance, reflectedLight.directDiffuse, reflectedLight.directSpecular);
 
 }
 

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -16,14 +16,14 @@ void addDirectRadiance(vec3 incidentDirection, vec3 color, Geometry geometry, Ma
         float clearCoatDotNL = saturate( dot( geometry.clearCoatNormal, incidentDirection ) );
         vec3 clearCoatIrradiance = clearCoatDotNL * color;
 
-        reflectedLight.directSpecular += material.clearCoat * clearCoatIrradiance * BRDF_Specular_GGX( incidentDirection, geometry, geometry.clearCoatNormal, vec3( 0.04 ), material.clearCoatRoughness );
+        reflectedLight.directSpecular += material.clearCoat * clearCoatIrradiance * BRDF_Specular_GGX( incidentDirection, geometry, material, geometry.clearCoatNormal, vec3( 0.04 ), material.clearCoatRoughness );
         attenuation -= material.clearCoat * F_Schlick(material.f0, geometry.clearCoatDotNV);
     #endif
 
     float dotNL = saturate( dot( geometry.normal, incidentDirection ) );
     vec3 irradiance = dotNL * color * PI;
 
-    reflectedLight.directSpecular += attenuation * irradiance * BRDF_Specular_GGX( incidentDirection, geometry, geometry.normal, material.specularColor, material.roughness);
+    reflectedLight.directSpecular += attenuation * irradiance * BRDF_Specular_GGX( incidentDirection, geometry, material, geometry.normal, material.specularColor, material.roughness);
     reflectedLight.directDiffuse += attenuation * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
     // Sheen Lobe

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -84,3 +84,14 @@ vec3 getLightProbeRadiance(Geometry geometry, vec3 normal, float roughness, int 
     #endif
 
 }
+
+
+void evaluateSheenIBL(Geometry geometry, Material material, float radianceAttenuation, inout vec3 diffuseColor, inout vec3 specularColor){
+    #ifdef MATERIAL_ENABLE_SHEEN
+        diffuseColor *= material.sheenScaling;
+        specularColor *= material.sheenScaling;
+
+        vec3 reflectance = material.specularAO * radianceAttenuation * material.approxIBLSheenDG * material.sheenColor;
+        specularColor += reflectance;
+    #endif
+}

--- a/packages/core/src/shaderlib/pbr/index.ts
+++ b/packages/core/src/shaderlib/pbr/index.ts
@@ -8,6 +8,9 @@ import ibl_frag_define from "./ibl_frag_define.glsl";
 
 import pbr_frag from "./pbr_frag.glsl";
 
+import btdf from "./btdf.glsl";
+import refraction from "./refraction.glsl";
+
 export default {
   pbr_frag_define,
 
@@ -16,5 +19,8 @@ export default {
   direct_irradiance_frag_define,
   ibl_frag_define,
 
-  pbr_frag
+  pbr_frag,
+
+  btdf,
+  refraction
 };

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -46,6 +46,19 @@ reflectedLight.indirectSpecular += material.specularAO * radianceAttenuation * r
 // IBL Sheen
 evaluateSheenIBL(geometry, material, radianceAttenuation, reflectedLight.indirectDiffuse, reflectedLight.indirectSpecular);
 
+
+// Final color
+vec3 totalDiffuseColor = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse;
+vec3 totalSpecularColor = reflectedLight.directSpecular + reflectedLight.indirectSpecular;
+
+#ifdef MATERIAL_ENABLE_TRANSMISSION 
+    vec3 refractionTransmitted = evaluateTransmission(geometry, material);
+    totalDiffuseColor = mix(totalDiffuseColor, refractionTransmitted, material.transmission);
+#endif
+
+vec4 finalColor = vec4(totalDiffuseColor + totalSpecularColor, material.opacity);
+
+
 // Emissive
 vec3 emissiveRadiance = material_EmissiveColor;
 #ifdef MATERIAL_HAS_EMISSIVETEXTURE
@@ -56,12 +69,7 @@ vec3 emissiveRadiance = material_EmissiveColor;
     emissiveRadiance *= emissiveColor.rgb;
 #endif
 
-// Total
-vec3 totalRadiance =    reflectedLight.directDiffuse + 
-                        reflectedLight.indirectDiffuse + 
-                        reflectedLight.directSpecular + 
-                        reflectedLight.indirectSpecular + 
-                        emissiveRadiance;
+finalColor.rgb += emissiveRadiance;
 
-vec4 targetColor =vec4(totalRadiance, material.opacity);
-gl_FragColor = targetColor;
+
+gl_FragColor = finalColor;

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -34,7 +34,13 @@ float radianceAttenuation = 1.0;
     radianceAttenuation -= material.clearCoat * F_Schlick(material.f0, geometry.clearCoatDotNV);
 #endif
 
-reflectedLight.indirectSpecular += material.specularAO * radianceAttenuation * radiance * material.envSpecularDFG;
+#ifdef MATERIAL_ENABLE_IRIDESCENCE
+    vec3 speculaColor = mix(material.specularColor, material.iridescenceSpecularColor, material.iridescenceFactor);
+#else
+    vec3 speculaColor = material.specularColor;
+#endif
+
+reflectedLight.indirectSpecular += material.specularAO * radianceAttenuation * radiance * envBRDFApprox(speculaColor, material.roughness, geometry.dotNV);
 
 
 // IBL Sheen

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -20,37 +20,25 @@ addTotalDirectRadiance(geometry, material, reflectedLight);
    irradiance *= PI;
 #endif
 
-reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+reflectedLight.indirectDiffuse += material.diffuseAO * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
 
 // IBL specular
 vec3 radiance = getLightProbeRadiance(geometry, geometry.normal, material.roughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity);
 float radianceAttenuation = 1.0;
 
+// IBL Clear Coat
 #ifdef MATERIAL_ENABLE_CLEAR_COAT
     vec3 clearCoatRadiance = getLightProbeRadiance( geometry, geometry.clearCoatNormal, material.clearCoatRoughness, int(scene_EnvMapLight.mipMapLevel), scene_EnvMapLight.specularIntensity );
 
-    reflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * envBRDFApprox(vec3( 0.04 ), material.clearCoatRoughness, geometry.clearCoatDotNV);
+    reflectedLight.indirectSpecular += material.specularAO * clearCoatRadiance * material.clearCoat * envBRDFApprox(vec3( 0.04 ), material.clearCoatRoughness, geometry.clearCoatDotNV);
     radianceAttenuation -= material.clearCoat * F_Schlick(material.f0, geometry.clearCoatDotNV);
 #endif
 
-reflectedLight.indirectSpecular += radianceAttenuation * radiance * envBRDFApprox(material.specularColor, material.roughness, geometry.dotNV );
+reflectedLight.indirectSpecular += material.specularAO * radianceAttenuation * radiance * material.envSpecularDFG;
 
 
-// Occlusion
-#ifdef MATERIAL_HAS_OCCLUSION_TEXTURE
-    vec2 aoUV = v_uv;
-    #ifdef RENDERER_HAS_UV1
-        if(material_OcclusionTextureCoord == 1.0){
-            aoUV = v_uv1;
-        }
-    #endif
-    float ambientOcclusion = (texture2D(material_OcclusionTexture, aoUV).r - 1.0) * material_OcclusionIntensity + 1.0;
-    reflectedLight.indirectDiffuse *= ambientOcclusion;
-    #ifdef SCENE_USE_SPECULAR_ENV
-        reflectedLight.indirectSpecular *= computeSpecularOcclusion(ambientOcclusion, material.roughness, geometry.dotNV);
-    #endif
-#endif
-
+// IBL Sheen
+evaluateSheenIBL(geometry, material, radianceAttenuation, reflectedLight.indirectDiffuse, reflectedLight.indirectSpecular);
 
 // Emissive
 vec3 emissiveRadiance = material_EmissiveColor;

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -88,6 +88,23 @@ uniform float material_OcclusionTextureCoord;
     #endif
 #endif
 
+#ifdef MATERIAL_ENABLE_TRANSMISSION
+    uniform float material_Transmission;
+    #ifdef MATERIAL_HAS_TRANSMISSION_TEXTURE
+        uniform sampler2D material_TransmissionTexture;
+    #endif
+
+    #ifdef MATERIAL_HAS_THICKNESS
+        uniform vec3 material_AttenuationColor;
+        uniform float material_AttenuationDistance;
+        uniform float material_Thickness;
+
+        #ifdef MATERIAL_HAS_THICKNESS_TEXTURE
+            uniform sampler2D material_ThicknessTexture;
+        #endif
+    #endif
+#endif
+
 // Runtime
 struct ReflectedLight {
     vec3 directDiffuse;
@@ -123,7 +140,8 @@ struct Material {
     float f0;
     float diffuseAO;
     float specularAO;
-    vec3 envSpecularDFG;
+    vec3  envSpecularDFG;
+    float IOR;
 
     #ifdef MATERIAL_ENABLE_CLEAR_COAT
         float clearCoat;
@@ -142,5 +160,11 @@ struct Material {
         vec3  sheenColor;
         float sheenScaling;
         float approxIBLSheenDG;
+    #endif
+
+    #ifdef MATERIAL_ENABLE_TRANSMISSION 
+        vec3 absorptionCoefficient;
+        float transmission;
+        float thickness;
     #endif
 };

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -76,6 +76,18 @@ uniform float material_OcclusionTextureCoord;
     #endif
 #endif
 
+
+#ifdef MATERIAL_ENABLE_IRIDESCENCE
+    uniform vec4 material_IridescenceInfo;
+    #ifdef MATERIAL_HAS_IRIDESCENCE_THICKNESS_TEXTURE
+       uniform sampler2D material_IridescenceThicknessTexture;
+    #endif
+
+    #ifdef MATERIAL_HAS_IRIDESCENCE_TEXTURE
+       uniform sampler2D material_IridescenceTexture;
+    #endif
+#endif
+
 // Runtime
 struct ReflectedLight {
     vec3 directDiffuse;
@@ -116,6 +128,13 @@ struct Material {
     #ifdef MATERIAL_ENABLE_CLEAR_COAT
         float clearCoat;
         float clearCoatRoughness;
+    #endif
+
+    #ifdef MATERIAL_ENABLE_IRIDESCENCE
+        float iridescenceIOR;
+        float iridescenceFactor;
+        float iridescenceThickness;
+        vec3 iridescenceSpecularColor;
     #endif
 
     #ifdef MATERIAL_ENABLE_SHEEN

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -63,6 +63,19 @@ uniform float material_OcclusionTextureCoord;
     uniform sampler2D material_OcclusionTexture;
 #endif
 
+
+#ifdef MATERIAL_ENABLE_SHEEN
+    uniform float material_SheenRoughness;
+    uniform vec3 material_SheenColor;
+    #ifdef MATERIAL_HAS_SHEEN_TEXTURE
+       uniform sampler2D material_SheenTexture;
+    #endif
+
+    #ifdef MATERIAL_HAS_SHEEN_ROUGHNESS_TEXTURE
+       uniform sampler2D material_SheenRoughnessTexture;
+    #endif
+#endif
+
 // Runtime
 struct ReflectedLight {
     vec3 directDiffuse;
@@ -96,9 +109,19 @@ struct Material {
     vec3  specularColor;
     float opacity;
     float f0;
+    float diffuseAO;
+    float specularAO;
+    vec3 envSpecularDFG;
+
     #ifdef MATERIAL_ENABLE_CLEAR_COAT
         float clearCoat;
         float clearCoatRoughness;
     #endif
 
+    #ifdef MATERIAL_ENABLE_SHEEN
+        float sheenRoughness;
+        vec3  sheenColor;
+        float sheenScaling;
+        float approxIBLSheenDG;
+    #endif
 };

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -1,5 +1,6 @@
 #include <normal_get>
 #include <brdf>
+#include <btdf>
 
 // direct + indirect
 #include <direct_irradiance_frag_define>
@@ -90,6 +91,7 @@ void initMaterial(out Material material, inout Geometry geometry){
         float f0 = pow2( (material_IOR - 1.0) / (material_IOR + 1.0) );
 
         material.f0 = f0;
+        material.IOR = material_IOR;
 
         #ifdef MATERIAL_HAS_BASETEXTURE
             vec4 baseTextureColor = texture2D(material_BaseTexture, v_uv);
@@ -226,6 +228,22 @@ void initMaterial(out Material material, inout Geometry geometry){
                 float topIOR = 1.0;
                 material.iridescenceSpecularColor = evalIridescenceSpecular(topIOR, geometry.dotNV, material.iridescenceIOR, material.specularColor, material.iridescenceThickness);   
             #endif
+        #endif
+
+        // Transmission
+        #ifdef MATERIAL_ENABLE_TRANSMISSION 
+            material.transmission = material_Transmission;
+            #ifdef MATERIAL_HAS_TRANSMISSION_TEXTURE
+                material.transmission *= texture2D(material_TransmissionTexture, v_uv).r;
+            #endif
+
+            #ifdef MATERIAL_HAS_THICKNESS
+                material.absorptionCoefficient = -log(material_AttenuationColor + HALF_EPS) / max(HALF_EPS, material_AttenuationDistance);
+                material.thickness = max(material_Thickness, 0.0001);
+                #ifdef MATERIAL_HAS_THICKNESS_TEXTURE
+                    material.thickness *= texture2D( material_ThicknessTexture, v_uv).g;
+                #endif
+            #endif    
         #endif
 
 }

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -206,6 +206,28 @@ void initMaterial(out Material material, inout Geometry geometry){
             material.sheenScaling = 1.0 - material.approxIBLSheenDG * max(max(material.sheenColor.r, material.sheenColor.g), material.sheenColor.b);
         #endif
 
+        // Iridescence
+        #ifdef MATERIAL_ENABLE_IRIDESCENCE
+            material.iridescenceFactor = material_IridescenceInfo.x;
+            material.iridescenceIOR = material_IridescenceInfo.y;
+
+            #ifdef MATERIAL_HAS_IRIDESCENCE_THICKNESS_TEXTURE
+               float iridescenceThicknessWeight = texture2D( material_IridescenceThicknessTexture, v_uv).g;
+               material.iridescenceThickness = mix(material_IridescenceInfo.z, material_IridescenceInfo.w, iridescenceThicknessWeight);
+            #else
+               material.iridescenceThickness = material_IridescenceInfo.w;
+            #endif
+
+            #ifdef MATERIAL_HAS_IRIDESCENCE_TEXTURE
+               material.iridescenceFactor *= texture2D( material_IridescenceTexture, v_uv).r;
+            #endif
+             
+            #ifdef MATERIAL_ENABLE_IRIDESCENCE
+                float topIOR = 1.0;
+                material.iridescenceSpecularColor = evalIridescenceSpecular(topIOR, geometry.dotNV, material.iridescenceIOR, material.specularColor, material.iridescenceThickness);   
+            #endif
+        #endif
+
 }
 
 

--- a/packages/core/src/shaderlib/pbr/refraction.glsl
+++ b/packages/core/src/shaderlib/pbr/refraction.glsl
@@ -1,0 +1,40 @@
+#ifdef MATERIAL_ENABLE_TRANSMISSION 
+	struct RefractionModelResult {
+	    float transmissionLength;         // length of the transmission during refraction through the shape
+	    vec3 positionExit;      // out ray position
+	    // vec3 directionExit;     // out ray direction
+	};
+
+	//https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@15.0/manual/refraction-models.html
+	 void refractionModelSphere(vec3 V, vec3 positionWS, vec3 normalWS, float ior, float thickness, out RefractionModelResult ray) {
+	    // Refracted ray
+	    vec3 R1 = refract(V, normalWS, 1.0 / ior);
+	    // Center of the tangent sphere
+	    // vec3 C = positionWS - normalWS * thickness * 0.5;
+
+	    // Second refraction (tangent sphere out)
+	    float dist = dot(-normalWS, R1) * thickness;
+	    // Out hit point in the tangent sphere
+	    vec3 P1 = positionWS + R1 * dist;
+	    // Out normal
+	    // vec3 N1 = safeNormalize(C - P1);
+	    // Out refracted ray
+	    // vec3 R2 = refract(R1, N1, ior);
+
+	    ray.transmissionLength = dist;
+	    ray.positionExit = P1;
+	    // ray.directionExit = R2; 
+	}
+
+	void refractionModelPlanar(vec3 V, vec3 positionWS, vec3 normalWS, float ior, float thickness, out RefractionModelResult ray) {
+	    // Refracted ray
+	    vec3 R = refract(V, normalWS, 1.0 / ior);
+	    // Optical depth within the thin plane
+	    float dist = thickness / max(dot(-normalWS, R), 1e-5f);
+
+	    ray.transmissionLength = dist;
+	    ray.positionExit = vec3(positionWS + R * dist);
+	    // ray.directionExit = V;
+	}
+
+#endif

--- a/packages/shader-shaderlab/src/shaders/PBR.gs
+++ b/packages/shader-shaderlab/src/shaders/PBR.gs
@@ -44,9 +44,9 @@ Shader "PBRShaderName" {
       }
 
       Header("Thin Film Iridescence"){
-        material_Iridescence("Iridescence", Range(0, 1, 0.01)) = 0;
-        material_IridescenceIOR("IOR", Range(1, 5, 0.01)) = 1.3;
-        material_IridescenceRange("ThicknessRange", Vector2) = (100,400);
+        iridescence("Iridescence", Range(0, 1, 0.01)) = 0;
+        iridescenceIOR("IOR", Range(1, 5, 0.01)) = 1.3;
+        iridescenceRange("ThicknessRange", Vector2) = (100, 400);
         material_IridescenceThicknessTexture("ThicknessTexture", Texture2D);
         material_IridescenceTexture("IridescenceTexture", Texture2D);
       }

--- a/packages/shader-shaderlab/src/shaders/shadingPBR/LightIndirectPBR.glsl
+++ b/packages/shader-shaderlab/src/shaders/shadingPBR/LightIndirectPBR.glsl
@@ -61,7 +61,7 @@ float evaluateClearCoatIBL(Varyings varyings, SurfaceData surfaceData, BRDFData 
     #ifdef MATERIAL_ENABLE_CLEAR_COAT
         vec3 clearCoatRadiance = getLightProbeRadiance(surfaceData, surfaceData.clearCoatNormal, brdfData.clearCoatRoughness);
         specularColor += surfaceData.specularAO * clearCoatRadiance * surfaceData.clearCoat * envBRDFApprox(brdfData.clearCoatSpecularColor, brdfData.clearCoatRoughness, surfaceData.clearCoatDotNV);
-        radianceAttenuation -= surfaceData.clearCoat * F_Schlick(0.04, surfaceData.clearCoatDotNV);
+        radianceAttenuation -= surfaceData.clearCoat * F_Schlick(surfaceData.f0, surfaceData.clearCoatDotNV);
     #endif
 
     return radianceAttenuation;

--- a/packages/shader-shaderlab/src/shaders/shadingPBR/LightIndirectPBR.glsl
+++ b/packages/shader-shaderlab/src/shaders/shadingPBR/LightIndirectPBR.glsl
@@ -76,7 +76,7 @@ void evaluateSpecularIBL(Varyings varyings, SurfaceData surfaceData, BRDFData br
         vec3 speculaColor = brdfData.specularColor;
     #endif
 
-    outSpecularColor += surfaceData.specularAO * radianceAttenuation * radiance * brdfData.envSpecularDFG;
+    outSpecularColor += surfaceData.specularAO * radianceAttenuation * radiance * envBRDFApprox(speculaColor, brdfData.roughness, surfaceData.dotNV);
 }
 
 void evaluateSheenIBL(Varyings varyings, SurfaceData surfaceData, BRDFData brdfData,  float radianceAttenuation, inout vec3 diffuseColor, inout vec3 specularColor){


### PR DESCRIPTION
* Add iri from https://github.com/galacean/engine-toolkit/pull/310
* Add sheen from https://github.com/galacean/engine-toolkit/pull/312
* Add transimission from #2478 
* Add refraction from #2470
* Fix ibl brdf in `LightIndirectPBR.glsl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced shader library with additional GLSL imports for advanced rendering techniques.
- **Improvements**
  - Expanded PBR (Physically Based Rendering) module with new shader definitions for more complex light interactions.
- **Refactor**
  - Updated naming conventions for material properties in the Thin Film Iridescence shader for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->