### PR TITLE
Fix WebP decoding capability detection

### DIFF
--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -19,7 +19,7 @@ export class SystemInfo {
   /** Whether the system support SIMD. */
   private static _simdSupported: boolean | null = null;
 
-  static _webpSupported: AssetPromise<boolean> | null = null;
+  private static _webpSupported: AssetPromise<boolean> | null = null;
 
   /**
    * The pixel ratio of the device.

--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -90,8 +90,7 @@ export class SystemInfo {
   static _checkWebpSupported(): AssetPromise<boolean> {
     if (!this._webpSupported) {
       this._webpSupported = new AssetPromise((resolve) => {
-        // @ts-ignore
-        if (SystemInfo._isBrowser) {
+        if (this._isBrowser) {
           const img = new Image();
           img.onload = function () {
             const result = img.width > 0 && img.height > 0;

--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -2,6 +2,7 @@ import { GLCapabilityType } from "./base/Constant";
 import { Engine } from "./Engine";
 import { Platform } from "./Platform";
 import { TextureFormat } from "./texture";
+import { AssetPromise } from "./asset/AssetPromise";
 
 /**
  * Access operating system, platform and hardware information.
@@ -17,6 +18,8 @@ export class SystemInfo {
 
   /** Whether the system support SIMD. */
   private static _simdSupported: boolean | null = null;
+
+  static _webpSupported: AssetPromise<boolean> | null = null;
 
   /**
    * The pixel ratio of the device.
@@ -82,6 +85,29 @@ export class SystemInfo {
       );
     }
     return this._simdSupported;
+  }
+
+  static _checkWebpSupported(): AssetPromise<boolean> {
+    if (!this._webpSupported) {
+      this._webpSupported = new AssetPromise((resolve) => {
+        // @ts-ignore
+        if (SystemInfo._isBrowser) {
+          const img = new Image();
+          img.onload = function () {
+            const result = img.width > 0 && img.height > 0;
+            resolve(result);
+          };
+          img.onerror = function () {
+            resolve(false);
+          };
+          img.src =
+            "data:image/webp;base64,UklGRhACAABXRUJQVlA4WAoAAAAwAAAAAAAAAAAASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZBTFBIAgAAAAAAVlA4IBgAAAAwAQCdASoBAAEAAUAmJaQAA3AA/v02aAA=";
+        } else {
+          resolve(false);
+        }
+      });
+    }
+    return this._webpSupported;
   }
 
   /**

--- a/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
+++ b/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
@@ -8,8 +8,13 @@ import { GLTFExtensionMode, GLTFExtensionParser } from "./GLTFExtensionParser";
 interface EXTWebPSchema {
   source: number;
 }
+
+let webpSupportPromise: AssetPromise<boolean> | null = null;
 function checkWebpSupport(): AssetPromise<boolean> {
-  return new AssetPromise((resolve) => {
+  if (webpSupportPromise) {
+    return webpSupportPromise;
+  }
+  webpSupportPromise = new AssetPromise((resolve) => {
     // @ts-ignore
     if (SystemInfo._isBrowser) {
       const img = new Image();
@@ -26,6 +31,7 @@ function checkWebpSupport(): AssetPromise<boolean> {
       resolve(false);
     }
   });
+  return webpSupportPromise;
 }
 
 @registerGLTFExtension("EXT_texture_webp", GLTFExtensionMode.CreateAndParse)

--- a/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
+++ b/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
@@ -9,31 +9,6 @@ interface EXTWebPSchema {
   source: number;
 }
 
-let webpSupportPromise: AssetPromise<boolean> | null = null;
-function checkWebpSupport(): AssetPromise<boolean> {
-  if (webpSupportPromise) {
-    return webpSupportPromise;
-  }
-  webpSupportPromise = new AssetPromise((resolve) => {
-    // @ts-ignore
-    if (SystemInfo._isBrowser) {
-      const img = new Image();
-      img.onload = function () {
-        const result = img.width > 0 && img.height > 0;
-        resolve(result);
-      };
-      img.onerror = function () {
-        resolve(false);
-      };
-      img.src =
-        "data:image/webp;base64,UklGRhACAABXRUJQVlA4WAoAAAAwAAAAAAAAAAAASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZBTFBIAgAAAAAAVlA4IBgAAAAwAQCdASoBAAEAAUAmJaQAA3AA/v02aAA=";
-    } else {
-      resolve(false);
-    }
-  });
-  return webpSupportPromise;
-}
-
 @registerGLTFExtension("EXT_texture_webp", GLTFExtensionMode.CreateAndParse)
 class EXT_texture_webp extends GLTFExtensionParser {
   override createAndParse(
@@ -45,7 +20,7 @@ class EXT_texture_webp extends GLTFExtensionParser {
   ): AssetPromise<Texture2D> {
     const webPIndex = schema.source;
     const { sampler, source: fallbackIndex = 0, name: textureName } = textureInfo;
-    return checkWebpSupport().then((supportWebP) => {
+    return SystemInfo._checkWebpSupported().then((supportWebP) => {
       return GLTFTextureParser._parseTexture(
         context,
         supportWebP ? webPIndex : fallbackIndex,

--- a/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
+++ b/packages/loader/src/gltf/extensions/EXT_texture_webp.ts
@@ -30,8 +30,6 @@ function checkWebpSupport(): AssetPromise<boolean> {
 
 @registerGLTFExtension("EXT_texture_webp", GLTFExtensionMode.CreateAndParse)
 class EXT_texture_webp extends GLTFExtensionParser {
-  private _supportWebP = checkWebpSupport();
-
   override createAndParse(
     context: GLTFParserContext,
     schema: EXTWebPSchema,
@@ -41,7 +39,7 @@ class EXT_texture_webp extends GLTFExtensionParser {
   ): AssetPromise<Texture2D> {
     const webPIndex = schema.source;
     const { sampler, source: fallbackIndex = 0, name: textureName } = textureInfo;
-    return this._supportWebP.then((supportWebP) => {
+    return checkWebpSupport().then((supportWebP) => {
       return GLTFTextureParser._parseTexture(
         context,
         supportWebP ? webPIndex : fallbackIndex,


### PR DESCRIPTION
Safari 的 WebP 支持和 canvas.toDataURL('image/webp') 并非同时支持，故使用canvas.toDataURL('image/webp')判断webp支持不合适，改成加载一个1px的webp base64图片进行判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved WebP image support detection for textures with fully asynchronous handling, enhancing compatibility and reliability across browsers.

- **Bug Fixes**
  - Fixed issues with WebP texture loading by replacing synchronous checks with an asynchronous verification process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->