### PR TITLE
Fix text metrices not support actualBoundingBoxLeft and actualBoundingBoxRight in some device

### DIFF
--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -72,7 +72,7 @@ export class Polyfill {
   }
 
   private static _registerTextMetrics(): void {
-    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textBaseline is always in middle mode.
+    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start" and direction is left to right.
     // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
     // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -72,19 +72,19 @@ export class Polyfill {
   }
 
   private static _registerTextMetrics(): void {
-    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start".
+    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start" and direction is left to right.
     // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
     // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {
       Object.defineProperties(TextMetrics.prototype, {
         actualBoundingBoxLeft: {
           get: function () {
-            return this.width;
+            return 0;
           }
         },
         actualBoundingBoxRight: {
           get: function () {
-            return 0;
+            return this.width;
           }
         }
       });

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -72,7 +72,7 @@ export class Polyfill {
   }
 
   private static _registerTextMetrics(): void {
-    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start" and direction is left to right.
+    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and `textAlign` uses the default value `start` and direction is left to right.
     // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
     // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -7,6 +7,7 @@ export class Polyfill {
   static registerPolyfill(): void {
     Polyfill._registerMatchAll();
     Polyfill._registerAudioContext();
+    Polyfill._registerMeasureText();
   }
 
   private static _registerMatchAll(): void {
@@ -67,6 +68,27 @@ export class Polyfill {
           );
         });
       };
+    }
+  }
+
+  private static _registerMeasureText(): void {
+    if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {
+      Object.defineProperties(TextMetrics.prototype, {
+        actualBoundingBoxLeft: {
+          get: function () {
+            return this.width; // 将 actualBoundingBoxLeft 的值与 width 保持一致
+          },
+          configurable: true,
+          enumerable: true
+        },
+        actualBoundingBoxRight: {
+          get: function () {
+            return 0;
+          },
+          configurable: true,
+          enumerable: true
+        }
+      });
     }
   }
 }

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -72,7 +72,7 @@ export class Polyfill {
   }
 
   private static _registerTextMetrics(): void {
-    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start" and direction is left to right.
+    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textAlign uses the default value "start".
     // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
     // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -72,6 +72,9 @@ export class Polyfill {
   }
 
   private static _registerMeasureText(): void {
+    // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
+    // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
+    // This polyfill ensures compatibility by defining these properties dynamically.
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {
       Object.defineProperties(TextMetrics.prototype, {
         actualBoundingBoxLeft: {

--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -7,7 +7,7 @@ export class Polyfill {
   static registerPolyfill(): void {
     Polyfill._registerMatchAll();
     Polyfill._registerAudioContext();
-    Polyfill._registerMeasureText();
+    Polyfill._registerTextMetrics();
   }
 
   private static _registerMatchAll(): void {
@@ -71,25 +71,21 @@ export class Polyfill {
     }
   }
 
-  private static _registerMeasureText(): void {
+  private static _registerTextMetrics(): void {
+    // Based on the specific version of the engine implementation, when actualBoundingBoxLeft is not supported, width is used to represent the rendering width, and textBaseline is always in middle mode.
     // Some devices do not support actualBoundingBoxLeft and actualBoundingBoxRight in TextMetrics.
     // Examples: Google Pixel 2 XL (Android 11), Honor 6X (Android 8).
-    // This polyfill ensures compatibility by defining these properties dynamically.
     if (!("actualBoundingBoxLeft" in TextMetrics.prototype)) {
       Object.defineProperties(TextMetrics.prototype, {
         actualBoundingBoxLeft: {
           get: function () {
-            return this.width; // 将 actualBoundingBoxLeft 的值与 width 保持一致
-          },
-          configurable: true,
-          enumerable: true
+            return this.width;
+          }
         },
         actualBoundingBoxRight: {
           get: function () {
             return 0;
-          },
-          configurable: true,
-          enumerable: true
+          }
         }
       });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility on certain Android devices by ensuring text measurement properties are available, preventing potential display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->