### PR TITLE
Fix the error in `text.bounds` when there is no root canvas

### DIFF
--- a/packages/ui/src/component/advanced/Text.ts
+++ b/packages/ui/src/component/advanced/Text.ts
@@ -598,7 +598,8 @@ export class Text extends UIRenderer implements ITextRenderer {
       this._text === "" ||
       this._fontSize === 0 ||
       (this.enableWrapping && size.x <= 0) ||
-      (this.overflowMode === OverflowMode.Truncate && size.y <= 0)
+      (this.overflowMode === OverflowMode.Truncate && size.y <= 0) ||
+      !this._getRootCanvas()
     );
   }
 

--- a/tests/src/ui/Text.test.ts
+++ b/tests/src/ui/Text.test.ts
@@ -42,6 +42,26 @@ describe("Text", async () => {
     expect(label.enableWrapping).to.eq(true);
   });
 
+  it("get bounds", () => {
+    const textWithoutCanvas = root.addComponent(Text);
+    textWithoutCanvas.text = "hello world";
+    const bounds = textWithoutCanvas.bounds;
+    expect(bounds.min).to.deep.include({ x: -50, y: -50, z: 0 });
+    expect(bounds.max).to.deep.include({ x: 50, y: 50, z: 0 });
+
+    const labelBounds = label.bounds;
+    expect(labelBounds.min).to.deep.include({ x: -50, y: -50, z: 0 });
+    expect(labelBounds.max).to.deep.include({ x: 50, y: 50, z: 0 });
+    label.text = "hello world";
+    const labelBounds2 = label.bounds;
+    expect(labelBounds2.min).to.deep.include({ x: -50, y: -50, z: 0 });
+    expect(labelBounds2.max).to.deep.include({ x: 50, y: 50, z: 0 });
+    (<UITransform>label.entity.transform).size.x = 200;
+    const labelBounds3 = label.bounds;
+    expect(labelBounds3.min).to.deep.include({ x: -100, y: -50, z: 0 });
+    expect(labelBounds3.max).to.deep.include({ x: 100, y: 50, z: 0 });
+  });
+
   it("emoji", () => {
     const textEntity = canvasEntity.createChild("text");
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Refined the text component’s display logic to ensure that text elements render consistently under a variety of conditions, resulting in a smoother and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->