### PR TITLE
Fix particle `ForceOverLifetime` bug when render mode is `stretched`

### DIFF
--- a/e2e/case/particleRenderer-force.ts
+++ b/e2e/case/particleRenderer-force.ts
@@ -247,6 +247,7 @@ function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
   particleEntity.transform.position.set(-1.54, 0, 0);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+  particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
   const material = new ParticleMaterial(fireEntity.engine);
   material.baseTexture = texture;
   particleRenderer.setMaterial(material);

--- a/e2e/case/particleRenderer-force.ts
+++ b/e2e/case/particleRenderer-force.ts
@@ -18,6 +18,7 @@ import {
   ParticleMaterial,
   ParticleRenderMode,
   ParticleRenderer,
+  Scene,
   Texture2D,
   Vector3,
   WebGLEngine,
@@ -33,15 +34,28 @@ WebGLEngine.create({
   Logger.enable();
   engine.canvas.resizeByClientSize();
 
-  const scene = engine.sceneManager.activeScene;
-  const rootEntity = scene.createRootEntity();
-  scene.background.solidColor = new Color(15 / 255, 38 / 255, 18 / 255, 1);
+  const leftScene = engine.sceneManager.activeScene;
+  const leftRootEntity = leftScene.createRootEntity();
+  leftScene.background.solidColor = new Color(15 / 255, 38 / 255, 18 / 255, 1);
+
+  const rightScene = new Scene(engine);
+  engine.sceneManager.addScene(rightScene);
+  const rightRootEntity = rightScene.createRootEntity();
+  rightScene.background.solidColor = new Color(15 / 255, 38 / 255, 18 / 255, 1);
 
   // Create camera
-  const cameraEntity = rootEntity.createChild("camera_entity");
-  cameraEntity.transform.position = new Vector3(0, 1, 3);
-  const camera = cameraEntity.addComponent(Camera);
-  camera.fieldOfView = 60;
+  const leftCameraEntity = leftRootEntity.createChild("left-camera");
+  leftCameraEntity.transform.position = new Vector3(0, 1, 3);
+  const leftCamera = leftCameraEntity.addComponent(Camera);
+  leftCamera.viewport.set(0, 0, 0.5, 1);
+  leftCamera.fieldOfView = 60;
+
+  const rightCameraEntity = rightRootEntity.createChild("right-camera");
+  const rightCamera = rightCameraEntity.addComponent(Camera);
+  rightCamera.viewport.set(0.5, 0, 0.5, 1);
+  rightCamera.fieldOfView = 60;
+  rightCameraEntity.transform.setPosition(10, 10, 20);
+  rightCameraEntity.transform.lookAt(new Vector3(0, 0, 0));
 
   engine.run();
 
@@ -65,23 +79,37 @@ WebGLEngine.create({
       }
     ])
     .then((textures) => {
-      const fireEntity = createDebrisParticle(engine, <Texture2D>textures[0]);
-      createGlowParticle(fireEntity, <Texture2D>textures[1]);
-      createSparksParticle(fireEntity, <Texture2D>textures[2]);
-      createHighlightsParticle(fireEntity, <Texture2D>textures[3]);
+      const leftFireEntity = createDebrisParticle(engine, <Texture2D>textures[0]);
+      createGlowParticle(leftFireEntity, <Texture2D>textures[1]);
+      createSparksParticle(leftFireEntity, <Texture2D>textures[2]);
+      createHighlightsParticle(leftFireEntity, <Texture2D>textures[3]);
+      leftCameraEntity.addChild(leftFireEntity);
 
-      cameraEntity.addChild(fireEntity);
+      const rightFireEntity = createDebrisParticle(engine, <Texture2D>textures[0], true, 2);
+      createGlowParticle(rightFireEntity, <Texture2D>textures[1], true, 3);
+      createSparksParticle(rightFireEntity, <Texture2D>textures[2], true, 4);
+      createHighlightsParticle(rightFireEntity, <Texture2D>textures[3], true, 5);
+      rightCameraEntity.addChild(rightFireEntity);
 
       updateForE2E(engine, 500);
-      initScreenshot(engine, camera);
+      initScreenshot(engine, [leftCamera, rightCamera]);
     });
 });
 
-function createDebrisParticle(engine: Engine, texture: Texture2D): Entity {
+function createDebrisParticle(
+  engine: Engine,
+  texture: Texture2D,
+  stretch: boolean = false,
+  lengthScale: number = 2
+): Entity {
   const particleEntity = new Entity(engine, "Debris");
   particleEntity.transform.position.set(0, -7.5, -8);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+  if (stretch) {
+    particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
+    particleRenderer.lengthScale = lengthScale;
+  }
 
   const material = new ParticleMaterial(engine);
   material.baseColor = new Color(1.0, 1.0, 1.0, 1.0);
@@ -150,27 +178,34 @@ function createDebrisParticle(engine: Engine, texture: Texture2D): Entity {
   forceOverLifetime.enabled = true;
   const { forceX, forceY, forceZ } = forceOverLifetime;
   forceX.mode = ParticleCurveMode.Constant;
-  forceX.constantMax = 0;
+  forceX.constantMax = 2;
   forceX.constantMin = -10;
 
   forceY.mode = ParticleCurveMode.Constant;
-  forceY.constantMax = 10;
+  forceY.constantMax = 2;
   forceY.constantMin = 0;
 
   forceZ.mode = ParticleCurveMode.Constant;
-  forceZ.constantMax = 0;
+  forceZ.constantMax = 2;
   forceZ.constantMin = 0;
 
   return particleEntity;
 }
 
-function createGlowParticle(fireEntity: Entity, texture: Texture2D): void {
+function createGlowParticle(
+  fireEntity: Entity,
+  texture: Texture2D,
+  stretch: boolean = false,
+  lengthScale: number = 2
+): void {
   const particleEntity = fireEntity.createChild("Glow");
   particleEntity.transform.position.set(-1.88, 0, 0);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
-  particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
-  particleRenderer.lengthScale = 2;
+  if (stretch) {
+    particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
+    particleRenderer.lengthScale = lengthScale;
+  }
 
   const material = new ParticleMaterial(fireEntity.engine);
   material.blendMode = BlendMode.Additive;
@@ -179,8 +214,8 @@ function createGlowParticle(fireEntity: Entity, texture: Texture2D): void {
   particleRenderer.priority = 1;
 
   const generator = particleRenderer.generator;
-  generator.useAutoRandomSeed = false;
   const { main, emission, velocityOverLifetime, colorOverLifetime, forceOverLifetime } = generator;
+  particleRenderer.generator.useAutoRandomSeed = false;
 
   // Main module
   main.startSpeed.constant = 0.0;
@@ -242,12 +277,16 @@ function createGlowParticle(fireEntity: Entity, texture: Texture2D): void {
   forceZ.constantMin = 0;
 }
 
-function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
+function createSparksParticle(fireEntity: Entity, texture: Texture2D, stretch = false, lengthScale = 2): void {
   const particleEntity = fireEntity.createChild("Sparks");
   particleEntity.transform.position.set(-1.54, 0, 0);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
-  particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
+  if (stretch) {
+    particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
+    particleRenderer.lengthScale = lengthScale;
+  }
+
   const material = new ParticleMaterial(fireEntity.engine);
   material.baseTexture = texture;
   particleRenderer.setMaterial(material);
@@ -313,21 +352,25 @@ function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
   forceZ.curveMax = new ParticleCurve(new CurveKey(0, 0.2), new CurveKey(0.5, 8), new CurveKey(1, 0.8));
 }
 
-function createHighlightsParticle(fireEntity: Entity, texture: Texture2D): void {
+function createHighlightsParticle(fireEntity: Entity, texture: Texture2D, stretch = false, lengthScale = 2): void {
   const particleEntity = fireEntity.createChild("Highlights");
   particleEntity.transform.position.set(-5.31, 0, 0);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+  if (stretch) {
+    particleRenderer.renderMode = ParticleRenderMode.StretchBillboard;
+    particleRenderer.lengthScale = lengthScale;
+  }
 
   const material = new ParticleMaterial(fireEntity.engine);
   material.blendMode = BlendMode.Additive;
   material.baseTexture = texture;
   particleRenderer.setMaterial(material);
   particleRenderer.priority = 3;
+  particleRenderer.generator.useAutoRandomSeed = false;
 
   const generator = particleRenderer.generator;
   const { main, emission, sizeOverLifetime, colorOverLifetime, velocityOverLifetime, forceOverLifetime } = generator;
-  generator.useAutoRandomSeed = false;
 
   // Main module
   main.startSpeed.constant = 0;

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -208,7 +208,7 @@ export const E2E_CONFIG = {
     forceOverLifetime: {
       category: "Particle",
       caseFileName: "particleRenderer-force",
-      threshold: 0.3
+      threshold: 0.1
     },
     textureSheetAnimation: {
       category: "Particle",

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -203,7 +203,7 @@ export const E2E_CONFIG = {
     particleDream: {
       category: "Particle",
       caseFileName: "particleRenderer-dream",
-      threshold: 0.3
+      threshold: 0.1
     },
     forceOverLifetime: {
       category: "Particle",
@@ -213,12 +213,12 @@ export const E2E_CONFIG = {
     textureSheetAnimation: {
       category: "Particle",
       caseFileName: "particleRenderer-textureSheetAnimation",
-      threshold: 0.3
+      threshold: 0.1
     },
     particleShapeMesh: {
       category: "Particle",
       caseFileName: "particleRenderer-shape-mesh",
-      threshold: 0.3
+      threshold: 0.1
     }
   },
   PostProcess: {
@@ -261,7 +261,7 @@ export const E2E_CONFIG = {
     ProjectLoader: {
       category: "Advance",
       caseFileName: "project-loader",
-      threshold: 0.4
+      threshold: 0.1
     },
     MultiSceneClear: {
       category: "Advance",

--- a/e2e/fixtures/originImage/Particle_particleRenderer-dream.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-dream.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34e8af9b64ce0084ee8be066566141782767265e368b91f5b5cc399235c4f264
-size 385654
+oid sha256:a9d52d19398d799d896b3a2c30b7a3abcfecd53d80bfe7c88e4293881e1e473b
+size 387111

--- a/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a523a75d0198df9aad71df5f4e8c43e743c37f5abc5cd8b5357db31bc3eba903
-size 427877
+oid sha256:bf51468d4a3fd8482a9a0611352abfee86535a76909c262c7de5985c9a69af0c
+size 429501

--- a/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae8f51bc585537f6a71de0f3858d94a9cdb2ff6ee923bb8cd907b5ba44674a2d
-size 353889
+oid sha256:a523a75d0198df9aad71df5f4e8c43e743c37f5abc5cd8b5357db31bc3eba903
+size 427877

--- a/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-force.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf51468d4a3fd8482a9a0611352abfee86535a76909c262c7de5985c9a69af0c
-size 429501
+oid sha256:af90e70392dbecba225a9b2d3b8fd2d3967b475fa2a89d8524d45c18f687c46f
+size 480255

--- a/packages/core/src/shaderlib/extra/particle.vs.glsl
+++ b/packages/core/src/shaderlib/extra/particle.vs.glsl
@@ -92,10 +92,13 @@ vec3 computeParticlePosition(in vec3 startVelocity, in float age, in float norma
     #endif
 
     #ifdef _FOL_MODULE_ENABLED
-        vec3 forcePositionOffset = computeForcePositionOffset(normalizedAge, age);
+        vec3 forceVelocity;
+        vec3 forcePositionOffset = computeForcePositionOffset(normalizedAge, age, forceVelocity);
         if (renderer_FOLSpace == 0) {
+            localVelocity += forceVelocity;
             localPositionOffset += forcePositionOffset;
         } else {
+            worldVelocity += forceVelocity;
             worldPositionOffset += forcePositionOffset;
         }
     #endif

--- a/packages/core/src/shaderlib/particle/force_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/force_over_lifetime_module.glsl
@@ -33,10 +33,6 @@
     float computeDisplacementIntegral(in float to, in float tr, in float a1, in float a2, in float v1) {
         return to * to * to * (a2 - a1) / (tr * 6.0) + a1 * to * to * 0.5 + v1 * to;
     }
-    // float computeDisplacementIntegral(in float tHat, in float t1, in float t2, in float a1, in float a2, in float v1) {
-    //     float tHatSubT1 = tHat - t1;
-    //     return tHatSubT1 * tHatSubT1 * tHatSubT1 * (a2 - a1) / ((t2 - t1) * 6.0) + a1 * tHatSubT1 * tHatSubT1 * 0.5 + v1 * tHatSubT1;
-    // }
 
     float evaluateForceParticleCurveCumulative(in vec2 keys[4], in float normalizedAge, out float velocityCumulative) {
         float cumulativeValue = 0.0;

--- a/packages/core/src/shaderlib/particle/force_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/force_over_lifetime_module.glsl
@@ -34,9 +34,10 @@
         return tHatSubT1 * tHatSubT1 * tHatSubT1 * (a2 - a1) / ((t2 - t1) * 6.0) + a1 * tHatSubT1 * tHatSubT1 * 0.5 + v1 * tHatSubT1;
     }
 
-    float evaluateForceParticleCurveCumulative(in vec2 keys[4], in float normalizedAge) {
+    float evaluateForceParticleCurveCumulative(in vec2 keys[4], in float normalizedAge, out float velocityOffsetComponent) {
         float cumulativeValue = 0.0;
-        float lastVelocity = 0.0;
+        velocityOffsetComponent = 0.0;
+
         for (int i = 1; i < 4; i++){
             vec2 key = keys[i];
             vec2 lastKey = keys[i - 1];
@@ -45,38 +46,50 @@
 
             if (key.x >= normalizedAge){
                 float tHat = normalizedAge * a_ShapePositionStartLifeTime.w;
-                cumulativeValue += computeDisplacementIntegral(tHat, t1, t2, lastKey.y, key.y, lastVelocity);
+                cumulativeValue += computeDisplacementIntegral(tHat, t1, t2, lastKey.y, key.y, velocityOffsetComponent);
+
+                float timeOffset = normalizedAge - lastKey.x;
+                float ratio = timeOffset / (key.x - lastKey.x);
+                float finalAcceleration = mix(lastKey.y, key.y, ratio);
+                velocityOffsetComponent += 0.5 * timeOffset * (finalAcceleration + lastKey.y);
                 break;
             } else {  
-                cumulativeValue += computeDisplacementIntegral(t2, t1, t2, lastKey.y, key.y, lastVelocity);
-                lastVelocity += 0.5 * (t2 - t1) * (lastKey.y + key.y);
+                cumulativeValue += computeDisplacementIntegral(t2, t1, t2, lastKey.y, key.y, velocityOffsetComponent);
+                velocityOffsetComponent += 0.5 * (t2 - t1) * (lastKey.y + key.y);
             }
         }
         return cumulativeValue;
     }
 
-    vec3 computeForcePositionOffset(in float normalizedAge, in float age) {
+    vec3 computeForcePositionOffset(in float normalizedAge, in float age, out vec3 velocityOffset) {
         vec3 forcePosition;
 
         #if defined(RENDERER_FOL_CONSTANT_MODE)
             vec3 forceAcceleration = renderer_FOLMaxConst;
+
             #ifdef RENDERER_FOL_IS_RANDOM_TWO
                 forceAcceleration = mix(renderer_FOLMinConst, forceAcceleration, vec3(a_Random2.x, a_Random2.y, a_Random2.z));
             #endif
 
+            velocityOffset = forceAcceleration * age;
+
             forcePosition = 0.5 * forceAcceleration * age * age;
         #elif defined(RENDERER_FOL_CURVE_MODE)
             forcePosition = vec3(
-                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientX, normalizedAge),
-                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientY, normalizedAge),
-                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientZ, normalizedAge)
+                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientX, normalizedAge, velocityOffset.x),
+                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientY, normalizedAge, velocityOffset.y),
+                evaluateForceParticleCurveCumulative(renderer_FOLMaxGradientZ, normalizedAge, velocityOffset.z)
             );
             #ifdef RENDERER_FOL_IS_RANDOM_TWO
+                vec3 minVelocityOffset;
+
                 forcePosition = vec3(
-                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientX, normalizedAge), forcePosition.x, a_Random2.x),
-                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientY, normalizedAge), forcePosition.y, a_Random2.y),
-                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientZ, normalizedAge), forcePosition.z, a_Random2.z)
+                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientX, normalizedAge, minVelocityOffset.x), forcePosition.x, a_Random2.x),
+                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientY, normalizedAge, minVelocityOffset.y), forcePosition.y, a_Random2.y),
+                    mix(evaluateForceParticleCurveCumulative(renderer_FOLMinGradientZ, normalizedAge, minVelocityOffset.z), forcePosition.z, a_Random2.z)
                 );
+
+                velocityOffset = mix(minVelocityOffset, velocityOffset, vec3(a_Random2.x, a_Random2.y, a_Random2.z));
             #endif
         #endif
         return forcePosition;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Comparison with streched billboard render mode

- Unity
![unity p](https://github.com/user-attachments/assets/711d51f8-5131-4621-abe9-170f3f3da34a) 

- Galacean before
![galacean b](https://github.com/user-attachments/assets/6f7764ce-6330-458e-83e4-cf63cfab7a9c)

- Galacean current
![editor p](https://github.com/user-attachments/assets/2a9e4f47-62bb-4679-a3dd-ed6d49d27506)  

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dual-scene rendering capabilities, enhancing visual output with separate camera views.
  - Updated particle creation functions to allow for additional rendering options, improving flexibility in effects.

- **Bug Fixes**
  - Adjusted threshold values for various particle properties to improve evaluation criteria and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->