### PR TITLE
Texture support `R8` and `R8G8` Format

### DIFF
--- a/e2e/case/particleRenderer-force.ts
+++ b/e2e/case/particleRenderer-force.ts
@@ -28,8 +28,7 @@ import { initScreenshot, updateForE2E } from "./.mockForE2E";
 
 // Create engine
 WebGLEngine.create({
-  canvas: "canvas",
-  graphicDeviceOptions: { webGLMode: WebGLMode.WebGL1 }
+  canvas: "canvas"
 }).then((engine) => {
   Logger.enable();
   engine.canvas.resizeByClientSize();

--- a/e2e/case/texture-R8G8.ts
+++ b/e2e/case/texture-R8G8.ts
@@ -1,0 +1,53 @@
+/**
+ * @title PrimitiveMesh
+ * @category Primitive
+ */
+import {
+  Camera,
+  Logger,
+  MeshRenderer,
+  PrimitiveMesh,
+  Texture2D,
+  TextureFormat,
+  UnlitMaterial,
+  WebGLEngine
+} from "@galacean/engine";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+Logger.enable();
+WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
+  engine.canvas.resizeByClientSize(2);
+
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+
+  // Create camera
+  const cameraEntity = rootEntity.createChild("Camera");
+  cameraEntity.transform.setPosition(0, 0, 1);
+  const camera = cameraEntity.addComponent(Camera);
+
+  // Create Plane
+  const material = new UnlitMaterial(engine);
+  const planeEntity = rootEntity.createChild("ground");
+  planeEntity.transform.setRotation(5, 0, 0);
+
+  const planeRenderer = planeEntity.addComponent(MeshRenderer);
+  planeRenderer.mesh = PrimitiveMesh.createPlane(engine, 2, 2);
+  planeRenderer.setMaterial(material);
+
+  const width = 1024;
+  const height = 1024;
+  const r8Texture = new Texture2D(engine, width, height, TextureFormat.R8G8, false);
+  const pixels = new Uint8Array(width * height * 2); // 2 bytes per pixel (R and G)
+  for (let i = 0; i < width * height; i++) {
+    pixels[i * 2] = 200; // R
+    pixels[i * 2 + 1] = 128; // G
+  }
+  r8Texture.setPixelBuffer(pixels);
+  r8Texture.generateMipmaps();
+
+  material.baseTexture = r8Texture;
+
+  updateForE2E(engine);
+  initScreenshot(engine, camera);
+});

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -141,6 +141,11 @@ export const E2E_CONFIG = {
       category: "Texture",
       caseFileName: "texture-sRGB-KTX2",
       threshold: 0.2
+    },
+    R8G8: {
+      category: "Texture",
+      caseFileName: "texture-R8G8",
+      threshold: 0.1
     }
   },
   Shadow: {

--- a/e2e/fixtures/originImage/Texture_texture-R8G8.jpg
+++ b/e2e/fixtures/originImage/Texture_texture-R8G8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78ad76f8b12350e3d24dcd91dd2e959c3f93a867c09d89394d8f7f5cbf5bf5a4
+size 19039

--- a/examples/benchmark-particle.ts
+++ b/examples/benchmark-particle.ts
@@ -29,14 +29,13 @@ import {
   Vector2,
   Vector3,
   WebGLEngine,
-  WebGLMode,
+  WebGLMode
 } from "@galacean/engine";
 import { Stats } from "@galacean/engine-toolkit";
 
 // Create engine
 WebGLEngine.create({
-  canvas: "canvas",
-  graphicDeviceOptions: { webGLMode: WebGLMode.WebGL1 },
+  canvas: "canvas"
 }).then((engine) => {
   Logger.enable();
   engine.canvas.resizeByClientSize();
@@ -58,20 +57,20 @@ WebGLEngine.create({
     .load([
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*yu-DSb0surwAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: " https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*JlayRa2WltYAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*cFafRr6WaWUAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*TASTTpESkIIAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
-      },
+        type: AssetType.Texture2D
+      }
     ])
     .then((textures) => {
       const fireEntity = createFireParticle(engine, <Texture2D>textures[0]);
@@ -104,13 +103,7 @@ function createFireParticle(engine: Engine, texture: Texture2D): Entity {
   particleRenderer.priority = 2;
 
   const generator = particleRenderer.generator;
-  const {
-    main,
-    emission,
-    textureSheetAnimation,
-    sizeOverLifetime,
-    colorOverLifetime,
-  } = generator;
+  const { main, emission, textureSheetAnimation, sizeOverLifetime, colorOverLifetime } = generator;
 
   // Main module
   main.startLifetime.constantMin = 0.2;
@@ -202,12 +195,7 @@ function createFireGlowParticle(fireEntity: Entity, texture: Texture2D): void {
   main.startRotationZ.constantMax = 360;
   main.startRotationZ.mode = ParticleCurveMode.TwoConstants;
 
-  main.startColor.constant = new Color(
-    255 / 255,
-    100 / 255,
-    0 / 255,
-    168 / 255
-  );
+  main.startColor.constant = new Color(255 / 255, 100 / 255, 0 / 255, 168 / 255);
 
   main.simulationSpace = ParticleSimulationSpace.World;
 
@@ -258,13 +246,7 @@ function createFireSmokeParticle(fireEntity: Entity, texture: Texture2D): void {
   particleRenderer.priority = 0;
 
   const generator = particleRenderer.generator;
-  const {
-    main,
-    emission,
-    sizeOverLifetime,
-    colorOverLifetime,
-    textureSheetAnimation,
-  } = generator;
+  const { main, emission, sizeOverLifetime, colorOverLifetime, textureSheetAnimation } = generator;
 
   // Main module
   main.startLifetime.constantMin = 1;
@@ -279,12 +261,7 @@ function createFireSmokeParticle(fireEntity: Entity, texture: Texture2D): void {
   main.startRotationZ.constantMax = 360;
   main.startRotationZ.mode = ParticleCurveMode.TwoConstants;
 
-  main.startColor.constant = new Color(
-    255 / 255,
-    255 / 255,
-    255 / 255,
-    84 / 255
-  );
+  main.startColor.constant = new Color(255 / 255, 255 / 255, 255 / 255, 84 / 255);
 
   main.gravityModifier.constant = -0.05;
 
@@ -335,10 +312,7 @@ function createFireSmokeParticle(fireEntity: Entity, texture: Texture2D): void {
   frameOverTime.curveMax.keys[1].value = 0.382;
 }
 
-function createFireEmbersParticle(
-  fireEntity: Entity,
-  texture: Texture2D
-): void {
+function createFireEmbersParticle(fireEntity: Entity, texture: Texture2D): void {
   const particleEntity = fireEntity.createChild("FireEmbers");
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
@@ -350,14 +324,7 @@ function createFireEmbersParticle(
   particleRenderer.priority = 3;
 
   const generator = particleRenderer.generator;
-  const {
-    main,
-    emission,
-    sizeOverLifetime,
-    colorOverLifetime,
-    velocityOverLifetime,
-    rotationOverLifetime,
-  } = generator;
+  const { main, emission, sizeOverLifetime, colorOverLifetime, velocityOverLifetime, rotationOverLifetime } = generator;
 
   // Main module
   main.duration = 3;

--- a/examples/particle-dream.ts
+++ b/examples/particle-dream.ts
@@ -19,14 +19,12 @@ import {
   ParticleRenderer,
   Texture2D,
   Vector3,
-  WebGLEngine,
-  WebGLMode,
+  WebGLEngine
 } from "@galacean/engine";
 
 // Create engine
 WebGLEngine.create({
-  canvas: "canvas",
-  graphicDeviceOptions: { webGLMode: WebGLMode.WebGL1 },
+  canvas: "canvas"
 }).then((engine) => {
   Logger.enable();
   engine.canvas.resizeByClientSize();
@@ -47,20 +45,20 @@ WebGLEngine.create({
     .load([
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*JPsCSK5LtYkAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*eWTFRZPqfDMAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*J8uhRoxJtYgAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
+        type: AssetType.Texture2D
       },
       {
         url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*Ea3qRb1yCQMAAAAAAAAAAAAADil6AQ/original",
-        type: AssetType.Texture2D,
-      },
+        type: AssetType.Texture2D
+      }
     ])
     .then((textures) => {
       const fireEntity = createDebrisParticle(engine, <Texture2D>textures[0]);
@@ -85,13 +83,7 @@ function createDebrisParticle(engine: Engine, texture: Texture2D): Entity {
   particleRenderer.setMaterial(material);
   particleRenderer.priority = 2;
 
-  const {
-    main,
-    emission,
-    sizeOverLifetime,
-    colorOverLifetime,
-    velocityOverLifetime,
-  } = particleRenderer.generator;
+  const { main, emission, sizeOverLifetime, colorOverLifetime, velocityOverLifetime } = particleRenderer.generator;
 
   // Main module
   main.startSpeed.constant = 0;
@@ -176,18 +168,8 @@ function createGlowParticle(fireEntity: Entity, texture: Texture2D): void {
   main.startRotationZ.constantMax = 360;
   main.startRotationZ.mode = ParticleCurveMode.TwoConstants;
 
-  main.startColor.constantMin = new Color(
-    0 / 255,
-    157 / 255,
-    255 / 255,
-    64 / 255
-  );
-  main.startColor.constantMax = new Color(
-    13 / 255,
-    255 / 255,
-    0 / 255,
-    128 / 255
-  );
+  main.startColor.constantMin = new Color(0 / 255, 157 / 255, 255 / 255, 64 / 255);
+  main.startColor.constantMax = new Color(13 / 255, 255 / 255, 0 / 255, 128 / 255);
   main.startColor.mode = ParticleGradientMode.TwoConstants;
 
   // Emission module
@@ -232,8 +214,7 @@ function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
   particleRenderer.setMaterial(material);
   particleRenderer.priority = 0;
 
-  const { main, emission, colorOverLifetime, velocityOverLifetime } =
-    particleRenderer.generator;
+  const { main, emission, colorOverLifetime, velocityOverLifetime } = particleRenderer.generator;
 
   // Main module
   main.startLifetime.constant = 5;
@@ -247,12 +228,7 @@ function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
   main.startRotationZ.constantMax = 360;
   main.startRotationZ.mode = ParticleCurveMode.TwoConstants;
 
-  main.startColor.constant = new Color(
-    37 / 255,
-    133 / 255,
-    255 / 255,
-    255 / 255
-  );
+  main.startColor.constant = new Color(37 / 255, 133 / 255, 255 / 255, 255 / 255);
 
   // Emission module
   emission.rateOverTime.constant = 30;
@@ -286,10 +262,7 @@ function createSparksParticle(fireEntity: Entity, texture: Texture2D): void {
   gradient.addAlphaKey(0.8, 1.0);
 }
 
-function createHighlightsParticle(
-  fireEntity: Entity,
-  texture: Texture2D
-): void {
+function createHighlightsParticle(fireEntity: Entity, texture: Texture2D): void {
   const particleEntity = fireEntity.createChild("Highlights");
   particleEntity.transform.position.set(-5.31, 0, 0);
 
@@ -302,13 +275,7 @@ function createHighlightsParticle(
   particleRenderer.priority = 3;
 
   const generator = particleRenderer.generator;
-  const {
-    main,
-    emission,
-    sizeOverLifetime,
-    colorOverLifetime,
-    velocityOverLifetime,
-  } = generator;
+  const { main, emission, sizeOverLifetime, colorOverLifetime, velocityOverLifetime } = generator;
 
   // Main module
   main.startSpeed.constant = 0;

--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -1,7 +1,10 @@
+import { GLCapabilityType } from "./base/Constant";
+import { Engine } from "./Engine";
 import { Platform } from "./Platform";
+import { TextureFormat } from "./texture";
 
 /**
- * System info.
+ * Access operating system, platform and hardware information.
  */
 export class SystemInfo {
   /** The platform is running on. */
@@ -79,6 +82,46 @@ export class SystemInfo {
       );
     }
     return this._simdSupported;
+  }
+
+  /**
+   * Checks whether the system supports the given texture format.
+   * @param format - The texture format
+   * @returns Whether support the texture format
+   */
+  static supportsTextureFormat(engine: Engine, format: TextureFormat): boolean {
+    const rhi = engine._hardwareRenderer;
+    rhi.canIUse(GLCapabilityType.depthTexture);
+    switch (format) {
+      case TextureFormat.R16G16B16A16:
+        if (!rhi.canIUse(GLCapabilityType.textureHalfFloat)) {
+          return false;
+        }
+        break;
+      case TextureFormat.R32G32B32A32:
+        if (!rhi.canIUse(GLCapabilityType.textureFloat)) {
+          return false;
+        }
+        break;
+      case TextureFormat.Depth16:
+      case TextureFormat.Depth24Stencil8:
+      case TextureFormat.Depth:
+      case TextureFormat.DepthStencil:
+        if (!rhi.canIUse(GLCapabilityType.depthTexture)) {
+          return false;
+        }
+        break;
+      case TextureFormat.R11G11B10_UFloat:
+      case TextureFormat.R32G32B32A32_UInt:
+      case TextureFormat.Depth24:
+      case TextureFormat.Depth32:
+      case TextureFormat.Depth32Stencil8:
+      case TextureFormat.R8:
+      case TextureFormat.R8G8:
+        return rhi.isWebGL2;
+    }
+
+    return true;
   }
 }
 

--- a/packages/core/src/texture/Texture.ts
+++ b/packages/core/src/texture/Texture.ts
@@ -2,6 +2,7 @@ import { GraphicsResource } from "../asset/GraphicsResource";
 import { Logger } from "../base/Logger";
 import { Engine } from "../Engine";
 import { IPlatformTexture } from "../renderingHardwareInterface";
+import { SystemInfo } from "../SystemInfo";
 import { TextureDepthCompareFunction } from "./enums/TextureDepthCompareFunction";
 import { TextureFilterMode } from "./enums/TextureFilterMode";
 import { TextureFormat } from "./enums/TextureFormat";
@@ -181,6 +182,10 @@ export abstract class Texture extends GraphicsResource {
     mipmap: boolean,
     isSRGBColorSpace: boolean
   ) {
+    if (!SystemInfo.supportsTextureFormat(engine, format)) {
+      throw new Error(`Texture format is not supported:${TextureFormat[format]}`);
+    }
+
     super(engine);
 
     this._width = width;

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -37,6 +37,10 @@ export class Texture2DArray extends Texture {
     mipmap: boolean = true,
     isSRGBColorSpace = true
   ) {
+    if (!engine._hardwareRenderer.isWebGL2) {
+      throw new Error(`Texture2D Array is not supported in WebGL1.0`);
+    }
+
     super(engine, width, height, format, mipmap, isSRGBColorSpace);
 
     this._length = length;

--- a/packages/core/src/texture/enums/TextureFormat.ts
+++ b/packages/core/src/texture/enums/TextureFormat.ts
@@ -12,10 +12,6 @@ export enum TextureFormat {
   R5G5B5A1 = 3,
   /** RGB format, 5 bits in R channel, 6 bits in G channel, 5 bits in B channel. */
   R5G6B5 = 4,
-  /** Transparent format, 8 bits. */
-  Alpha8 = 5,
-  /** Luminance/alpha in RGB channel, alpha in A channel. */
-  LuminanceAlpha = 6,
   /** RGBA format, 16 bits per channel. */
   R16G16B16A16 = 7,
   /** RGBA format, 32 bits per channel. */
@@ -81,6 +77,10 @@ export enum TextureFormat {
   /** 32-bit depth + 8-bit stencil format. */
   Depth32Stencil8 = 34,
 
+  /** @deprecated Use 'TextureFormat.R8' instead. */
+  Alpha8 = 5,
+  /** @deprecated Use 'TextureFormat.R8G8' instead. */
+  LuminanceAlpha = 6,
   /** @deprecated Use `TextureFormat.BC1` instead. */
   DXT1 = 10,
   /** @deprecated Use `TextureFormat.BC3` instead. */

--- a/packages/core/src/texture/enums/TextureFormat.ts
+++ b/packages/core/src/texture/enums/TextureFormat.ts
@@ -24,6 +24,10 @@ export enum TextureFormat {
   R32G32B32A32_UInt = 9,
   /** RGB unsigned float format, 11 bits in R channel, 11 bits in G channel, 10 bits in B channel. */
   R11G11B10_UFloat = 35,
+  /** R float format, 8 bits. */
+  R8 = 36,
+  /** RG float format, 8 bits per channel. */
+  R8G8 = 37,
 
   /** RGB compressed format, 4 bits per pixel. */
   BC1 = 10,

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -36,7 +36,8 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: isSRGBColorSpace ? (isWebGL2 ? gl.RGB : gl.SRGB8) : gl.RGB,
           readFormat: gl.RGB,
           dataType: gl.UNSIGNED_BYTE,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 1
         };
       case TextureFormat.R8G8B8A8:
         return {
@@ -44,70 +45,100 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: isSRGBColorSpace ? (isWebGL2 ? gl.RGBA : gl.SRGB8_ALPHA8) : gl.RGBA,
           readFormat: gl.RGBA,
           dataType: gl.UNSIGNED_BYTE,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 4
         };
       case TextureFormat.R4G4B4A4:
         return {
           internalFormat: isWebGL2 ? gl.RGBA4 : gl.RGBA,
           baseFormat: gl.RGBA,
           dataType: gl.UNSIGNED_SHORT_4_4_4_4,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 2
         };
       case TextureFormat.R5G5B5A1:
         return {
           internalFormat: isWebGL2 ? gl.RGB5_A1 : gl.RGBA,
           baseFormat: gl.RGBA,
           dataType: gl.UNSIGNED_SHORT_5_5_5_1,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 2
         };
       case TextureFormat.R5G6B5:
         return {
           internalFormat: isWebGL2 ? gl.RGB565 : gl.RGB,
           baseFormat: gl.RGB,
           dataType: gl.UNSIGNED_SHORT_5_6_5,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 2
         };
       case TextureFormat.Alpha8:
         return {
           internalFormat: gl.ALPHA,
           baseFormat: gl.ALPHA,
           dataType: gl.UNSIGNED_BYTE,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 1
         };
       case TextureFormat.LuminanceAlpha:
         return {
           internalFormat: gl.LUMINANCE_ALPHA,
           baseFormat: gl.LUMINANCE_ALPHA,
           dataType: gl.UNSIGNED_BYTE,
-          isCompressed: false
-        };
-      case TextureFormat.R11G11B10_UFloat:
-        return {
-          internalFormat: isWebGL2 ? gl.R11F_G11F_B10F : gl.NONE,
-          baseFormat: gl.RGB,
-          dataType: gl.FLOAT,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 2
         };
       case TextureFormat.R16G16B16A16:
         return {
           internalFormat: isWebGL2 ? gl.RGBA16F : gl.RGBA,
           baseFormat: gl.RGBA,
           dataType: gl.HALF_FLOAT,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 8
         };
       case TextureFormat.R32G32B32A32:
         return {
           internalFormat: isWebGL2 ? gl.RGBA32F : gl.RGBA,
           baseFormat: gl.RGBA,
           dataType: gl.FLOAT,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 8
         };
+      // Only WebGL2 support
+      case TextureFormat.R11G11B10_UFloat:
+        return {
+          internalFormat: gl.R11F_G11F_B10F,
+          baseFormat: gl.RGB,
+          dataType: gl.FLOAT,
+          isCompressed: false,
+          unpackAlignment: 4
+        };
+      // Only WebGL2 support
       case TextureFormat.R32G32B32A32_UInt:
         return {
-          internalFormat: isWebGL2 ? gl.RGBA32UI : gl.NONE,
+          internalFormat: gl.RGBA32UI,
           baseFormat: gl.RGBA_INTEGER,
           dataType: gl.UNSIGNED_INT,
-          isCompressed: false
+          isCompressed: false,
+          unpackAlignment: 8
+        };
+      // Only WebGL2 support
+      case TextureFormat.R8:
+        return {
+          internalFormat: gl.R8,
+          baseFormat: gl.RED,
+          dataType: gl.UNSIGNED_BYTE,
+          isCompressed: false,
+          unpackAlignment: 1
+        };
+      // Only WebGL2 support
+      case TextureFormat.R8G8:
+        return {
+          internalFormat: gl.RG8,
+          baseFormat: gl.RG,
+          dataType: gl.UNSIGNED_BYTE,
+          isCompressed: false,
+          unpackAlignment: 2
         };
       case TextureFormat.BC1:
         return {
@@ -239,6 +270,7 @@ export class GLTexture implements IPlatformTexture {
           isCompressed: false,
           attachment: gl.DEPTH_STENCIL_ATTACHMENT
         };
+      // Only WebGL2 support
       case TextureFormat.Depth24:
         return {
           internalFormat: gl.DEPTH_COMPONENT24,
@@ -247,6 +279,7 @@ export class GLTexture implements IPlatformTexture {
           isCompressed: false,
           attachment: gl.DEPTH_ATTACHMENT
         };
+      // Only WebGL2 support
       case TextureFormat.Depth32:
         return {
           internalFormat: gl.DEPTH_COMPONENT32F,
@@ -255,6 +288,7 @@ export class GLTexture implements IPlatformTexture {
           isCompressed: false,
           attachment: gl.DEPTH_ATTACHMENT
         };
+      // Only WebGL2 support
       case TextureFormat.Depth32Stencil8:
         return {
           internalFormat: gl.DEPTH32F_STENCIL8,
@@ -348,40 +382,6 @@ export class GLTexture implements IPlatformTexture {
     }
   }
 
-  /**
-   * Check whether the corresponding texture format is supported.
-   * @internal
-   */
-  static _supportTextureFormat(format: TextureFormat, rhi: WebGLGraphicDevice): boolean {
-    switch (format) {
-      case TextureFormat.R16G16B16A16:
-        if (!rhi.canIUse(GLCapabilityType.textureHalfFloat)) {
-          return false;
-        }
-        break;
-      case TextureFormat.R32G32B32A32:
-        if (!rhi.canIUse(GLCapabilityType.textureFloat)) {
-          return false;
-        }
-        break;
-      case TextureFormat.Depth16:
-      case TextureFormat.Depth24Stencil8:
-      case TextureFormat.Depth:
-      case TextureFormat.DepthStencil:
-        if (!rhi.canIUse(GLCapabilityType.depthTexture)) {
-          return false;
-        }
-        break;
-      case TextureFormat.R11G11B10_UFloat:
-      case TextureFormat.R32G32B32A32_UInt:
-      case TextureFormat.Depth24:
-      case TextureFormat.Depth32:
-      case TextureFormat.Depth32Stencil8:
-        return rhi.isWebGL2;
-    }
-
-    return true;
-  }
   /**
    * @internal
    */
@@ -650,7 +650,7 @@ export class GLTexture implements IPlatformTexture {
     out: ArrayBufferView
   ): void {
     const gl = this._gl;
-    const { baseFormat, dataType, readFormat } = this._formatDetail;
+    const { baseFormat, dataType, readFormat, unpackAlignment } = this._formatDetail;
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
 
@@ -671,6 +671,7 @@ export class GLTexture implements IPlatformTexture {
       gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._glTexture, mipLevel);
     }
 
+    gl.pixelStorei(gl.PACK_ALIGNMENT, unpackAlignment);
     // Base format is different from read format in webgl1.0 with sRGB
     gl.readPixels(x, y, width, height, readFormat ?? baseFormat, dataType, out);
 
@@ -687,11 +688,6 @@ export class GLTexture implements IPlatformTexture {
 
   protected _validate(texture: Texture, rhi: WebGLGraphicDevice): void {
     const { format, width, height } = texture;
-
-    // Validate format
-    if (!GLTexture._supportTextureFormat(format, rhi)) {
-      throw new Error(`Texture format is not supported:${TextureFormat[format]}`);
-    }
 
     // Validate sRGB format
     // @ts-ignore

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -37,7 +37,7 @@ export class GLTexture implements IPlatformTexture {
           readFormat: gl.RGB,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 1
+          alignment: 1
         };
       case TextureFormat.R8G8B8A8:
         return {
@@ -46,7 +46,7 @@ export class GLTexture implements IPlatformTexture {
           readFormat: gl.RGBA,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 4
+          alignment: 4
         };
       case TextureFormat.R4G4B4A4:
         return {
@@ -54,7 +54,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGBA,
           dataType: gl.UNSIGNED_SHORT_4_4_4_4,
           isCompressed: false,
-          unpackAlignment: 2
+          alignment: 2
         };
       case TextureFormat.R5G5B5A1:
         return {
@@ -62,7 +62,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGBA,
           dataType: gl.UNSIGNED_SHORT_5_5_5_1,
           isCompressed: false,
-          unpackAlignment: 2
+          alignment: 2
         };
       case TextureFormat.R5G6B5:
         return {
@@ -70,7 +70,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGB,
           dataType: gl.UNSIGNED_SHORT_5_6_5,
           isCompressed: false,
-          unpackAlignment: 2
+          alignment: 2
         };
       case TextureFormat.Alpha8:
         return {
@@ -78,7 +78,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.ALPHA,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 1
+          alignment: 1
         };
       case TextureFormat.LuminanceAlpha:
         return {
@@ -86,7 +86,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.LUMINANCE_ALPHA,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 2
+          alignment: 2
         };
       case TextureFormat.R16G16B16A16:
         return {
@@ -94,7 +94,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGBA,
           dataType: gl.HALF_FLOAT,
           isCompressed: false,
-          unpackAlignment: 8
+          alignment: 8
         };
       case TextureFormat.R32G32B32A32:
         return {
@@ -102,7 +102,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGBA,
           dataType: gl.FLOAT,
           isCompressed: false,
-          unpackAlignment: 8
+          alignment: 8
         };
       // Only WebGL2 support
       case TextureFormat.R11G11B10_UFloat:
@@ -111,7 +111,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGB,
           dataType: gl.FLOAT,
           isCompressed: false,
-          unpackAlignment: 4
+          alignment: 4
         };
       // Only WebGL2 support
       case TextureFormat.R32G32B32A32_UInt:
@@ -120,7 +120,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RGBA_INTEGER,
           dataType: gl.UNSIGNED_INT,
           isCompressed: false,
-          unpackAlignment: 8
+          alignment: 8
         };
       // Only WebGL2 support
       case TextureFormat.R8:
@@ -129,7 +129,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RED,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 1
+          alignment: 1
         };
       // Only WebGL2 support
       case TextureFormat.R8G8:
@@ -138,7 +138,7 @@ export class GLTexture implements IPlatformTexture {
           baseFormat: gl.RG,
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false,
-          unpackAlignment: 2
+          alignment: 2
         };
       case TextureFormat.BC1:
         return {
@@ -650,7 +650,7 @@ export class GLTexture implements IPlatformTexture {
     out: ArrayBufferView
   ): void {
     const gl = this._gl;
-    const { baseFormat, dataType, readFormat, unpackAlignment } = this._formatDetail;
+    const { baseFormat, dataType, readFormat, alignment } = this._formatDetail;
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
 
@@ -671,7 +671,7 @@ export class GLTexture implements IPlatformTexture {
       gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._glTexture, mipLevel);
     }
 
-    gl.pixelStorei(gl.PACK_ALIGNMENT, unpackAlignment);
+    gl.pixelStorei(gl.PACK_ALIGNMENT, alignment);
     // Base format is different from read format in webgl1.0 with sRGB
     gl.readPixels(x, y, width, height, readFormat ?? baseFormat, dataType, out);
 

--- a/packages/rhi-webgl/src/GLTexture2D.ts
+++ b/packages/rhi-webgl/src/GLTexture2D.ts
@@ -32,8 +32,8 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
     height?: number
   ): void {
     const gl = this._gl;
-    const isWebGL2: boolean = this._isWebGL2;
-    const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
+
+    const formatDetail = this._formatDetail;
     const mipWidth = Math.max(1, this._texture.width >> mipLevel);
     const mipHeight = Math.max(1, this._texture.height >> mipLevel);
 
@@ -42,10 +42,9 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
 
     this._bind();
 
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
-    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-
-    if (isCompressed) {
+    if (formatDetail.isCompressed) {
+      const isWebGL2 = this._isWebGL2;
+      const { internalFormat } = formatDetail;
       const mipBit = 1 << mipLevel;
       if (isWebGL2 || this._compressedMipFilled & mipBit) {
         gl.compressedTexSubImage2D(this._target, mipLevel, x, y, width, height, internalFormat, colorBuffer);
@@ -54,6 +53,10 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
         this._compressedMipFilled |= mipBit;
       }
     } else {
+      const { baseFormat, dataType } = formatDetail;
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
       gl.texSubImage2D(this._target, mipLevel, x, y, width, height, baseFormat, dataType, colorBuffer);
     }
   }

--- a/packages/rhi-webgl/src/GLTexture2D.ts
+++ b/packages/rhi-webgl/src/GLTexture2D.ts
@@ -56,7 +56,7 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
       const { baseFormat, dataType } = formatDetail;
       gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
       gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-      gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.alignment);
       gl.texSubImage2D(this._target, mipLevel, x, y, width, height, baseFormat, dataType, colorBuffer);
     }
   }

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -1,4 +1,4 @@
-import { IPlatformTexture2DArray, Logger, Texture2DArray, TextureFormat, TextureUtils } from "@galacean/engine-core";
+import { IPlatformTexture2DArray, Logger, Texture2DArray, TextureUtils } from "@galacean/engine-core";
 import { GLTexture } from "./GLTexture";
 import { WebGLGraphicDevice } from "./WebGLGraphicDevice";
 
@@ -117,16 +117,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
   }
 
   protected override _validate(texture: Texture2DArray, rhi: WebGLGraphicDevice): void {
-    if (!this._isWebGL2) {
-      throw new Error(`Texture2D Array is not supported in WebGL1.0`);
-    }
-
     const { format } = texture;
-
-    // Validate format
-    if (!GLTexture._supportTextureFormat(format, rhi)) {
-      throw new Error(`Texture format is not supported:${TextureFormat[format]}`);
-    }
 
     // Validate sRGB format
     // @ts-ignore

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -31,7 +31,8 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
     length?: number
   ): void {
     const { _target: target, _gl: gl } = this;
-    const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
+    const formatDetail = this._formatDetail;
+    const { internalFormat, baseFormat, dataType, isCompressed } = formatDetail;
 
     width = width || Math.max(1, this._texture.width >> mipLevel) - x;
     height = height || Math.max(1, this._texture.height >> mipLevel) - y;
@@ -40,6 +41,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
     this._bind();
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
 
     if (isCompressed) {
       gl.compressedTexSubImage3D(
@@ -110,6 +112,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
       throw new Error("Unable to read compressed texture");
     }
 
+    gl.pixelStorei(gl.PACK_ALIGNMENT, formatDetail.unpackAlignment);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
     gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, this._glTexture, mipLevel, elementIndex);
     gl.readPixels(x, y, width, height, formatDetail.baseFormat, formatDetail.dataType, out);

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -41,7 +41,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
     this._bind();
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.alignment);
 
     if (isCompressed) {
       gl.compressedTexSubImage3D(
@@ -112,7 +112,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
       throw new Error("Unable to read compressed texture");
     }
 
-    gl.pixelStorei(gl.PACK_ALIGNMENT, formatDetail.unpackAlignment);
+    gl.pixelStorei(gl.PACK_ALIGNMENT, formatDetail.alignment);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
     gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, this._glTexture, mipLevel, elementIndex);
     gl.readPixels(x, y, width, height, formatDetail.baseFormat, formatDetail.dataType, out);

--- a/packages/rhi-webgl/src/GLTextureCube.ts
+++ b/packages/rhi-webgl/src/GLTextureCube.ts
@@ -34,7 +34,8 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   ): void {
     const gl = this._gl;
     const isWebGL2 = this._isWebGL2;
-    const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
+    const formatDetail = this._formatDetail;
+    const { internalFormat, baseFormat, dataType, isCompressed } = formatDetail;
     const mipSize = Math.max(1, this._texture.width >> mipLevel);
 
     width = width || mipSize - x;
@@ -44,6 +45,7 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
 
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
 
     if (isCompressed) {
       const mipBit = 1 << mipLevel;

--- a/packages/rhi-webgl/src/GLTextureCube.ts
+++ b/packages/rhi-webgl/src/GLTextureCube.ts
@@ -45,7 +45,7 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
 
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.unpackAlignment);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, formatDetail.alignment);
 
     if (isCompressed) {
       const mipBit = 1 << mipLevel;

--- a/packages/rhi-webgl/src/type.ts
+++ b/packages/rhi-webgl/src/type.ts
@@ -49,8 +49,8 @@ export interface TextureFormatDetail {
   dataType?: GLenum;
   isCompressed: boolean;
   attachment?: GLenum;
-  // Read format are different in readPixels at some cases.
-  readFormat?: GLenum;
+  readFormat?: GLenum; // Read format are different in readPixels at some cases
+  unpackAlignment?: number; // Uncompressed texture data alignment
 }
 
 export enum GLCompressedTextureInternalFormat {

--- a/packages/rhi-webgl/src/type.ts
+++ b/packages/rhi-webgl/src/type.ts
@@ -50,7 +50,7 @@ export interface TextureFormatDetail {
   isCompressed: boolean;
   attachment?: GLenum;
   readFormat?: GLenum; // Read format are different in readPixels at some cases
-  unpackAlignment?: number; // Uncompressed texture data alignment
+  alignment?: number; // Uncompressed texture data alignment
 }
 
 export enum GLCompressedTextureInternalFormat {

--- a/tests/src/core/texture/Texture2D.test.ts
+++ b/tests/src/core/texture/Texture2D.test.ts
@@ -99,7 +99,7 @@ describe("Texture2D", () => {
         texture.getPixelBuffer(0, 0, 1, 1, buffer);
       }).to.throw;
     });
-    it("读取成功", () => {
+    it("读取 R8G8B8A8 成功", () => {
       const texture = new Texture2D(engine, width, height);
       const buffer = new Uint8Array(4);
 
@@ -109,6 +109,36 @@ describe("Texture2D", () => {
       expect(buffer[0]).to.eq(1);
       expect(buffer[1]).to.eq(2);
       expect(buffer[2]).to.eq(3);
+      expect(buffer[3]).to.eq(4);
+    });
+
+    it.only("读取 R8G8 成功", () => {
+      const texture = new Texture2D(engine, width, height, TextureFormat.R8G8);
+      const buffer = new Uint8Array(8);
+
+      texture.setPixelBuffer(new Uint8Array([1, 2, 3, 4, 7, 4, 3, 3]), 0, 5, 0, 2, 2);
+      texture.getPixelBuffer(5, 0, 2, 2, buffer);
+
+      expect(buffer[0]).to.eq(1);
+      expect(buffer[1]).to.eq(2);
+      expect(buffer[2]).to.eq(3);
+      expect(buffer[3]).to.eq(4);
+      expect(buffer[4]).to.eq(7);
+      expect(buffer[5]).to.eq(4);
+      expect(buffer[6]).to.eq(3);
+      expect(buffer[7]).to.eq(3);
+    });
+
+    it.only("读取 R8 成功", () => {
+      const texture = new Texture2D(engine, width, height, TextureFormat.R8);
+      const buffer = new Uint8Array(4);
+
+      texture.setPixelBuffer(new Uint8Array([1, 6, 8, 4]), 0, 5, 0, 2, 2);
+      texture.getPixelBuffer(5, 0, 2, 2, buffer);
+
+      expect(buffer[0]).to.eq(1);
+      expect(buffer[1]).to.eq(6);
+      expect(buffer[2]).to.eq(8);
       expect(buffer[3]).to.eq(4);
     });
   });

--- a/tests/src/core/texture/Texture2D.test.ts
+++ b/tests/src/core/texture/Texture2D.test.ts
@@ -1,6 +1,6 @@
 import { Engine, Texture2D, TextureFormat } from "@galacean/engine-core";
 import { WebGLEngine } from "@galacean/engine-rhi-webgl";
-import { describe, beforeAll, beforeEach, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Texture2D", () => {
   const width = 1024;

--- a/tests/src/core/texture/Texture2D.test.ts
+++ b/tests/src/core/texture/Texture2D.test.ts
@@ -112,7 +112,7 @@ describe("Texture2D", () => {
       expect(buffer[3]).to.eq(4);
     });
 
-    it.only("读取 R8G8 成功", () => {
+    it("读取 R8G8 成功", () => {
       const texture = new Texture2D(engine, width, height, TextureFormat.R8G8);
       const buffer = new Uint8Array(8);
 
@@ -129,7 +129,7 @@ describe("Texture2D", () => {
       expect(buffer[7]).to.eq(3);
     });
 
-    it.only("读取 R8 成功", () => {
+    it("读取 R8 成功", () => {
       const texture = new Texture2D(engine, width, height, TextureFormat.R8);
       const buffer = new Uint8Array(4);
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
- Supoort `R8` and `R8G8` Format to instead `Alpha8` and `LuminanceAlpha` in the future（Modern graphic API is not suggest this these format）
- `SystemInfo` support `supportsTextureFormat`
- Fix `getPixelBuffer` and set `setPixelBuffer` when format is R8G8B8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Expanded texture configuration options with additional formats R8 and R8G8, including sRGB color space support for enhanced texture handling.
  - Improved system checks for texture format compatibility, ensuring better rendering performance and mipmap accuracy.
  - Added a new example scene demonstrating rendering with the R8G8 texture format in a WebGL environment.

- **Tests**
  - Introduced targeted test cases for reading pixel buffers from textures in R8, R8G8, and R8G8B8A8 formats to validate format-specific functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->