### PR TITLE
Fix `Particle` emit bug when MeshShape's  mesh share position and normal buffer

### DIFF
--- a/packages/core/src/particle/modules/shape/MeshShape.ts
+++ b/packages/core/src/particle/modules/shape/MeshShape.ts
@@ -109,7 +109,7 @@ export class MeshShape extends BaseShape {
 
     let typedBuffer: TypedArray;
     if (reusePositionBuffer) {
-      return this._positionBuffer;
+      typedBuffer = this._positionBuffer;
     } else {
       const buffer = vertexBufferBinding?.buffer;
       if (!buffer) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved buffer handling in mesh shapes to ensure consistent output of vertex information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->