### PR TITLE
Fix error when set `UICanvas.renderCamera` to null

### DIFF
--- a/packages/ui/src/component/UICanvas.ts
+++ b/packages/ui/src/component/UICanvas.ts
@@ -155,7 +155,7 @@ export class UICanvas extends Component implements IElement {
   set renderCamera(value: Camera) {
     const preCamera = this._renderCamera;
     if (preCamera !== value) {
-      this._isSameOrChildEntity(value.entity) &&
+      value && this._isSameOrChildEntity(value.entity) &&
         Logger.warn(
           "Camera entity matching or nested within the canvas entity disables canvas auto-adaptation in ScreenSpaceCamera mode."
         );

--- a/packages/ui/src/component/UICanvas.ts
+++ b/packages/ui/src/component/UICanvas.ts
@@ -155,7 +155,8 @@ export class UICanvas extends Component implements IElement {
   set renderCamera(value: Camera) {
     const preCamera = this._renderCamera;
     if (preCamera !== value) {
-      value && this._isSameOrChildEntity(value.entity) &&
+      value &&
+        this._isSameOrChildEntity(value.entity) &&
         Logger.warn(
           "Camera entity matching or nested within the canvas entity disables canvas auto-adaptation in ScreenSpaceCamera mode."
         );

--- a/tests/src/ui/UICanvas.test.ts
+++ b/tests/src/ui/UICanvas.test.ts
@@ -41,6 +41,10 @@ describe("UICanvas", async () => {
     expect(!!rootCanvas.renderCamera).to.eq(false);
     rootCanvas.renderCamera = camera;
     expect(rootCanvas.renderCamera).to.eq(camera);
+    rootCanvas.renderCamera = null;
+    expect(!!rootCanvas.renderCamera).to.eq(false);
+    rootCanvas.renderCamera = camera;
+    expect(rootCanvas.renderCamera).to.eq(camera);
 
     // Resolution Adaptation Strategy
     rootCanvas.resolutionAdaptationMode = ResolutionAdaptationMode.WidthAdaptation;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability of the camera assignment in the UI by preventing errors when clearing or reassigning the render camera.

- **Tests**
  - Enhanced test coverage to verify correct handling when the render camera is set to null and then reassigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->