### PR TITLE
Fix scene/camera shaderData in blitter

### DIFF
--- a/packages/core/src/RenderPipeline/Blitter.ts
+++ b/packages/core/src/RenderPipeline/Blitter.ts
@@ -48,6 +48,7 @@ export class Blitter {
     const blitMaterial = material || basicResources.blitMaterial;
     const rhi = engine._hardwareRenderer;
     const context = engine._renderContext;
+    const camera = context.camera;
 
     // We not use projection matrix when blit, but we must modify flipProjection to make front face correct
     context.flipProjection = !!destination;
@@ -66,7 +67,7 @@ export class Blitter {
     const compileMacros = Shader._compileMacros;
 
     ShaderMacroCollection.unionCollection(
-      context.camera._globalShaderMacro,
+      camera._globalShaderMacro,
       blitMaterial.shaderData._macroCollection,
       compileMacros
     );
@@ -74,6 +75,8 @@ export class Blitter {
 
     program.bind();
     program.groupingOtherUniformBlock();
+    program.uploadAll(program.sceneUniformBlock, camera.scene.shaderData);
+    program.uploadAll(program.cameraUniformBlock, camera.shaderData);
     program.uploadAll(program.rendererUniformBlock, rendererShaderData);
     program.uploadAll(program.materialUniformBlock, blitMaterial.shaderData);
     program.uploadUnGroupTextures();


### PR DESCRIPTION
Users should be allowed to use the shader data of scene and camera in blitter shader, such as `camera_DepthTexture`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the rendering pipeline to ensure camera settings are applied accurately. This update contributes to smoother and more consistent visual outputs during scene rendering, enhancing the overall display quality without altering the core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->