### PR TITLE
Support camera HDR require alpha config

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -103,6 +103,18 @@ export class Camera extends Component {
    */
   antiAliasing: AntiAliasing = AntiAliasing.None;
 
+  /**
+   * Determines whether to preserve the alpha channel in the output.
+   * When set to true, the alpha channel is always preserved.
+   * When set to false, the engine automatically decides whether to preserve it.
+   *
+   * @remarks
+   * Set to true if you need to ensure the alpha channel is preserved, for example, when performing canvas transparent blending.
+   *
+   * @defaultValue `false`
+   */
+  isAlphaOutputRequired = false;
+
   /** @internal */
   _cameraType: CameraType = CameraType.Normal;
   /** @internal */
@@ -743,7 +755,7 @@ export class Camera extends Component {
    */
   _getInternalColorTextureFormat(): TextureFormat {
     return this._enableHDR
-      ? this.engine._hardwareRenderer.isWebGL2
+      ? this.engine._hardwareRenderer.isWebGL2 && !this.isAlphaOutputRequired
         ? TextureFormat.R11G11B10_UFloat
         : TextureFormat.R16G16B16A16
       : TextureFormat.R8G8B8A8;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether the alpha channel is preserved in camera output.

- **Behavior Changes**
  - The internal color texture format selection now adapts based on the alpha output requirement, potentially affecting rendering results when HDR is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->