### PR TITLE
refactor: delete platform adapter from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,66 +110,9 @@ jobs:
           cp -r ${{ github.workspace }}/editor/packages/decorators/dist ${{ github.workspace }}/temp/@galacean/editor-decorators
           find ${{ github.workspace }}/temp
 
-      - name: Ensure Adapter Directory Exists
-        run: mkdir -p ${{ github.workspace }}/platform-adapter/dist
-
-      # Create a mock package.json to specify the path and version of the adapter build result when syncing with the CDN later.
-      # name is set to @galacean/engine-platform-adapter-release to avoid conflicts with the real package.json
-      # version is set to the version of the engine package
-      - name: Create package.json for platform-adapter
-        run: |
-          VERSION=$(jq -r '.version' ${{ github.workspace }}/packages/galacean/package.json)
-          echo "{\"name\": \"@galacean/engine-platform-adapter-release\", \"version\": \"$VERSION\"}" > ${{ github.workspace }}/platform-adapter/package.json
-          cat ${{ github.workspace }}/platform-adapter/package.json
-
-      - name: Bundle polyfill and engine
-        uses: galacean/platform-adapter@main
-        env:
-          ADAPTER_BUNDLE_SETTINGS: |
-            {
-              "polyfill": true,
-              "engine": [
-                "${{ github.workspace }}/temp/@galacean/engine/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-xr/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-ui/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-shaderlab/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-shader-shaderlab/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-physics-lite/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-physics-physx/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-toolkit/umd/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-lottie/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/engine-spine/dist/browser.js",
-                "${{ github.workspace }}/temp/@galacean/editor-decorators/dist/browser.js"
-              ],
-              "wasm": [
-                "${{ github.workspace }}/packages/physics-physx/libs/physx.release.wasm"
-              ],
-              "jsWASMLoader": [
-                "${{ github.workspace }}/packages/physics-physx/libs/physx.release.js"
-              ],
-              "outputDir": "${{ github.workspace }}/platform-adapter/dist"
-            }
-      
-      - name: Print Adapter Bundle
-        run: find ${{ github.workspace }}/platform-adapter -type f
-
       - name: Release engine packages and Sync to CDN
         uses: galacean/publish@main
         if: success() || failure()
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
-          OASISBE_UPLOAD_URL: https://oasisbe.alipay.com/api/file/no-auth/crypto/upload
-          OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
-          OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
-
-      - name: Sync Platform Adapter to CDN
-        uses: galacean/publish@main
-        if: success() || failure()
-        with:
-          publish: false
-          packages: |
-            platform-adapter
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed all steps related to preparing, bundling, and syncing the platform adapter package from the release workflow. The workflow now only handles engine package releases and CDN synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->