### PR TITLE
Fix depth pass shader error with has skinned mesh

### DIFF
--- a/packages/core/src/shaderlib/extra/depthOnly.vs.glsl
+++ b/packages/core/src/shaderlib/extra/depthOnly.vs.glsl
@@ -1,3 +1,4 @@
+#define MATERIAL_OMIT_NORMAL
 #include <common>
 #include <common_vert>
 #include <blendShape_input>


### PR DESCRIPTION
one material share the same macroCollection in different pass, so we should disable normal manually in depth pass.

```glsl
// depthOnly.vs.glsl
...
#include <skinning_vert>
...
```
```glsl
// skinning_vert.glsl
...
 #if defined(RENDERER_HAS_NORMAL) && !defined(MATERIAL_OMIT_NORMAL)
     normal = normal * skinNormalMatrix;
...
```