### PR TITLE
Remove strict type checking

### DIFF
--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -892,6 +892,13 @@ export namespace ASTNode {
       super.init();
       if (this.children.length === 1) {
         this.type = (this.children[0] as UnaryExpression).type;
+        // TODO: Temporarily remove type deduce due to generic function type issue.
+        // } else {
+        //   const exp1 = this.children[0] as MultiplicativeExpression;
+        //   const exp2 = this.children[2] as UnaryExpression;
+        //   if (exp1.type === exp2.type) {
+        //     this.type = exp1.type;
+        //   }
       }
     }
   }
@@ -902,6 +909,13 @@ export namespace ASTNode {
       super.init();
       if (this.children.length === 1) {
         this.type = (this.children[0] as MultiplicativeExpression).type;
+        // TODO: Temporarily remove type deduce due to generic function type issue.
+        // } else {
+        //   const exp1 = this.children[0] as AdditiveExpression;
+        //   const exp2 = this.children[2] as MultiplicativeExpression;
+        //   if (exp1.type === exp2.type) {
+        //     this.type = exp1.type;
+        //   }
       }
     }
   }

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -892,12 +892,6 @@ export namespace ASTNode {
       super.init();
       if (this.children.length === 1) {
         this.type = (this.children[0] as UnaryExpression).type;
-      } else {
-        const exp1 = this.children[0] as MultiplicativeExpression;
-        const exp2 = this.children[2] as UnaryExpression;
-        if (exp1.type === exp2.type) {
-          this.type = exp1.type;
-        }
       }
     }
   }
@@ -908,12 +902,6 @@ export namespace ASTNode {
       super.init();
       if (this.children.length === 1) {
         this.type = (this.children[0] as MultiplicativeExpression).type;
-      } else {
-        const exp1 = this.children[0] as AdditiveExpression;
-        const exp2 = this.children[2] as MultiplicativeExpression;
-        if (exp1.type === exp2.type) {
-          this.type = exp1.type;
-        }
       }
     }
   }

--- a/packages/shader-lab/src/parser/builtin/functions.ts
+++ b/packages/shader-lab/src/parser/builtin/functions.ts
@@ -65,6 +65,9 @@ export class BuiltinFunction {
     BuiltinFunctionTable.set(ident, list);
   }
 
+  // TODO: correct the type deduce, consider the following case:
+  // It incorrectly inferred the type of the following expression as float, which should be vec3.
+  // max(scatterAmt.xyz,0.0001)
   static getFn(ident: string, parameterTypes: NonGenericGalaceanType[]): BuiltinFunction | undefined {
     const list = BuiltinFunctionTable.get(ident);
     if (list) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Currently ShaderLab cannot deduce some generic function type properly in Verbose version.
```glsl
// It incorrectly inferred the type of the following expression as float, which should be vec3. 
max(scatterAmt.xyz,0.0001)
```
Temporaly remove strict type checking in multiplicative and additive expression. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated type handling for multiplicative and additive expressions in the shader parsing system.
	- Removed strict type consistency checks during expression initialization.
- **Chores**
	- Added a comment regarding a future correction needed for type inference in the `getFn` method of the `BuiltinFunction` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->