### PR TITLE
`BoundingBox`  support `toJson`

### DIFF
--- a/packages/math/src/BoundingBox.ts
+++ b/packages/math/src/BoundingBox.ts
@@ -2,7 +2,7 @@ import { BoundingSphere } from "./BoundingSphere";
 import { IClone } from "./IClone";
 import { ICopy } from "./ICopy";
 import { Matrix } from "./Matrix";
-import { Vector3 } from "./Vector3";
+import { Vector3, Vector3Like } from "./Vector3";
 
 /**
  * Axis Aligned Bound Box (AABB).
@@ -77,8 +77,8 @@ export class BoundingBox implements IClone<BoundingBox>, ICopy<BoundingBox, Boun
     const e = matrix.elements;
     // prettier-ignore
     const e0 = e[0], e1 = e[1], e2 = e[2],
-    e4 = e[4], e5 = e[5], e6 = e[6],
-    e8 = e[8], e9 = e[9], e10 = e[10];
+      e4 = e[4], e5 = e[5], e6 = e[6],
+      e8 = e[8], e9 = e[9], e10 = e[10];
     extent.set(
       (e0 === 0 ? 0 : Math.abs(x * e0)) + (e4 === 0 ? 0 : Math.abs(y * e4)) + (e8 === 0 ? 0 : Math.abs(z * e8)),
       (e1 === 0 ? 0 : Math.abs(x * e1)) + (e5 === 0 ? 0 : Math.abs(y * e5)) + (e9 === 0 ? 0 : Math.abs(z * e9)),
@@ -215,4 +215,34 @@ export class BoundingBox implements IClone<BoundingBox>, ICopy<BoundingBox, Boun
     this.max.copyFrom(source.max);
     return this;
   }
+
+
+  /**
+   * Serialize this bounding box to a JSON representation.
+   * @returns A JSON representation of this bounding box
+   */
+  toJSON(): BoundingBoxLike {
+    const min = this.min;
+    const max = this.max;
+    return {
+      min: {
+        x: min._x,
+        y: min._y,
+        z: min._z,
+      },
+      max: {
+        x: max._x,
+        y: max._y,
+        z: max._z,
+      }
+    };
+  }
+}
+
+
+interface BoundingBoxLike {
+  /** {@inheritDoc BoundingBox.min} */
+  min: Vector3Like;
+  /** {@inheritDoc BoundingBox.max} */
+  max: Vector3Like;
 }

--- a/packages/math/src/BoundingBox.ts
+++ b/packages/math/src/BoundingBox.ts
@@ -216,7 +216,6 @@ export class BoundingBox implements IClone<BoundingBox>, ICopy<BoundingBox, Boun
     return this;
   }
 
-
   /**
    * Serialize this bounding box to a JSON representation.
    * @returns A JSON representation of this bounding box
@@ -228,17 +227,16 @@ export class BoundingBox implements IClone<BoundingBox>, ICopy<BoundingBox, Boun
       min: {
         x: min._x,
         y: min._y,
-        z: min._z,
+        z: min._z
       },
       max: {
         x: max._x,
         y: max._y,
-        z: max._z,
+        z: max._z
       }
     };
   }
 }
-
 
 interface BoundingBoxLike {
   /** {@inheritDoc BoundingBox.min} */

--- a/packages/math/src/Vector3.ts
+++ b/packages/math/src/Vector3.ts
@@ -611,7 +611,7 @@ export class Vector3 implements IClone<Vector3>, ICopy<Vector3Like, Vector3> {
   }
 }
 
-interface Vector3Like {
+export interface Vector3Like {
   /** {@inheritDoc Vector3.x} */
   x: number;
   /** {@inheritDoc Vector3.y} */


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to serialize bounding boxes to a JSON-compatible format, including their minimum and maximum coordinates.

- **Documentation**
  - Improved type definitions for JSON representations of bounding boxes and their coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->