### PR TITLE
修复 1.1.x 上下文丢失没有恢复的问题

### DIFF
--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -141,7 +141,10 @@ export class Background {
           super(mesh);
         }
         restoreContent() {
-          mesh._reUploadAdvancedData();
+          mesh.setPositions(mesh.getPositions());
+          mesh.setUVs(mesh.getUVs());
+          mesh.setIndices(mesh.getIndices());
+          mesh.uploadData(false);
         }
       })()
     );

--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -1,5 +1,5 @@
 import { Color, Vector2, Vector3 } from "@galacean/engine-math";
-import { CompareFunction, Material, ModelMesh, Shader } from ".";
+import { CompareFunction, ContentRestorer, Material, ModelMesh, Shader } from ".";
 import { Engine } from "./Engine";
 import { BackgroundMode } from "./enums/BackgroundMode";
 import { BackgroundTextureFillMode } from "./enums/BackgroundTextureFillMode";
@@ -134,7 +134,17 @@ export class Background {
   }
 
   private _initMesh(engine: Engine): void {
-    this._mesh = this._createPlane(engine);
+    const mesh = (this._mesh = this._createPlane(engine));
+    engine.resourceManager.addContentRestorer(
+      new (class extends ContentRestorer<ModelMesh> {
+        constructor() {
+          super(mesh);
+        }
+        restoreContent() {
+          mesh._reUploadAdvancedData();
+        }
+      })()
+    );
     this._mesh._addReferCount(1);
   }
 

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -791,6 +791,20 @@ export class ModelMesh extends Mesh {
 
   /**
    * @internal
+   * @remarks Only used for advanced vertex and readable data mesh.
+   */
+  _reUploadAdvancedData(): void {
+    this._advancedDataUpdateFlag = 0xffff;
+    this._indicesChangeFlag = true;
+    const advancedVertexDataVersions = this._advancedVertexDataVersions;
+    for (let i = 0, n = advancedVertexDataVersions.length; i < n; i++) {
+      advancedVertexDataVersions[i] = this._dataVersionCounter++;
+    }
+    this.uploadData(false);
+  }
+
+  /**
+   * @internal
    */
   _getVertexTypedArray(vertexDataBuffer: ArrayBuffer, dataType: DataType): TypedArray {
     switch (dataType) {
@@ -1159,6 +1173,7 @@ export class ModelMesh extends Mesh {
           }
         }
       }
+      vertexBufferInfo.dataVersion = advancedDataVersion;
       vertexBufferInfo.uploadAdvancedData = true;
     }
   }

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -1159,7 +1159,6 @@ export class ModelMesh extends Mesh {
           }
         }
       }
-      vertexBufferInfo.dataVersion = advancedDataVersion;
       vertexBufferInfo.uploadAdvancedData = true;
     }
   }

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -791,20 +791,6 @@ export class ModelMesh extends Mesh {
 
   /**
    * @internal
-   * @remarks Only used for advanced vertex and readable data mesh.
-   */
-  _reUploadAdvancedData(): void {
-    this._advancedDataUpdateFlag = 0xffff;
-    this._indicesChangeFlag = true;
-    const advancedVertexDataVersions = this._advancedVertexDataVersions;
-    for (let i = 0, n = advancedVertexDataVersions.length; i < n; i++) {
-      advancedVertexDataVersions[i] = this._dataVersionCounter++;
-    }
-    this.uploadData(false);
-  }
-
-  /**
-   * @internal
    */
   _getVertexTypedArray(vertexDataBuffer: ArrayBuffer, dataType: DataType): TypedArray {
     switch (dataType) {

--- a/packages/loader/src/EnvLoader.ts
+++ b/packages/loader/src/EnvLoader.ts
@@ -2,49 +2,70 @@ import {
   AmbientLight,
   AssetPromise,
   AssetType,
+  ContentRestorer,
   DiffuseMode,
-  Loader,
+  Engine,
   LoadItem,
-  resourceLoader,
+  Loader,
   ResourceManager,
   TextureCube,
   TextureCubeFace,
-  TextureFilterMode
+  TextureFilterMode,
+  resourceLoader
 } from "@galacean/engine-core";
 import { SphericalHarmonics3 } from "@galacean/engine-math";
 
 @resourceLoader(AssetType.Env, ["env"])
 class EnvLoader extends Loader<AmbientLight> {
+  /**
+   * @internal
+   */
+  static _setTextureByBuffer(engine: Engine, buffer: ArrayBuffer, texture?: TextureCube) {
+    const shByteLength = 27 * 4;
+    const size = new Uint16Array(buffer, shByteLength, 1)?.[0];
+    texture ||= new TextureCube(engine, size);
+    texture.filterMode = TextureFilterMode.Trilinear;
+    const mipmapCount = texture.mipmapCount;
+    let offset = shByteLength + 2;
+
+    for (let mipLevel = 0; mipLevel < mipmapCount; mipLevel++) {
+      const mipSize = size >> mipLevel;
+
+      for (let face = 0; face < 6; face++) {
+        const dataSize = mipSize * mipSize * 4;
+        const data = new Uint8Array(buffer, offset, dataSize);
+        offset += dataSize;
+        texture.setPixelBuffer(TextureCubeFace.PositiveX + face, data, mipLevel);
+      }
+    }
+    return texture;
+  }
+
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<AmbientLight> {
     return new AssetPromise((resolve, reject) => {
-      this.request<ArrayBuffer>(item.url, { type: "arraybuffer" })
+      const engine = resourceManager.engine;
+      const request = this.request;
+      request<ArrayBuffer>(item.url, { ...item, type: "arraybuffer" })
         .then((arraybuffer) => {
-          const shArray = new Float32Array(arraybuffer, 0, 27);
-          const shByteLength = 27 * 4;
-          const size = new Uint16Array(arraybuffer, shByteLength, 1)?.[0];
-
-          const { engine } = resourceManager;
-          const texture = new TextureCube(engine, size);
-          texture.filterMode = TextureFilterMode.Trilinear;
-          const mipmapCount = texture.mipmapCount;
-          let offset = shByteLength + 2;
-
-          for (let mipLevel = 0; mipLevel < mipmapCount; mipLevel++) {
-            const mipSize = size >> mipLevel;
-
-            for (let face = 0; face < 6; face++) {
-              const dataSize = mipSize * mipSize * 4;
-              const data = new Uint8Array(arraybuffer, offset, dataSize);
-              offset += dataSize;
-              texture.setPixelBuffer(TextureCubeFace.PositiveX + face, data, mipLevel);
-            }
-          }
-
+          const texture = EnvLoader._setTextureByBuffer(engine, arraybuffer);
+          engine.resourceManager.addContentRestorer(
+            new (class extends ContentRestorer<TextureCube> {
+              override restoreContent(): AssetPromise<TextureCube> {
+                return new AssetPromise((resolve, reject) => {
+                  request<ArrayBuffer>(item.url, { ...item, type: "arraybuffer" })
+                    .then((buffer) => {
+                      EnvLoader._setTextureByBuffer(engine, buffer, texture);
+                      resolve(texture);
+                    })
+                    .catch(reject);
+                });
+              }
+            })(texture)
+          );
           const ambientLight = new AmbientLight(engine);
           const sh = new SphericalHarmonics3();
-
           ambientLight.diffuseMode = DiffuseMode.SphericalHarmonics;
-          sh.copyFromArray(shArray);
+          sh.copyFromArray(new Float32Array(arraybuffer, 0, 27));
           ambientLight.diffuseSphericalHarmonics = sh;
           ambientLight.specularTexture = texture;
           ambientLight.specularTextureDecodeRGBM = true;

--- a/packages/loader/src/HDRLoader.ts
+++ b/packages/loader/src/HDRLoader.ts
@@ -1,13 +1,17 @@
 import {
   AssetPromise,
   AssetType,
-  Loader,
+  ContentRestorer,
+  Engine,
   LoadItem,
-  resourceLoader,
+  Loader,
   ResourceManager,
   TextureCube,
-  TextureCubeFace
+  TextureCubeFace,
+  request,
+  resourceLoader
 } from "@galacean/engine-core";
+import { RequestConfig } from "@galacean/engine-core/types/asset/request";
 import { Color, Vector3 } from "@galacean/engine-math";
 
 const PI = Math.PI;
@@ -80,6 +84,23 @@ class HDRLoader extends Loader<TextureCube> {
   private static _temp3Vector3 = new Vector3();
   private static _temp4Vector3 = new Vector3();
   private static _temp5Vector3 = new Vector3();
+
+  /**
+   * @internal
+   */
+  static _setTextureByBuffer(engine: Engine, buffer: ArrayBuffer, texture?: TextureCube) {
+    const bufferArray = new Uint8Array(buffer);
+    const { width, height, dataPosition } = HDRLoader._parseHeader(bufferArray);
+    const cubeSize = height >> 1;
+    texture ||= new TextureCube(engine, cubeSize);
+    const pixels = HDRLoader._readPixels(bufferArray.subarray(dataPosition), width, height);
+    const cubeMapData = HDRLoader._convertToCubemap(pixels, width, height, cubeSize);
+    for (let faceIndex = 0; faceIndex < 6; faceIndex++) {
+      texture.setPixelBuffer(TextureCubeFace.PositiveX + faceIndex, cubeMapData[faceIndex], 0);
+    }
+    texture.generateMipmaps();
+    return texture;
+  }
 
   private static _convertToCubemap(
     pixels: Uint8Array,
@@ -373,22 +394,36 @@ class HDRLoader extends Loader<TextureCube> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<TextureCube> {
     return new AssetPromise((resolve, reject) => {
       const engine = resourceManager.engine;
-
-      this.request<ArrayBuffer>(item.url, { type: "arraybuffer" })
+      const requestConfig = { ...item, type: "arraybuffer" } as RequestConfig;
+      this.request<ArrayBuffer>(item.url, requestConfig)
         .then((buffer) => {
-          const uint8Array = new Uint8Array(buffer);
-          const { width, height, dataPosition } = HDRLoader._parseHeader(uint8Array);
-          const pixels = HDRLoader._readPixels(uint8Array.subarray(dataPosition), width, height);
-          const cubeSize = height >> 1;
-
-          const cubeMapData = HDRLoader._convertToCubemap(pixels, width, height, cubeSize);
-          const texture = new TextureCube(engine, cubeSize);
-
-          for (let faceIndex = 0; faceIndex < 6; faceIndex++) {
-            texture.setPixelBuffer(TextureCubeFace.PositiveX + faceIndex, cubeMapData[faceIndex], 0);
-          }
-          texture.generateMipmaps();
+          const texture = HDRLoader._setTextureByBuffer(engine, buffer);
+          engine.resourceManager.addContentRestorer(new HDRContentRestorer(texture, item.url, requestConfig));
           resolve(texture);
+        })
+        .catch(reject);
+    });
+  }
+}
+
+/**
+ * @internal
+ */
+class HDRContentRestorer extends ContentRestorer<TextureCube> {
+  constructor(
+    resource: TextureCube,
+    public url: string,
+    public requestConfig: RequestConfig
+  ) {
+    super(resource);
+  }
+
+  override restoreContent(): AssetPromise<TextureCube> {
+    return new AssetPromise((resolve, reject) => {
+      request<ArrayBuffer>(this.url, this.requestConfig)
+        .then((buffer) => {
+          HDRLoader._setTextureByBuffer(this.resource.engine, buffer, this.resource);
+          resolve(this.resource);
         })
         .catch(reject);
     });

--- a/packages/loader/src/gltf/GLTFUtils.ts
+++ b/packages/loader/src/gltf/GLTFUtils.ts
@@ -389,31 +389,32 @@ export class GLTFUtils {
 
     const dataView = new DataView(originBuffer);
 
-    // read header
+    // Read header
     const header = {
       magic: dataView.getUint32(0, true),
       version: dataView.getUint32(UINT32_LENGTH, true),
       length: dataView.getUint32(2 * UINT32_LENGTH, true)
     };
 
+    // Return the original buffer if it is not a glb
     if (header.magic !== GLB_HEADER_MAGIC) {
       return { originBuffer };
     }
 
-    // read main data
+    // Read main data
     let chunkLength = dataView.getUint32(GLB_HEADER_LENGTH, true);
     let chunkType = dataView.getUint32(GLB_HEADER_LENGTH + UINT32_LENGTH, true);
 
-    // read glTF json
+    // Read glTF json
     if (chunkType !== GLB_CHUNK_TYPES.JSON) {
       console.error("Invalid glb chunk type. Expected 0x4E4F534A, found 0x" + chunkType.toString(16));
       return null;
     }
 
     const glTFData = new Uint8Array(originBuffer, GLB_HEADER_LENGTH + 2 * UINT32_LENGTH, chunkLength);
-    const glTF: IGLTF = JSON.parse(Utils.decodeText(glTFData));
+    const glTF = <IGLTF>JSON.parse(Utils.decodeText(glTFData));
 
-    // read all buffers
+    // Read all buffers
     const buffers: ArrayBuffer[] = [];
     let byteOffset = GLB_HEADER_LENGTH + 2 * UINT32_LENGTH + chunkLength;
 

--- a/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
@@ -16,7 +16,10 @@ export class GLTFSchemaParser extends GLTFParser {
     return request<ArrayBuffer>(url, requestConfig)
       .then((buffer) => {
         const parseResult = GLTFUtils.parseGLB(context, buffer);
-        parseResult.buffers && restoreBufferRequests.push(new BufferRequestInfo(url, requestConfig));
+        // If the buffer is a GLB file, we need to restore the buffer data
+        if (parseResult?.glTF) {
+          restoreBufferRequests.push(new BufferRequestInfo(url, requestConfig));
+        }
         return parseResult;
       })
       .then((result) => {

--- a/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
@@ -15,7 +15,8 @@ export class GLTFSchemaParser extends GLTFParser {
     const requestConfig = <RequestConfig>{ type: "arraybuffer" };
     return request<ArrayBuffer>(url, requestConfig)
       .then((buffer) => {
-        restoreBufferRequests.push(new BufferRequestInfo(url, requestConfig));
+        const parseResult = GLTFUtils.parseGLB(context, buffer);
+        parseResult.buffers && restoreBufferRequests.push(new BufferRequestInfo(url, requestConfig));
         return GLTFUtils.parseGLB(context, buffer);
       })
       .then((result) => {

--- a/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSchemaParser.ts
@@ -17,7 +17,7 @@ export class GLTFSchemaParser extends GLTFParser {
       .then((buffer) => {
         const parseResult = GLTFUtils.parseGLB(context, buffer);
         parseResult.buffers && restoreBufferRequests.push(new BufferRequestInfo(url, requestConfig));
-        return GLTFUtils.parseGLB(context, buffer);
+        return parseResult;
       })
       .then((result) => {
         if (result?.glTF) {

--- a/packages/loader/src/resource-deserialize/index.ts
+++ b/packages/loader/src/resource-deserialize/index.ts
@@ -1,14 +1,14 @@
 import { Engine } from "@galacean/engine-core";
 import { BufferReader } from "./utils/BufferReader";
-import { decoderMap, decoder } from "./utils/Decorator";
+import { decoderMap } from "./utils/Decorator";
 import { FileHeader } from "./utils/FileHeader";
 
-export { MeshDecoder } from "./resources/mesh/MeshDecoder";
-export { Texture2DDecoder } from "./resources/texture2D/TextureDecoder";
-export { ReflectionParser } from "./resources/parser/ReflectionParser";
-export { PrefabParser } from "./resources/parser/PrefabParser";
 export * from "./resources/animationClip/AnimationClipDecoder";
 export type { IModelMesh } from "./resources/mesh/IModelMesh";
+export { MeshDecoder } from "./resources/mesh/MeshDecoder";
+export { PrefabParser } from "./resources/parser/PrefabParser";
+export { ReflectionParser } from "./resources/parser/ReflectionParser";
+export { Texture2DDecoder } from "./resources/texture2D/TextureDecoder";
 
 /**
  * Decode engine binary resource.
@@ -16,16 +16,16 @@ export type { IModelMesh } from "./resources/mesh/IModelMesh";
  * @param engine - engine
  * @returns
  */
-export function decode<T>(arrayBuffer: ArrayBuffer, engine: Engine): Promise<T> {
+export function decode<T>(arrayBuffer: ArrayBuffer, engine: Engine, ...args: any[]): Promise<T> {
   const header = FileHeader.decode(arrayBuffer);
   const bufferReader = new BufferReader(new Uint8Array(arrayBuffer), header.headerLength, header.dataLength);
-  return decoderMap[header.type].decode(engine, bufferReader).then((object) => {
+  return decoderMap[header.type].decode(engine, bufferReader, ...args).then((object) => {
     object.name = header.name;
     return object;
   });
 }
 
-export * from "./resources/schema";
-export * from "./resources/scene/SceneParser";
-export * from "./resources/scene/MeshLoader";
 export * from "./resources/scene/EditorTextureLoader";
+export * from "./resources/scene/MeshLoader";
+export * from "./resources/scene/SceneParser";
+export * from "./resources/schema";

--- a/packages/loader/src/resource-deserialize/resources/mesh/MeshDecoder.ts
+++ b/packages/loader/src/resource-deserialize/resources/mesh/MeshDecoder.ts
@@ -10,9 +10,9 @@ import type { IEncodedModelMesh } from "./IModelMesh";
  */
 @decoder("Mesh")
 export class MeshDecoder {
-  public static decode(engine: Engine, bufferReader: BufferReader): Promise<ModelMesh> {
+  public static decode(engine: Engine, bufferReader: BufferReader, restoredMesh?: ModelMesh): Promise<ModelMesh> {
     return new Promise((resolve) => {
-      const modelMesh = new ModelMesh(engine);
+      const modelMesh = restoredMesh || new ModelMesh(engine);
       const jsonDataString = bufferReader.nextStr();
       const encodedMeshData: IEncodedModelMesh = JSON.parse(jsonDataString);
 

--- a/packages/loader/src/resource-deserialize/resources/scene/EditorTextureLoader.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/EditorTextureLoader.ts
@@ -1,13 +1,35 @@
-import { AssetPromise, Loader, LoadItem, resourceLoader, ResourceManager, Texture2D } from "@galacean/engine-core";
+import {
+  AssetPromise,
+  ContentRestorer,
+  Loader,
+  LoadItem,
+  resourceLoader,
+  ResourceManager,
+  Texture2D
+} from "@galacean/engine-core";
 import { decode } from "../..";
 
 @resourceLoader("EditorTexture2D", ["prefab"], true)
 export class EditorTextureLoader extends Loader<Texture2D> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Texture2D> {
     return new AssetPromise((resolve, reject) => {
-      this.request<ArrayBuffer>(item.url, { type: "arraybuffer" })
+      const request = this.request;
+      request<ArrayBuffer>(item.url, {
+        ...item,
+        type: "arraybuffer"
+      })
         .then((data) => {
           decode<Texture2D>(data, resourceManager.engine).then((texture) => {
+            resourceManager.addContentRestorer(
+              new (class extends ContentRestorer<Texture2D> {
+                override restoreContent(): AssetPromise<Texture2D> {
+                  return request<ArrayBuffer>(item.url, {
+                    ...item,
+                    type: "arraybuffer"
+                  }).then((data) => decode<Texture2D>(data, resourceManager.engine, texture));
+                }
+              })(texture)
+            );
             resolve(texture);
           });
         })

--- a/packages/loader/src/resource-deserialize/resources/texture2D/TextureDecoder.ts
+++ b/packages/loader/src/resource-deserialize/resources/texture2D/TextureDecoder.ts
@@ -4,7 +4,7 @@ import { decoder } from "../../utils/Decorator";
 
 @decoder("Texture2D")
 export class Texture2DDecoder {
-  static decode(engine: Engine, bufferReader: BufferReader): Promise<Texture2D> {
+  static decode(engine: Engine, bufferReader: BufferReader, restoredTexture?: Texture2D): Promise<Texture2D> {
     return new Promise((resolve, reject) => {
       const objectId = bufferReader.nextStr();
       const mipmap = !!bufferReader.nextUint8();
@@ -20,7 +20,7 @@ export class Texture2DDecoder {
       const mipCount = bufferReader.nextUint8();
       const imagesData = bufferReader.nextImagesData(mipCount);
 
-      const texture2D = new Texture2D(engine, width, height, format, mipmap);
+      const texture2D = restoredTexture || new Texture2D(engine, width, height, format, mipmap);
       texture2D.filterMode = filterMode;
       texture2D.anisoLevel = anisoLevel;
       texture2D.wrapModeU = wrapModeU;

--- a/packages/loader/src/resource-deserialize/utils/Decorator.ts
+++ b/packages/loader/src/resource-deserialize/utils/Decorator.ts
@@ -4,7 +4,7 @@ import type { BufferReader } from "./BufferReader";
 export const decoderMap: Record<
   string,
   {
-    decode: (engine: Engine, bufferReader: BufferReader) => Promise<any>;
+    decode: (engine: Engine, bufferReader: BufferReader, ...arg: any[]) => Promise<any>;
   }
 > = {};
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automatic content restoration for meshes and textures, allowing resources to be recovered seamlessly in case of loss or reload scenarios.

- **Refactor**
  - Modularized texture creation and mesh decoding logic for improved maintainability and clarity.

- **Bug Fixes**
  - Improved handling of restoration requests to ensure they are only registered for valid resource types.

- **Documentation**
  - Updated and standardized code comments for improved readability.

- **Style**
  - Minor code style and type assertion adjustments for consistency.

- **Chores**
  - Updated internal method and function signatures to support restoration and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->