### PR TITLE
Fix macro match bug when code token contains character `.` 

### DIFF
--- a/packages/shader-lab/src/lexer/Utils.ts
+++ b/packages/shader-lab/src/lexer/Utils.ts
@@ -23,7 +23,6 @@ export default class LexerUtils {
   static isPpCharacters(charCode: number) {
     return (
       charCode === 35 || // #
-      charCode === 46 || // .
       charCode === 95 || // _
       (charCode >= 48 && charCode <= 57) || // 0 - 9
       (charCode >= 65 && charCode <= 90) || // A - Z

--- a/tests/src/shader-lab/test-case/compare/macro.txt
+++ b/tests/src/shader-lab/test-case/compare/macro.txt
@@ -1,0 +1,4 @@
+
+
+vec2 q = vec2(uv.x * iResolution.x, uv.y * iResolution.y).xy / iResolution.xy;
+vec2 p = ( 2.0 * vec2(uv.x * iResolution.x, uv.y * iResolution.y).xy - iResolution.xy ) / min( iResolution.y, iResolution.x );

--- a/tests/src/shader-lab/test-case/index.ts
+++ b/tests/src/shader-lab/test-case/index.ts
@@ -4,7 +4,7 @@ const { readFile } = server.commands;
 const sourceDir = "test-case/source/";
 const cmpDir = "test-case/compare/";
 
-const files = ["frag.txt", "frag2.txt"];
+const files = ["frag.txt", "frag2.txt", "macro.txt"];
 const testCaseList: { source: string; compare: string; name: string }[] = [];
 for (const f of files) {
   const cmpFilePath = `${cmpDir}${f}`;

--- a/tests/src/shader-lab/test-case/source/macro.txt
+++ b/tests/src/shader-lab/test-case/source/macro.txt
@@ -1,0 +1,4 @@
+#define fragCoord vec2(uv.x * iResolution.x, uv.y * iResolution.y)
+
+vec2 q = fragCoord.xy / iResolution.xy;
+vec2 p = ( 2.0 * fragCoord.xy - iResolution.xy ) / min( iResolution.y, iResolution.x );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

WebGL doesn't support macros cotain character `.` 

![image](https://github.com/user-attachments/assets/d94aa820-2d85-4d0c-8581-66fee502518e)

close #2620


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new shader macro definitions and coordinate transformation variables for enhanced shader testing.
  - Expanded test coverage by introducing a new shader test case.

- **Bug Fixes**
  - Updated character recognition in preprocessor logic to exclude the period ('.') character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->