### PR TITLE
Doc: add subpackage for export mini wechat game doc

### DIFF
--- a/docs/en/platform/wechatMiniGame.mdx
+++ b/docs/en/platform/wechatMiniGame.mdx
@@ -9,7 +9,7 @@ label: Platform
 
 When exporting to the WeChat Mini Game platform, there are the following configuration items:
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*natiS7i3cvUAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*Dc_mQITPRogAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
 | Configuration          | Describe                                                                                                                              | Corresponding to the configuration file of WeChat Mini Games | Corresponding to the fields in WeChat Mini Games
 | ------------- | ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -19,6 +19,7 @@ When exporting to the WeChat Mini Game platform, there are the following configu
 | Connect Socket | wx.connectSocket timeout, unit: milliseconds | game.json | networkTimeout.connectSocket |
 | Upload File | wx.uploadFile timeout, unit: milliseconds | game.json | networkTimeout.uploadFile |
 | Download File | wx.downloadFile timeout, unit: milliseconds | game.json | networkTimeout.downloadFile |
+| Subpackages | Subpackage list configuration | game.json | subpackages |
 
 For more configuration details, see: [project.config.json](https://developers.weixin.qq.com/minigame/dev/devtools/projectconfig.html)、[game.json](https://developers.weixin.qq.com/minigame/dev/reference/configuration/app.html)
 
@@ -26,49 +27,86 @@ For more configuration details, see: [project.config.json](https://developers.we
 
 After selecting the WeChat Mini Game platform, click the download button at the bottom of the export panel to export the required project:
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*a1-PQIsWlgIAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*yAeER487lbsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
 ## Debug
 
-1、After exporting the project to the local computer, first go to the root directory and execute the following command to install the dependent packages:
+1. After exporting from the editor to the local directory, the directory structure is as follows:
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
+
+**Project Directory Description**
+| Directory or File | Description |
+|-------------------|-------------|
+| public            | Asset directory. All assets from the editor are exported to this directory, and the asset path is /public/xxx |
+| scripts           | Scripts added by developers in the editor. After exporting locally, developers can further develop these script components |
+| game.json         | Corresponds to the [game.json](https://developers.weixin.qq.com/minigame/dev/reference/configuration/app.html) required for the WeChat Mini Game project |
+| game.ts           | Entry file where all initialization logic is placed |
+| package.json      | Mainly stores project dependencies |
+| project.config.json | Corresponds to the [project.config.json](https://developers.weixin.qq.com/minigame/dev/devtools/projectconfig.html) required for the WeChat Mini Game project |
+| project.ts        | Galacean project file, containing initialization-related information |
+
+2. After exporting the project locally, navigate to the root directory and run the following command to install dependencies:
 
 ```bash
 npm i
 ```
 
-2、Open **WeChat Developer Tools**, select Mini Game, and import the project just now, as follows:
+3. To locally build the output required for the WeChat Mini Game platform during the debugging phase, run the following command:
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*gCnXSqRgLnMAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+```bash
+npm run dev
+```
+After running this command, a new directory will be generated in the root directory of the project. This directory contains the output required for the WeChat Mini Game, as shown below:
 
-3、In WeChat Developer Tools, click **Tools->Build** npm, as follows:
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*G5aBQKNFdV8AAAAAAAAAAAAADjCHAQ/fmt.webp" />
+When running the `dev` command, the output will include source map files for debugging. Once the developer has completed debugging and is ready to release, the following command can be executed:
 
-4、After completing the above 3, you can preview the final result in the WeChat developer tool as follows:
+```bash
+npm run release
+```
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*JyoIS54k3uYAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+After running this command, the output compared to `dev` will remove the source map files and compress the code, making it smaller and suitable for release, as shown below:
 
-5、For debugging in WeChat developer tools, see: [WeChat Mini Game Debugging](https://developers.weixin.qq.com/minigame/dev/guide/runtime/debug/)
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
-## Publish
+4. Open **WeChat Developer Tools**, select Mini Game, and import the directory generated in step 3, as shown below:
 
-After local debugging is completed, you can publish it. For details on the publishing process, see: [WeChat Mini Games Publish](https://developers.weixin.qq.com/minigame/introduction/guide/)
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*v-odQJDjcfUAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
-## Export Project Directory Description
+5. After completing step 4, you can preview the final result in the WeChat Developer Tools, as shown below:
 
-The project directory exported to the local is as follows:
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*meRxSLDswlgAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*3jBDQYE5T9AAAAAAAAAAAAAADjCHAQ/fmt.webp" style={{zoom: "50%"}} />
+6. For debugging in the WeChat Developer Tools, see: [WeChat Mini Game Debugging](https://developers.weixin.qq.com/minigame/dev/guide/runtime/debug/)
 
-**Project Catalog Description**
-|Directory or file|Describe|
-|-------------|-------------|
-|adapters|Engine-related packages used in the project, exported on demand|
-|public|Asset directory. All assets of the editor are exported to this directory. The path of the asset is /public/xxx|
-|scripts|After the script components added by the developer in the editor are exported to the local computer, the developer can perform secondary development in the script components inside.|
-|game.json|Corresponding to the requirements of WeChat mini-game projects [game.json](https://developers.weixin.qq.com/minigame/dev/reference/configuration/app.html)|
-|game.ts|Entry file, the initialization logic is placed here|
-|package.json|Mainly store project dependency packages|
-|polyfill.js|Developers do not need to worry about platform DOM adaptation code and global variable adaptation code|
-|project.config.json|Corresponding to the requirements of WeChat mini-game projects [project.config.json](https://developers.weixin.qq.com/minigame/dev/devtools/projectconfig.html)|
-|project.ts|Galacean project files are parsed during initialization|
+## Subpackage
+
+### Overview
+
+As mini-games become increasingly complex with more content, the package size grows, affecting loading speed. WeChat Mini Games provide a subpackage feature that splits the game content into a main package and subpackages according to rules. The main package contains resources necessary for the initial launch, while subpackages are loaded as needed, allowing users to quickly enter the game.
+
+### Subpackage Configuration in Galacean Editor
+
+In the Galacean editor, folders are the unit for subpackage division. Content not in subpackages will go into the main package. When exporting the mini-game, add subpackages in the subpackage list of the export panel and associate them with folders to complete the subpackage configuration.
+
+### Subpackage Configuration Steps
+
+1. Open the export panel, select the WeChat Mini Game platform, and click the "Add Subpackage" button in the subpackage list to add a subpackage:
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*j5u6Q7txvj4AAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+2. In the subpackage, select the folder to be included in the subpackage to complete the configuration:
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*ndgyR5bjGqsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+### Notes
+
+- Script resources in folders set as subpackages will not be included in the subpackage but will be exported to the main package separately.
+- In WeChat Mini Games, the main package size is limited to 4MB. There is no size limit for a single subpackage, but the total size of the main package and subpackages cannot exceed 30MB. For more detailed rules, see: [Subpackage](https://developers.weixin.qq.com/minigame/dev/guide/base-ability/subPackage/useSubPackage.html)
+- The configuration, loading, and other processes of subpackages are automatically handled by the engine. Developers can dynamically load assets in subpackages and regular assets in the same way using `engine.resourceManager.load`.
+
+## Release
+
+After completing local debugging, you can proceed with the release. For detailed release steps, see: [WeChat Mini Game Release](https://developers.weixin.qq.com/minigame/introduction/guide/)

--- a/docs/zh/platform/wechatMiniGame.mdx
+++ b/docs/zh/platform/wechatMiniGame.mdx
@@ -33,7 +33,7 @@ label: Platform
 
 1、从编辑器导出到本地后，目录结构如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ transform: "scale(0.5)" }} />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
 **工程目录说明**
 |目录或文件|说明|
@@ -59,7 +59,7 @@ npm run dev
 ```
 执行完这个命令后，会在项目的根目录下生成一个新的目录，这个目录就是微信小游戏所需要的产物，如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ width: '50%', height: '50%' }} />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
 执行 dev 命令，产物里会有源码的 source map 文件，方便调试，当开发者完成调试准备发包时，可以执行命令：
 
@@ -69,7 +69,7 @@ npm run release
 
 执行这个命令后，相对 dev 产生的产物会去掉 source map 文件，并对代码进行压缩，体积更小，适合发布，如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ transform: "scale(0.5)" }} />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
 
 4、打开**微信开发者工具** ，选择小游戏，并导入步骤 3 中生成的目录，如下：

--- a/docs/zh/platform/wechatMiniGame.mdx
+++ b/docs/zh/platform/wechatMiniGame.mdx
@@ -59,7 +59,7 @@ npm run dev
 ```
 执行完这个命令后，会在项目的根目录下生成一个新的目录，这个目录就是微信小游戏所需要的产物，如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ width: '50%', height: '50%' }} />
 
 执行 dev 命令，产物里会有源码的 source map 文件，方便调试，当开发者完成调试准备发包时，可以执行命令：
 
@@ -69,7 +69,7 @@ npm run release
 
 执行这个命令后，相对 dev 产生的产物会去掉 source map 文件，并对代码进行压缩，体积更小，适合发布，如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ transform: "scale(0.5)" }} />
 
 
 4、打开**微信开发者工具** ，选择小游戏，并导入步骤 3 中生成的目录，如下：

--- a/docs/zh/platform/wechatMiniGame.mdx
+++ b/docs/zh/platform/wechatMiniGame.mdx
@@ -9,7 +9,7 @@ label: Platform
 
 在导出到微信小游戏平台的时候，有以下这些配置项：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*natiS7i3cvUAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*Dc_mQITPRogAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
 | 配置          | 描述                                                                                                                              | 对应到微信小游戏的配置文件 | 对应到微信小游戏中的字段
 | ------------- | ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -19,6 +19,7 @@ label: Platform
 | Connect Socket | wx.connectSocket 的超时时间，单位：毫秒 | game.json | networkTimeout.connectSocket |
 | Upload File | wx.uploadFile 的超时时间，单位：毫秒 | game.json | networkTimeout.uploadFile |
 | Download File | wx.downloadFile 的超时时间，单位：毫秒 | game.json | networkTimeout.downloadFile |
+| Subpackages | 子包列表的配置 | game.json | subpackages |
 
 更多配置详见：[project.config.json](https://developers.weixin.qq.com/minigame/dev/devtools/projectconfig.html)、[game.json](https://developers.weixin.qq.com/minigame/dev/reference/configuration/app.html)
 
@@ -26,49 +27,72 @@ label: Platform
 
 选择好微信小游戏平台后，点击导出面板最下方的下载按钮，即可导出所需工程：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*a1-PQIsWlgIAAAAAAAAAAAAADjCHAQ/fmt.webp" />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*yAeER487lbsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
 ## 调试
 
-1、工程导出到本地后，先进入到根目录执行以下命令进行依赖包的安装：
+1、从编辑器导出到本地后，目录结构如下：
 
-```bash
-npm i
-```
-
-2、打开**微信开发者工具** ，选择小游戏，并导入刚才的工程，如下：
-
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*gCnXSqRgLnMAAAAAAAAAAAAADjCHAQ/fmt.webp" />
-
-3、在微信开发者工具中，点击**工具->构建 npm**，如下：
-
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*G5aBQKNFdV8AAAAAAAAAAAAADjCHAQ/fmt.webp" />
-
-4、完成上述 3 后，即可在微信开发者工具中预览最终的结果，如下：
-
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*JyoIS54k3uYAAAAAAAAAAAAADjCHAQ/fmt.webp" />
-
-5、在微信开发者工具中的调试，详见：[微信小游戏调试](https://developers.weixin.qq.com/minigame/dev/guide/runtime/debug/)
-
-## 发布
-
-本地完成调试后，即可进行发布，具体发布流程详见：[微信小游戏发布](https://developers.weixin.qq.com/minigame/introduction/guide/)
-
-## 导出工程目录说明
-
-导出到本地的工程目录如下：
-
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*3jBDQYE5T9AAAAAAAAAAAAAADjCHAQ/fmt.webp" style={{zoom: "50%"}} />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
 
 **工程目录说明**
 |目录或文件|说明|
 |-------------|-------------|
-|adapters|项目用到的引擎相关的包，按需导出|
 |public|资产目录，编辑器所有资产导出到这个目录下，资产的 path 为 /public/xxx|
 |scripts|开发者在编辑器中添加的脚本组件，导出到本地后，开发者可以在里面的脚本组件中进行二次开发|
 |game.json|对应微信小游戏工程所需要的 [game.json](https://developers.weixin.qq.com/minigame/dev/reference/configuration/app.html)|
 |game.ts|入口文件，初始化的逻辑都放在这里|
 |package.json|主要存放项目依赖包|
-|polyfill.js|平台 DOM 适配代码和全局变量适配代码，开发者无需关心|
 |project.config.json|对应微信小游戏工程所需要的 [project.config.json](https://developers.weixin.qq.com/minigame/dev/devtools/projectconfig.html)|
-|project.ts|Galacean 的工程文件，在初始化的时候会解析|
+|project.ts|Galacean 的工程文件，放置初始化相关信息|
+
+2、工程导出到本地后，先进入到根目录执行以下命令进行依赖包的安装：
+
+```bash
+npm i
+```
+
+3、本地构建微信小游戏平台所需产物，调试阶段可以执行如下命令：
+
+```bash
+npm run dev
+```
+执行完这个命令后，会在项目的根目录下生成一个新的目录，这个目录就是微信小游戏所需要的产物，如下：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*wYi0QoS-BUsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+执行 dev 命令，产物里会有源码的 source map 文件，方便调试，当开发者完成调试准备发包时，可以执行命令：
+
+```bash
+npm run release
+```
+
+执行这个命令后，相对 dev 产生的产物会去掉 source map 文件，并对代码进行压缩，体积更小，适合发布，如下：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*7mvZR6wwEV4AAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+
+4、打开**微信开发者工具** ，选择小游戏，并导入步骤 3 中生成的目录，如下：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*v-odQJDjcfUAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+5、完成步骤 4 后，即可在微信开发者工具中预览最终的结果，如下：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*meRxSLDswlgAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+6、在微信开发者工具中的调试，详见：[微信小游戏调试](https://developers.weixin.qq.com/minigame/dev/guide/runtime/debug/)
+
+## 分包
+
+微信小游戏对于包体大小有严格的限制，分包是微信小游戏的一个重要特性，在 Galacean 编辑器中，我们以文件夹作为子包的单位。在导出小游戏面板中，可以通过在子包列表中添加子包并设置对应的文件夹来进行分包，具体的配置如下：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*ndgyR5bjGqsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+关于子包，有几个点需要注意：
+- 设置为子包的文件夹下的脚本资源不会计入子包，会单独导出
+- 开发者无需关注子包的加载时机，引擎会自动处理，开发者加载子包中的资源和正常加载资源的方式一致
+
+## 发布
+
+本地完成调试后，即可进行发布，具体发布流程详见：[微信小游戏发布](https://developers.weixin.qq.com/minigame/introduction/guide/)
+

--- a/docs/zh/platform/wechatMiniGame.mdx
+++ b/docs/zh/platform/wechatMiniGame.mdx
@@ -84,11 +84,26 @@ npm run release
 
 ## 分包
 
-随着小游戏的玩法越来越丰富，开发者对于扩大包大小的需求越来越强烈，为了让用户尽快的加载完并进入游戏体验，微信小游戏提供了分包的功能，即把游戏内容按一定规则拆分这几包，在首次启动时先下载必要的包，这个必要的包我们称为主包。在 Galacean 编辑器中，我们以文件夹作为子包的单位，不在子包的内容均会打包到主包中。在导出小游戏面板中，可以通过在子包列表中添加子包并设置对应的文件夹来进行分包，具体的配置如下：
+### 概述
+
+随着小游戏玩法日益丰富，内容增多，包体积变大，影响加载速度。微信小游戏提供分包功能，将游戏内容按规则拆分为主包和子包。主包包含首次启动必要的资源，子包则按需加载，使用户能快速进入游戏。
+
+### Galacean 编辑器分包配置
+
+在 Galacean 编辑器中，文件夹是子包划分的单位。不在子包的内容会进主包。导出小游戏时，在导出面板的子包列表添加子包并关联文件夹即可分包。
+
+### 子包配置步骤
+
+1、打开导出面板，选择微信小游戏平台，点击子包列表的添加子包按钮，添加子包：
+
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*j5u6Q7txvj4AAAAAAAAAAAAAejCHAQ/fmt.webp" />
+
+2、在子包中，选择需要分包的文件夹即可完成子包的配置：
 
 <Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*ndgyR5bjGqsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
-关于分包的几点说明：
+### 注意事项
+
 - 设置为子包的文件夹下的脚本资源不会计入子包，会单独导出到主包中
 - 微信小游戏中，主包的大小限制为 4M，单个子包不限制大小，但是整个小游戏的主包+分包大小不超过 30M，更详细的规则见：[分包](https://developers.weixin.qq.com/minigame/dev/guide/base-ability/subPackage/useSubPackage.html)
 - 分包的配置、加载等引擎均帮开发者自动处理好了，开发者动态加载子包下的资产和普通资产是一样的，都是通过 engine.resourceManager.load 来加载

--- a/docs/zh/platform/wechatMiniGame.mdx
+++ b/docs/zh/platform/wechatMiniGame.mdx
@@ -33,7 +33,7 @@ label: Platform
 
 1、从编辑器导出到本地后，目录结构如下：
 
-<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{zoom: "50%"}} />
+<Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*LMWMQpQNdA0AAAAAAAAAAAAAejCHAQ/fmt.webp" style={{ transform: "scale(0.5)" }} />
 
 **工程目录说明**
 |目录或文件|说明|
@@ -84,13 +84,14 @@ npm run release
 
 ## 分包
 
-微信小游戏对于包体大小有严格的限制，分包是微信小游戏的一个重要特性，在 Galacean 编辑器中，我们以文件夹作为子包的单位。在导出小游戏面板中，可以通过在子包列表中添加子包并设置对应的文件夹来进行分包，具体的配置如下：
+随着小游戏的玩法越来越丰富，开发者对于扩大包大小的需求越来越强烈，为了让用户尽快的加载完并进入游戏体验，微信小游戏提供了分包的功能，即把游戏内容按一定规则拆分这几包，在首次启动时先下载必要的包，这个必要的包我们称为主包。在 Galacean 编辑器中，我们以文件夹作为子包的单位，不在子包的内容均会打包到主包中。在导出小游戏面板中，可以通过在子包列表中添加子包并设置对应的文件夹来进行分包，具体的配置如下：
 
 <Image src="https://mdn.alipayobjects.com/huamei_w6ifet/afts/img/A*ndgyR5bjGqsAAAAAAAAAAAAAejCHAQ/fmt.webp" />
 
-关于子包，有几个点需要注意：
-- 设置为子包的文件夹下的脚本资源不会计入子包，会单独导出
-- 开发者无需关注子包的加载时机，引擎会自动处理，开发者加载子包中的资源和正常加载资源的方式一致
+关于分包的几点说明：
+- 设置为子包的文件夹下的脚本资源不会计入子包，会单独导出到主包中
+- 微信小游戏中，主包的大小限制为 4M，单个子包不限制大小，但是整个小游戏的主包+分包大小不超过 30M，更详细的规则见：[分包](https://developers.weixin.qq.com/minigame/dev/guide/base-ability/subPackage/useSubPackage.html)
+- 分包的配置、加载等引擎均帮开发者自动处理好了，开发者动态加载子包下的资产和普通资产是一样的，都是通过 engine.resourceManager.load 来加载
 
 ## 发布
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and reorganized the WeChat Mini Game export documentation with clearer step-by-step instructions, updated images, and detailed explanations of the export, debugging, and release processes.
  - Introduced a comprehensive section on subpackage configuration, including setup steps, size limits, and resource handling.
  - Enhanced clarity and completeness for both English and Chinese documentation, providing improved guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->