### PR TITLE
Fix `ColorWriteMask` property type of `BlendState` in ShaderLab

### DIFF
--- a/docs/zh/graphics/material/shaderLab/global.mdx
+++ b/docs/zh/graphics/material/shaderLab/global.mdx
@@ -32,7 +32,7 @@ title: 全局变量声明
     SourceAlphaBlendFactor: BlendFactor.XXX;
     DestinationColorBlendFactor: BlendFactor.XXX;
     DestinationAlphaBlendFactor: BlendFactor.XXX;
-    ColorWriteMask: float // 0xffffffff
+    ColorWriteMask: ColorWriteMask.XXX;
     BlendColor: vec4;
     AlphaToCoverage: bool;
   }

--- a/packages/shader-lab/src/common/Keywords.ts
+++ b/packages/shader-lab/src/common/Keywords.ts
@@ -97,5 +97,6 @@ export enum EKeyword {
   GS_CompareFunction,
   GS_StencilOperation,
   GS_CullMode,
+  GS_ColorWriteMask,
   GS_UsePass
 }

--- a/packages/shader-lab/src/contentParser/KeywordMap.ts
+++ b/packages/shader-lab/src/contentParser/KeywordMap.ts
@@ -24,5 +24,6 @@ export const KeywordMap = new Map([
   ["true", EKeyword.TRUE],
   ["false", EKeyword.FALSE],
   ["UsePass", EKeyword.GS_UsePass],
+  ["ColorWriteMask", EKeyword.GS_ColorWriteMask],
   ["Color", EKeyword.GS_Color]
 ]);

--- a/packages/shader-lab/src/contentParser/ShaderContentParser.ts
+++ b/packages/shader-lab/src/contentParser/ShaderContentParser.ts
@@ -14,6 +14,7 @@ import {
   BlendOperation,
   BlendFactor,
   CullMode,
+  ColorWriteMask,
   Logger
 } from "@galacean/engine";
 import {
@@ -52,7 +53,15 @@ const RenderStateType = [
  * @internal
  */
 export class ShaderContentParser {
-  static _engineType = { RenderQueueType, CompareFunction, StencilOperation, BlendOperation, BlendFactor, CullMode };
+  static _engineType = {
+    RenderQueueType,
+    CompareFunction,
+    StencilOperation,
+    BlendOperation,
+    BlendFactor,
+    CullMode,
+    ColorWriteMask
+  };
 
   static _errors: GSError[] = [];
 

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -1,5 +1,6 @@
 import {
   BlendOperation,
+  ColorWriteMask,
   CompareFunction,
   CullMode,
   RenderStateDataKey,
@@ -187,7 +188,7 @@ describe("ShaderLab", () => {
       [RenderStateDataKey.StencilStateCompareFunctionFront]: CompareFunction.Less,
       // Blend State
       [RenderStateDataKey.BlendStateEnabled0]: true,
-      [RenderStateDataKey.BlendStateColorWriteMask0]: 0.8,
+      [RenderStateDataKey.BlendStateColorWriteMask0]: ColorWriteMask.None,
       [RenderStateDataKey.BlendStateAlphaBlendOperation0]: BlendOperation.Max,
 
       // Depth State

--- a/tests/src/shader-lab/shaders/demo.shader
+++ b/tests/src/shader-lab/shaders/demo.shader
@@ -28,9 +28,9 @@ Shader "Water" {
     BlendState {
       SourceAlphaBlendFactor = material_SrcBlend;
       Enabled[0] = true;
-      ColorWriteMask[0] = 0.8;
       BlendColor = Color(1.0, 1.0, 1.0, 1.0);
       AlphaBlendOperation = BlendOperation.Max;
+      ColorWriteMask = ColorWriteMask.None;
     }
 
     UsePass "pbr/Default/Forward"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix the doc error and runtime implementation of `ColorWriteMask`.
```glsl
BlendState state {
  Enabled: bool;
  ColorBlendOperation: BlendOperation.XXX;
  AlphaBlendOperation: BlendOperation.XXX;
  SourceColorBlendFactor: BlendFactor.XXX;
  SourceAlphaBlendFactor: BlendFactor.XXX;
  DestinationColorBlendFactor: BlendFactor.XXX;
  DestinationAlphaBlendFactor: BlendFactor.XXX;
  // should be ColorWriteMask.XXX;
  ColorWriteMask: float;
  BlendColor: vec4;
  AlphaToCoverage: bool;
}
```