### PR TITLE
Fix masklayer return type in SpriteRenderer and TextRenderer

### DIFF
--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -18,6 +18,7 @@ import { SpriteMaskInteraction } from "../enums/SpriteMaskInteraction";
 import { SpriteModifyFlags } from "../enums/SpriteModifyFlags";
 import { SpriteTileMode } from "../enums/SpriteTileMode";
 import { Sprite } from "./Sprite";
+import { SpriteMaskLayer } from "../../enums/SpriteMaskLayer";
 
 /**
  * Renders a Sprite for 2D graphics.
@@ -240,11 +241,11 @@ export class SpriteRenderer extends Renderer implements ISpriteRenderer {
   /**
    * The mask layer the sprite renderer belongs to.
    */
-  get maskLayer(): number {
+  get maskLayer(): SpriteMaskLayer {
     return this._maskLayer;
   }
 
-  set maskLayer(value: number) {
+  set maskLayer(value: SpriteMaskLayer) {
     this._maskLayer = value;
   }
 

--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -21,6 +21,7 @@ import { Font } from "./Font";
 import { ITextRenderer } from "./ITextRenderer";
 import { SubFont } from "./SubFont";
 import { TextUtils } from "./TextUtils";
+import { SpriteMaskLayer } from "../../enums/SpriteMaskLayer";
 
 /**
  * Renders a text for 2D graphics.
@@ -254,11 +255,11 @@ export class TextRenderer extends Renderer implements ITextRenderer {
   /**
    * The mask layer the sprite renderer belongs to.
    */
-  get maskLayer(): number {
+  get maskLayer(): SpriteMaskLayer {
     return this._maskLayer;
   }
 
-  set maskLayer(value: number) {
+  set maskLayer(value: SpriteMaskLayer) {
     this._maskLayer = value;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type safety for the mask layer property in 2D sprite and text rendering components by using a more specific type. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->