### PR TITLE
 Fixed memory leak after `engine.destroy`

### DIFF
--- a/packages/core/src/BasicResources.ts
+++ b/packages/core/src/BasicResources.ts
@@ -6,7 +6,7 @@ import { BufferBindFlag } from "./graphic/enums/BufferBindFlag";
 import { BufferUsage } from "./graphic/enums/BufferUsage";
 import { MeshTopology } from "./graphic/enums/MeshTopology";
 import { VertexElementFormat } from "./graphic/enums/VertexElementFormat";
-import { Material } from "./material";
+import { BlinnPhongMaterial, Material } from "./material";
 import { ModelMesh } from "./mesh";
 import { Shader } from "./shader/Shader";
 import { Texture, Texture2D, TextureCube, TextureCubeFace } from "./texture";
@@ -29,12 +29,14 @@ export class BasicResources {
   readonly whiteTexture2DArray: Texture2DArray;
   readonly uintWhiteTexture2D: Texture2D;
 
-  constructor(engine: Engine) {
+  private _blinnPhongMaterial: BlinnPhongMaterial;
+
+  constructor(public engine: Engine) {
     // prettier-ignore
     const vertices = new Float32Array([
       -1, -1, 0, 1, // left-bottom
       3, -1, 2, 1,  // right-bottom
-      -1, 3, 0, -1 ]); // left-top
+      -1, 3, 0, -1]); // left-top
 
     // prettier-ignore
     const flipYVertices = new Float32Array([
@@ -75,6 +77,14 @@ export class BasicResources {
       );
     }
   }
+
+  /**
+   * @internal
+   */
+  _getBlinnPhongMaterial(): BlinnPhongMaterial {
+    return (this._blinnPhongMaterial ||= new BlinnPhongMaterial(this.engine));
+  }
+
 
   private _createBlitMesh(engine: Engine, vertices: Float32Array): ModelMesh {
     const mesh = new ModelMesh(engine);

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -645,7 +645,6 @@ export class Camera extends Component {
     }
     this._renderPipeline.render(context, cubeFace, mipLevel, ignoreClearFlags);
     engine._renderCount++;
-    context.camera = null;
   }
 
   /**

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -645,6 +645,7 @@ export class Camera extends Component {
     }
     this._renderPipeline.render(context, cubeFace, mipLevel, ignoreClearFlags);
     engine._renderCount++;
+    context.camera = null;
   }
 
   /**

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -673,6 +673,7 @@ export class Engine extends EventDispatcher {
     this._subRenderElementPool.garbageCollection();
     this._textSubRenderElementPool.garbageCollection();
     this._renderElementPool.garbageCollection();
+    this._renderContext.garbageCollection();
   }
 
   /**

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -437,9 +437,8 @@ export class Engine extends EventDispatcher {
   private _destroy(): void {
     this._sceneManager._destroyAllScene();
 
+    Shader._clearShaderProgramPools(this);
     this._resourceManager._destroy();
-    this._textDefaultFont = null;
-    this._fontMap = null;
 
     this.inputManager._destroy();
     this._batcherManager.destroy();
@@ -452,12 +451,6 @@ export class Engine extends EventDispatcher {
     this._hardwareRenderer.destroy();
 
     this.removeAllEventListeners();
-
-    this._animate = null;
-    this._sceneManager = null;
-    this._resourceManager = null;
-    this._canvas = null;
-    this._time = null;
 
     this._waitingDestroy = false;
     this._destroyed = true;
@@ -675,7 +668,6 @@ export class Engine extends EventDispatcher {
     this._subRenderElementPool.garbageCollection();
     this._textSubRenderElementPool.garbageCollection();
     this._renderElementPool.garbageCollection();
-    this._renderContext.garbageCollection();
   }
 
   /**

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -47,6 +47,8 @@ import { Texture2D, TextureFormat } from "./texture";
 import { ClearableObjectPool } from "./utils/ClearableObjectPool";
 import { ReturnableObjectPool } from "./utils/ReturnableObjectPool";
 import { XRManager } from "./xr/XRManager";
+import { AnimationCurveOwner } from "./animation/internal/animationCurveOwner/AnimationCurveOwner";
+import { MaskManager } from "./RenderPipeline/MaskManager";
 
 ShaderPool.init();
 
@@ -436,14 +438,17 @@ export class Engine extends EventDispatcher {
 
   private _destroy(): void {
     this._sceneManager._destroyAllScene();
-
-    Shader._clearShaderProgramPools(this);
     this._resourceManager._destroy();
 
     this.inputManager._destroy();
     this._batcherManager.destroy();
     this.xrManager?._destroy();
     this.dispatch("shutdown", this);
+
+    Shader._clear(this);
+    UIUtils._clear();
+    MaskManager._clear();
+    AnimationCurveOwner._components.length = 0;
 
     // Cancel animation
     this.pause();

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -47,7 +47,6 @@ import { Texture2D, TextureFormat } from "./texture";
 import { ClearableObjectPool } from "./utils/ClearableObjectPool";
 import { ReturnableObjectPool } from "./utils/ReturnableObjectPool";
 import { XRManager } from "./xr/XRManager";
-import { MaskManager } from "./RenderPipeline/MaskManager";
 
 ShaderPool.init();
 
@@ -444,13 +443,10 @@ export class Engine extends EventDispatcher {
     this.xrManager?._destroy();
     this.dispatch("shutdown", this);
 
-    Shader._clear(this);
-    UIUtils._clear();
-    MaskManager._clear();
-
     // Cancel animation
     this.pause();
 
+    Shader._clear(this);
     this._hardwareRenderer.destroy();
 
     this.removeAllEventListeners();

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -643,6 +643,7 @@ export class Engine extends EventDispatcher {
     this._hardwareRenderer.resetState();
     this._lastRenderState = new RenderState();
     // Clear shader pools
+    Shader._clear(this);
     this._shaderProgramPools.length = 0;
 
     const { resourceManager } = this;

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -47,7 +47,6 @@ import { Texture2D, TextureFormat } from "./texture";
 import { ClearableObjectPool } from "./utils/ClearableObjectPool";
 import { ReturnableObjectPool } from "./utils/ReturnableObjectPool";
 import { XRManager } from "./xr/XRManager";
-import { AnimationCurveOwner } from "./animation/internal/animationCurveOwner/AnimationCurveOwner";
 import { MaskManager } from "./RenderPipeline/MaskManager";
 
 ShaderPool.init();
@@ -448,7 +447,6 @@ export class Engine extends EventDispatcher {
     Shader._clear(this);
     UIUtils._clear();
     MaskManager._clear();
-    AnimationCurveOwner._components.length = 0;
 
     // Cancel animation
     this.pause();

--- a/packages/core/src/RenderPipeline/PipelineUtils.ts
+++ b/packages/core/src/RenderPipeline/PipelineUtils.ts
@@ -211,5 +211,6 @@ export class PipelineUtils {
     );
 
     rhi.drawPrimitive(blitMesh._primitive, blitMesh.subMesh, program);
+    rendererShaderData.setTexture(PipelineUtils._blitTextureProperty, null);
   }
 }

--- a/packages/core/src/RenderPipeline/RenderContext.ts
+++ b/packages/core/src/RenderPipeline/RenderContext.ts
@@ -63,6 +63,10 @@ export class RenderContext {
     projectionParams.set(flipProjection ? -1 : 1, virtualCamera.nearClipPlane, virtualCamera.farClipPlane, 0);
     shaderData.setVector4(RenderContext._cameraProjectionProperty, projectionParams);
   }
+
+  garbageCollection(): void {
+    this.camera = null;
+  }
 }
 
 /**

--- a/packages/core/src/RenderPipeline/RenderContext.ts
+++ b/packages/core/src/RenderPipeline/RenderContext.ts
@@ -63,10 +63,6 @@ export class RenderContext {
     projectionParams.set(flipProjection ? -1 : 1, virtualCamera.nearClipPlane, virtualCamera.farClipPlane, 0);
     shaderData.setVector4(RenderContext._cameraProjectionProperty, projectionParams);
   }
-
-  garbageCollection(): void {
-    this.camera = null;
-  }
 }
 
 /**

--- a/packages/core/src/RenderPipeline/RenderQueue.ts
+++ b/packages/core/src/RenderPipeline/RenderQueue.ts
@@ -202,11 +202,9 @@ export class RenderQueue {
   private _drawMask(context: RenderContext, pipelineStageTagValue: string, master: SubRenderElement): void {
     const incrementMaskQueue = MaskManager.getMaskIncrementRenderQueue();
     incrementMaskQueue.renderQueueType = this.renderQueueType;
-    incrementMaskQueue.clear();
 
     const decrementMaskQueue = MaskManager.getMaskDecrementRenderQueue();
     decrementMaskQueue.renderQueueType = this.renderQueueType;
-    decrementMaskQueue.clear();
 
     const camera = context.camera;
     const engine = camera.engine;
@@ -216,9 +214,11 @@ export class RenderQueue {
     incrementMaskQueue._batch(engine._batcherManager);
     primitiveChunkManagerMask.uploadBuffer();
     incrementMaskQueue.render(context, pipelineStageTagValue, RenderQueueMaskType.Increment);
+    incrementMaskQueue.clear();
     decrementMaskQueue._batch(engine._batcherManager);
     primitiveChunkManagerMask.uploadBuffer();
     decrementMaskQueue.render(context, pipelineStageTagValue, RenderQueueMaskType.Decrement);
+    decrementMaskQueue.clear();
   }
 }
 

--- a/packages/core/src/animation/AnimationClip.ts
+++ b/packages/core/src/animation/AnimationClip.ts
@@ -212,14 +212,16 @@ export class AnimationClip extends EngineObject {
    */
   _sampleAnimation(entity: Entity, time: number): void {
     const { _curveBindings: curveBindings } = this;
+    const components = AnimationCurveOwner._components;
     for (let i = curveBindings.length - 1; i >= 0; i--) {
       const curve = curveBindings[i];
       const targetEntity = entity.findByPath(curve.relativePath);
       if (targetEntity) {
         const component =
           curve.typeIndex > 0
-            ? targetEntity.getComponents(curve.type, AnimationCurveOwner._components)[curve.typeIndex]
+            ? targetEntity.getComponents(curve.type, components)[curve.typeIndex]
             : targetEntity.getComponent(curve.type);
+        components.length = 0;
         if (!component) {
           continue;
         }

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -345,7 +345,7 @@ export class Animator extends Component {
     const { _curveBindings: curves } = animatorState.clip;
 
     const { curveOwnerPool: layerCurveOwnerPool } = animatorLayerData;
-
+    const components = AnimationCurveOwner._components;
     for (let i = curves.length - 1; i >= 0; i--) {
       const curve = curves[i];
       const { relativePath } = curve;
@@ -353,9 +353,9 @@ export class Animator extends Component {
       if (targetEntity) {
         const component =
           curve.typeIndex > 0
-            ? targetEntity.getComponents(curve.type, AnimationCurveOwner._components)[curve.typeIndex]
+            ? targetEntity.getComponents(curve.type, components)[curve.typeIndex]
             : targetEntity.getComponent(curve.type);
-
+        components.length = 0;
         if (!component) {
           continue;
         }

--- a/packages/core/src/physics/PhysicsScene.ts
+++ b/packages/core/src/physics/PhysicsScene.ts
@@ -312,26 +312,26 @@ export class PhysicsScene {
       }
       return shape.collider.entity.layer & layerMask && shape.isSceneQuery;
     };
-    let $idx: number;
-    let $distance: number;
-    let $position: Vector3;
-    let $normal: Vector3;
+    let outIDX: number;
+    let outDistance: number;
+    let outPosition: Vector3;
+    let outNormal: Vector3;
 
     if (hitResult != undefined) {
       const result = this._nativePhysicsScene.raycast(ray, distance, onRaycast, (idx, distance, position, normal) => {
-        $idx = idx;
-        $distance = distance;
-        $position = position;
-        $normal = normal;
+        outIDX = idx;
+        outDistance = distance;
+        outPosition = position;
+        outNormal = normal;
       });
 
       if (result) {
-        const hitShape = this._scene.engine._physicalObjectsMap[$idx];
+        const hitShape = this._scene.engine._physicalObjectsMap[outIDX];
         hitResult.entity = hitShape._collider.entity;
         hitResult.shape = hitShape;
-        hitResult.distance = $distance;
-        hitResult.point.copyFrom($position);
-        hitResult.normal.copyFrom($normal);
+        hitResult.distance = outDistance;
+        hitResult.point.copyFrom(outPosition);
+        hitResult.normal.copyFrom(outNormal);
         return true;
       } else {
         hitResult.entity = null;

--- a/packages/core/src/physics/PhysicsScene.ts
+++ b/packages/core/src/physics/PhysicsScene.ts
@@ -312,18 +312,26 @@ export class PhysicsScene {
       }
       return shape.collider.entity.layer & layerMask && shape.isSceneQuery;
     };
+    let $idx: number;
+    let $distance: number;
+    let $position: Vector3;
+    let $normal: Vector3;
 
     if (hitResult != undefined) {
       const result = this._nativePhysicsScene.raycast(ray, distance, onRaycast, (idx, distance, position, normal) => {
-        const hitShape = this._scene.engine._physicalObjectsMap[idx];
-        hitResult.entity = hitShape._collider.entity;
-        hitResult.shape = hitShape;
-        hitResult.distance = distance;
-        hitResult.normal.copyFrom(normal);
-        hitResult.point.copyFrom(position);
+        $idx = idx;
+        $distance = distance;
+        $position = position;
+        $normal = normal;
       });
 
       if (result) {
+        const hitShape = this._scene.engine._physicalObjectsMap[$idx];
+        hitResult.entity = hitShape._collider.entity;
+        hitResult.shape = hitShape;
+        hitResult.distance = $distance;
+        hitResult.point.copyFrom($position);
+        hitResult.normal.copyFrom($normal);
         return true;
       } else {
         hitResult.entity = null;

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -180,7 +180,6 @@ export class Shader implements IReferable {
     const shaderMap = Shader._shaderMap;
     for (const key in shaderMap) {
       const shader = shaderMap[key];
-      if (!shader) continue;
       const subShaders = shader._subShaders;
       for (let i = 0, n = subShaders.length; i < n; i++) {
         const passes = subShaders[i].passes;
@@ -188,7 +187,7 @@ export class Shader implements IReferable {
           const pass = passes[j];
           const passShaderProgramPools = pass._shaderProgramPools;
           for (let k = passShaderProgramPools.length - 1; k >= 0; k--) {
-            const shaderProgramPool = passShaderProgramPools[i];
+            const shaderProgramPool = passShaderProgramPools[k];
             if (shaderProgramPool.engine !== engine) continue;
             shaderProgramPool._destroy();
             passShaderProgramPools.splice(k, 1);

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -173,6 +173,33 @@ export class Shader implements IReferable {
     return Shader._shaderMap[name];
   }
 
+  /**
+   * @internal
+   */
+  static _clearShaderProgramPools(engine: Engine): void {
+    const shaderMap = Shader._shaderMap;
+    const engineShaderProgramPools = engine._shaderProgramPools;
+    for (const key in shaderMap) {
+      const shader = shaderMap[key];
+      if (!shader) continue;
+      const subShaders = shader._subShaders;
+      for (let i = 0, n = subShaders.length; i < n; i++) {
+        const passes = subShaders[i].passes;
+        for (let j = 0, m = passes.length; j < m; j++) {
+          const pass = passes[j];
+          const passShaderProgramPools = pass._shaderProgramPools;
+          for (let k = passShaderProgramPools.length - 1; k >= 0; k--) {
+            const shaderProgramPool = passShaderProgramPools[i];
+            if (shaderProgramPool.engine !== engine) continue;
+            shaderProgramPool._destroy();
+            delete engineShaderProgramPools[pass._shaderPassId];
+            passShaderProgramPools.splice(k, 1);
+          }
+        }
+      }
+    }
+  }
+
   private static _applyConstRenderStates(
     renderState: RenderState,
     key: RenderStateElementKey,

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -176,7 +176,7 @@ export class Shader implements IReferable {
   /**
    * @internal
    */
-  static _clearShaderProgramPools(engine: Engine): void {
+  static _clear(engine: Engine): void {
     const shaderMap = Shader._shaderMap;
     const engineShaderProgramPools = engine._shaderProgramPools;
     for (const key in shaderMap) {

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -178,7 +178,6 @@ export class Shader implements IReferable {
    */
   static _clear(engine: Engine): void {
     const shaderMap = Shader._shaderMap;
-    const engineShaderProgramPools = engine._shaderProgramPools;
     for (const key in shaderMap) {
       const shader = shaderMap[key];
       if (!shader) continue;
@@ -192,7 +191,6 @@ export class Shader implements IReferable {
             const shaderProgramPool = passShaderProgramPools[i];
             if (shaderProgramPool.engine !== engine) continue;
             shaderProgramPool._destroy();
-            delete engineShaderProgramPools[pass._shaderPassId];
             passShaderProgramPools.splice(k, 1);
           }
         }

--- a/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
@@ -17,12 +17,6 @@ import { GLTFParserContext, GLTFParserType, registerGLTFParser } from "./GLTFPar
 
 @registerGLTFParser(GLTFParserType.Material)
 export class GLTFMaterialParser extends GLTFParser {
-  /** @internal */
-  static _getDefaultMaterial(engine: Engine): BlinnPhongMaterial {
-    return (GLTFMaterialParser._defaultMaterial ||= new BlinnPhongMaterial(engine));
-  }
-  private static _defaultMaterial: BlinnPhongMaterial;
-
   /**
    * @internal
    */
@@ -172,7 +166,7 @@ export class GLTFMaterialParser extends GLTFParser {
     }
 
     return Promise.resolve(material).then((material) => {
-      material ||= GLTFMaterialParser._getDefaultMaterial(engine);
+      material ||= new BlinnPhongMaterial(engine);
       GLTFParser.executeExtensionsAdditiveAndParse(materialInfo.extensions, context, material, materialInfo);
       // @ts-ignore
       material._associationSuperResource(glTFResource);

--- a/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
@@ -1,6 +1,4 @@
 import {
-  BlinnPhongMaterial,
-  Engine,
   Logger,
   Material,
   PBRMaterial,
@@ -166,7 +164,7 @@ export class GLTFMaterialParser extends GLTFParser {
     }
 
     return Promise.resolve(material).then((material) => {
-      material ||= new BlinnPhongMaterial(engine);
+      material ||= context._getDefaultMaterial(engine);
       GLTFParser.executeExtensionsAdditiveAndParse(materialInfo.extensions, context, material, materialInfo);
       // @ts-ignore
       material._associationSuperResource(glTFResource);

--- a/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFMaterialParser.ts
@@ -164,7 +164,8 @@ export class GLTFMaterialParser extends GLTFParser {
     }
 
     return Promise.resolve(material).then((material) => {
-      material ||= context._getDefaultMaterial(engine);
+      // @ts-ignore
+      material ||= engine._basicResources._getBlinnPhongMaterial();
       GLTFParser.executeExtensionsAdditiveAndParse(materialInfo.extensions, context, material, materialInfo);
       // @ts-ignore
       material._associationSuperResource(glTFResource);

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -4,7 +4,6 @@ import {
   AnimatorController,
   BlinnPhongMaterial,
   Buffer,
-  Engine,
   Entity,
   Material,
   ModelMesh,
@@ -134,13 +133,6 @@ export class GLTFParserContext {
 
     this._addTaskCompletePromise(promise);
     return promise;
-  }
-
-  /**
-   * @internal
-   */
-  _getDefaultMaterial(engine: Engine): BlinnPhongMaterial {
-    return (this._defaultMaterial ||= new BlinnPhongMaterial(engine));
   }
 
   /**

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -2,7 +2,9 @@ import {
   AnimationClip,
   Animator,
   AnimatorController,
+  BlinnPhongMaterial,
   Buffer,
+  Engine,
   Entity,
   Material,
   ModelMesh,
@@ -38,6 +40,7 @@ export class GLTFParserContext {
     taskDetail: {},
     taskComplete: { loaded: 0, total: 0 }
   };
+  private _defaultMaterial: BlinnPhongMaterial;
 
   /** @internal */
   _setTaskCompleteProgress: (loaded: number, total: number) => void;
@@ -131,6 +134,13 @@ export class GLTFParserContext {
 
     this._addTaskCompletePromise(promise);
     return promise;
+  }
+
+  /**
+   * @internal
+   */
+  _getDefaultMaterial(engine: Engine): BlinnPhongMaterial {
+    return (this._defaultMaterial ||= new BlinnPhongMaterial(engine));
   }
 
   /**

--- a/packages/loader/src/gltf/parser/GLTFSceneParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSceneParser.ts
@@ -1,5 +1,4 @@
 import {
-  BlinnPhongMaterial,
   Camera,
   Entity,
   Material,
@@ -146,7 +145,7 @@ export class GLTFSceneParser extends GLTFParser {
       Promise.all(materialPromises)
     ]).then(([meshes, skin, materials]) => {
       for (let i = 0; i < rendererCount; i++) {
-        const material = materials[i] || new BlinnPhongMaterial(context.glTFResource.engine);
+        const material = materials[i] || context._getDefaultMaterial(context.glTFResource.engine);
         const glTFPrimitive = glTFMeshPrimitives[i];
         const mesh = meshes[i];
 

--- a/packages/loader/src/gltf/parser/GLTFSceneParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSceneParser.ts
@@ -1,4 +1,5 @@
 import {
+  BlinnPhongMaterial,
   Camera,
   Entity,
   Material,
@@ -11,7 +12,6 @@ import {
 import { BoundingBox, Matrix } from "@galacean/engine-math";
 import { GLTFResource } from "../GLTFResource";
 import { CameraType, ICamera, INode } from "../GLTFSchema";
-import { GLTFMaterialParser } from "./GLTFMaterialParser";
 import { GLTFParser } from "./GLTFParser";
 import { GLTFParserContext, GLTFParserType, registerGLTFParser } from "./GLTFParserContext";
 
@@ -146,7 +146,7 @@ export class GLTFSceneParser extends GLTFParser {
       Promise.all(materialPromises)
     ]).then(([meshes, skin, materials]) => {
       for (let i = 0; i < rendererCount; i++) {
-        const material = materials[i] || GLTFMaterialParser._getDefaultMaterial(context.glTFResource.engine);
+        const material = materials[i] || new BlinnPhongMaterial(context.glTFResource.engine);
         const glTFPrimitive = glTFMeshPrimitives[i];
         const mesh = meshes[i];
 

--- a/packages/loader/src/gltf/parser/GLTFSceneParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSceneParser.ts
@@ -144,8 +144,10 @@ export class GLTFSceneParser extends GLTFParser {
       skinID !== undefined && context.get<Skin>(GLTFParserType.Skin, skinID),
       Promise.all(materialPromises)
     ]).then(([meshes, skin, materials]) => {
+      // @ts-ignore
+      const basicResources = context.glTFResource.engine._basicResources;
       for (let i = 0; i < rendererCount; i++) {
-        const material = materials[i] || context._getDefaultMaterial(context.glTFResource.engine);
+        const material = materials[i] || basicResources._getBlinnPhongMaterial();
         const glTFPrimitive = glTFMeshPrimitives[i];
         const mesh = meshes[i];
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management by ensuring textures and shader programs are properly cleared after use, reducing potential memory leaks.
	- Enhanced animation and physics handling for more reliable component and hit data management.
	- Updated fallback material assignment in GLTF parsing, ensuring consistent material application when importing 3D models.
	- Fixed camera rendering context cleanup to prevent stale references after rendering.

- **Refactor**
	- Streamlined internal resource and shader management, centralizing logic for better maintainability.
	- Simplified fallback material retrieval in GLTF loaders for improved consistency.
	- Optimized render queue mask clearing to occur after rendering for better processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->