### PR TITLE
Fix camera MSAA value inaccurate

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -438,10 +438,10 @@ export class Camera extends Component {
       const maxMSAASamples = this._engine._hardwareRenderer.capability.maxAntiAliasing;
       if (value > maxMSAASamples) {
         Logger.warn(`MSAA samples exceeds the limit and is automatically downgraded to:${maxMSAASamples}`);
-        value = maxMSAASamples;
+        this._msaaSamples = maxMSAASamples;
+      } else {
+        this._msaaSamples = value;
       }
-
-      this._msaaSamples = value;
     }
   }
 

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -88,14 +88,6 @@ export class Camera extends Component {
   opaqueTextureDownsampling: Downsampling = Downsampling.TwoX;
 
   /**
-   * The number of samples used for hardware multisample anti-aliasing (MSAA) to smooth geometry edges during rasterization.
-   * Higher sample counts (e.g., 2x, 4x, 8x) produce smoother edges.
-   *
-   * @defaultValue `MSAASamples.FourX`
-   */
-  msaaSamples: MSAASamples = MSAASamples.FourX;
-
-  /**
    * The screen-space anti-aliasing mode applied after the camera renders the final image.
    * Unlike MSAA, it can smooth all pixels, including by shader-generated specular, alpha-cutoff edge, low resolution texture.
    *
@@ -152,6 +144,7 @@ export class Camera extends Component {
   private _opaqueTextureEnabled: boolean = false;
   private _enableHDR = false;
   private _enablePostProcess = false;
+  private _msaaSamples: MSAASamples;
 
   @ignoreClone
   private _updateFlagManager: UpdateFlagManager;
@@ -431,10 +424,34 @@ export class Camera extends Component {
   }
 
   /**
+   * The number of samples used for hardware multisample anti-aliasing (MSAA) to smooth geometry edges during rasterization.
+   * Higher sample counts (e.g., 2x, 4x, 8x) produce smoother edges.
+   *
+   * @defaultValue `MSAASamples.FourX`
+   */
+  get msaaSamples(): MSAASamples {
+    return this._msaaSamples;
+  }
+
+  set msaaSamples(value: MSAASamples) {
+    if (this._msaaSamples !== value) {
+      const maxMSAASamples = this._engine._hardwareRenderer.capability.maxAntiAliasing;
+      if (value > maxMSAASamples) {
+        Logger.warn(`MSAA samples exceeds the limit and is automatically downgraded to:${maxMSAASamples}`);
+        value = maxMSAASamples;
+      }
+
+      this._msaaSamples = value;
+    }
+  }
+
+  /**
    * @internal
    */
   constructor(entity: Entity) {
     super(entity);
+    // Include hardware check
+    this.msaaSamples = MSAASamples.FourX;
 
     this._isViewMatrixDirty = entity.registerWorldChangeFlag();
     this._isInvViewProjDirty = entity.registerWorldChangeFlag();

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -450,7 +450,7 @@ export class Camera extends Component {
    */
   constructor(entity: Entity) {
     super(entity);
-    // Include hardware check
+    // Includes hardware detection correction
     this.msaaSamples = MSAASamples.FourX;
 
     this._isViewMatrixDirty = entity.registerWorldChangeFlag();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of anti-aliasing settings for cameras to ensure compatibility with hardware capabilities. If an unsupported value is set, it will be automatically adjusted and a warning will be displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->