### PR TITLE
Fix error when physicsMaterial used in prefab

### DIFF
--- a/packages/loader/src/prefab/PrefabResource.ts
+++ b/packages/loader/src/prefab/PrefabResource.ts
@@ -33,16 +33,20 @@ export class PrefabResource extends ReferResource {
    */
   _addDependenceAsset(resource: ReferResource) {
     this._dependenceAssets.add(resource);
-    // @ts-ignore
-    resource._associationSuperResource(this);
+    if (resource instanceof ReferResource) {
+      // @ts-ignore
+      resource._associationSuperResource(this);
+    }
   }
 
   protected override _onDestroy(): void {
     super._onDestroy();
     this._root.destroy();
     this._dependenceAssets.forEach((asset) => {
-      // @ts-ignore
-      asset._disassociationSuperResource(this);
+      if (asset instanceof ReferResource) {
+        // @ts-ignore
+        asset?._disassociationSuperResource(this);
+      }
     });
   }
 }

--- a/packages/loader/src/prefab/PrefabResource.ts
+++ b/packages/loader/src/prefab/PrefabResource.ts
@@ -45,7 +45,7 @@ export class PrefabResource extends ReferResource {
     this._dependenceAssets.forEach((asset) => {
       if (asset instanceof ReferResource) {
         // @ts-ignore
-        asset?._disassociationSuperResource(this);
+        asset._disassociationSuperResource(this);
       }
     });
   }

--- a/packages/loader/src/prefab/PrefabResource.ts
+++ b/packages/loader/src/prefab/PrefabResource.ts
@@ -33,6 +33,9 @@ export class PrefabResource extends ReferResource {
    */
   _addDependenceAsset(resource: ReferResource) {
     this._dependenceAssets.add(resource);
+    // @todo: The PhysicsMaterial does not inherit from ReferResource. Currently,
+    // ReferResource requires the engine to be passed as a parameter, which prevents cross-engine reuse.
+    // A refactor of ReferResource will be needed in the future.
     if (resource instanceof ReferResource) {
       // @ts-ignore
       resource._associationSuperResource(this);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type safety for resource handling in prefab loading and destruction processes.
	- Added additional checks to prevent potential errors when processing resource dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->