### PR TITLE
Fix `Entity._isRoot` error and Entity modify error

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -240,7 +240,13 @@ export class Entity extends EngineObject {
       throw `The entity ${this.name} is not in the hierarchy`;
     }
 
-    this._setSiblingIndex(this._isRoot ? this._scene._rootEntities : this._parent._children, value);
+    if (this._isRoot) {
+      this._setSiblingIndex(this._scene._rootEntities, value);
+    } else {
+      const parent = this._parent;
+      this._setSiblingIndex(parent._children, value);
+      parent._dispatchModify(EntityModifyFlags.Child, parent);
+    }
   }
 
   /**
@@ -621,7 +627,7 @@ export class Entity extends EngineObject {
     if (oldParent != null) {
       Entity._removeFromChildren(oldParent._children, this);
       this._parent = null;
-      this._dispatchModify(EntityModifyFlags.Child, oldParent);
+      oldParent._dispatchModify(EntityModifyFlags.Child, oldParent);
     }
   }
 
@@ -809,7 +815,6 @@ export class Entity extends EngineObject {
         }
       }
     }
-    this._dispatchModify(EntityModifyFlags.Child, this);
   }
 
   //--------------------------------------------------------------deprecated----------------------------------------------------------------

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -686,6 +686,7 @@ export class Entity extends EngineObject {
       this._removeFromParent();
       this._parent = parent;
       if (parent) {
+        this._isRoot = false;
         parent._addToChildrenList(siblingIndex, this);
 
         const oldScene = this._scene;

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -608,5 +608,33 @@ describe("Entity", async () => {
       entity.destroy();
       expect(entity.children.length).eq(0);
     });
+
+    it("addChildAfterDestroy", () => {
+      class DestroyScript extends Script {
+        onDisable(): void {}
+        onDestroy(): void {}
+      }
+      DestroyScript.prototype.onDisable = vi.fn(DestroyScript.prototype.onDisable);
+      DestroyScript.prototype.onDestroy = vi.fn(DestroyScript.prototype.onDestroy);
+
+      const root = scene.createRootEntity("root");
+      const entity = root.createChild("entity");
+      const script = entity.addComponent(DestroyScript);
+      entity.destroy();
+      expect(entity.isActive).eq(false);
+      expect(entity.isActiveInHierarchy).eq(false);
+      expect(entity.parent).eq(null);
+      expect(entity.scene).eq(null);
+      expect(script.onDisable).toHaveBeenCalledTimes(1);
+
+      expect(entity.createChild("child0").isActiveInHierarchy).eq(false);
+      root.destroy();
+      expect(root.isActive).eq(false);
+      expect(root.isActiveInHierarchy).eq(false);
+      expect(root.createChild("child1").isActiveInHierarchy).eq(false);
+
+      engine.update();
+      expect(script.onDestroy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -400,70 +400,20 @@ describe("Entity", async () => {
       };
       expect(lonelyBadFn).to.throw();
     });
-  });
 
-  describe("clone", () => {
-    it("normal", () => {
-      const parent = new Entity(engine, "parent");
-
-      parent.parent = scene.getRootEntity();
-      const child = new Entity(engine, "child");
+    it("isRoot", () => {
+      const parent = scene.createRootEntity("parent");
+      const child = scene.createRootEntity("child");
+      parent.addChild(child);
+      scene.addRootEntity(child);
+      // @ts-ignore
+      expect(child._isRoot).eq(true);
       child.parent = parent;
-      const cloneParent = parent.clone();
-      expect(cloneParent.children.length).eq(parent.children.length);
-      expect(cloneParent.findByName("child").name).eq(child.name);
-      expect(cloneParent.findByName("child")).eq(cloneParent.getChild(0));
-    });
-  });
-
-  describe("destroy", () => {
-    it("normal", () => {
-      const parent = new Entity(engine, "parent");
-
-      parent.parent = scene.getRootEntity();
-      const child = new Entity(engine, "child");
-      child.parent = parent;
-      child.destroy();
-      expect(parent.children.length).eq(0);
-    });
-
-    it("children", () => {
-      const entity = new Entity(engine, "entity");
-      entity.createChild("child0");
-      entity.createChild("child1");
-      entity.createChild("child2");
-      entity.createChild("child3");
-      entity.createChild("child4");
-      entity.destroy();
-      expect(entity.children.length).eq(0);
-    });
-
-    it("addChildAfterDestroy", () => {
-      class DestroyScript extends Script {
-        onDisable(): void {}
-        onDestroy(): void {}
-      }
-      DestroyScript.prototype.onDisable = vi.fn(DestroyScript.prototype.onDisable);
-      DestroyScript.prototype.onDestroy = vi.fn(DestroyScript.prototype.onDestroy);
-
-      const root = scene.createRootEntity("root");
-      const entity = root.createChild("entity");
-      const script = entity.addComponent(DestroyScript);
-      entity.destroy();
-      expect(entity.isActive).eq(false);
-      expect(entity.isActiveInHierarchy).eq(false);
-      expect(entity.parent).eq(null);
-      expect(entity.scene).eq(null);
-      expect(script.onDisable).toHaveBeenCalledTimes(1);
-
-      expect(entity.createChild("child0").isActiveInHierarchy).eq(false);
-      root.destroy();
-      expect(root.isActive).eq(false);
-      expect(root.isActiveInHierarchy).eq(false);
-      expect(root.createChild("child1").isActiveInHierarchy).eq(false);
-
-      engine.update();
-      expect(script.onDestroy).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(child._isRoot).eq(false);
+      scene.addRootEntity(child);
+      // @ts-ignore
+      expect(child._isRoot).eq(true);
     });
 
     it("InActiveAndActive", () => {
@@ -562,20 +512,101 @@ describe("Entity", async () => {
       expect(enableInSceneCount).eq(3);
       expect(disableInSceneCount).eq(3);
     });
+  });
 
-    it("isRoot", () => {
-      const parent = scene.createRootEntity("parent");
-      const child = scene.createRootEntity("child");
-      parent.addChild(child);
-      scene.addRootEntity(child);
-      // @ts-ignore
-      expect(child._isRoot).eq(true);
+  describe("clone", () => {
+    it("normal", () => {
+      const parent = new Entity(engine, "parent");
+
+      parent.parent = scene.getRootEntity();
+      const child = new Entity(engine, "child");
       child.parent = parent;
+      const cloneParent = parent.clone();
+      expect(cloneParent.children.length).eq(parent.children.length);
+      expect(cloneParent.findByName("child").name).eq(child.name);
+      expect(cloneParent.findByName("child")).eq(cloneParent.getChild(0));
+    });
+  });
+
+  describe("modify", () => {
+    it("ParentAndChild", () => {
+      const parentA = scene.createRootEntity("parentA");
+      const parentB = scene.createRootEntity("parentB");
+      const child = new Entity(engine, "child");
+
+      let modifyParentACount = [0, 0, 0];
+      let modifyParentBCount = [0, 0, 0];
+      let modifyChildCount = [0, 0, 0];
+
+      const modifyParentA = (flag: EntityModifyFlags, child: Entity) => {
+        ++modifyParentACount[flag];
+      };
+      const modifyParentB = (flag: EntityModifyFlags, child: Entity) => {
+        ++modifyParentBCount[flag];
+      };
+      const modifyChild = (flag: EntityModifyFlags, child: Entity) => {
+        ++modifyChildCount[flag];
+      };
       // @ts-ignore
-      expect(child._isRoot).eq(false);
-      scene.addRootEntity(child);
+      parentA._registerModifyListener(modifyParentA);
       // @ts-ignore
-      expect(child._isRoot).eq(true);
+      parentB._registerModifyListener(modifyParentB);
+      // @ts-ignore
+      child._registerModifyListener(modifyChild);
+
+      expect(modifyParentACount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyParentACount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Parent]).eq(0);
+      parentA.addChild(child);
+
+      expect(modifyParentACount[EntityModifyFlags.Child]).eq(1);
+      expect(modifyParentACount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Parent]).eq(1);
+
+      child.siblingIndex = 2;
+      expect(modifyParentACount[EntityModifyFlags.Child]).eq(2);
+      expect(modifyParentACount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Parent]).eq(1);
+
+      parentB.addChild(child);
+      expect(modifyParentACount[EntityModifyFlags.Child]).eq(3);
+      expect(modifyParentACount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyParentBCount[EntityModifyFlags.Child]).eq(1);
+      expect(modifyParentBCount[EntityModifyFlags.Parent]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Child]).eq(0);
+      expect(modifyChildCount[EntityModifyFlags.Parent]).eq(2);
+    });
+  });
+
+  describe("destroy", () => {
+    it("normal", () => {
+      const parent = new Entity(engine, "parent");
+
+      parent.parent = scene.getRootEntity();
+      const child = new Entity(engine, "child");
+      child.parent = parent;
+      child.destroy();
+      expect(parent.children.length).eq(0);
+    });
+
+    it("children", () => {
+      const entity = new Entity(engine, "entity");
+      entity.createChild("child0");
+      entity.createChild("child1");
+      entity.createChild("child2");
+      entity.createChild("child3");
+      entity.createChild("child4");
+      entity.destroy();
+      expect(entity.children.length).eq(0);
     });
   });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved management of entity relationships, ensuring accurate updates and notifications for hierarchy changes.
- **Tests**
  - Expanded test coverage to verify root status, activation state handling, and modification event triggering.
  - Removed an outdated test to focus on more relevant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->