### PR TITLE
chore: separate editor-preload into two packages

### DIFF
--- a/.github/workflows/release-editor-kit.yml
+++ b/.github/workflows/release-editor-kit.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to use for editor-preload package'
+        description: 'Version to use for editor-preload-ecosystem package'
         required: true
       use_npm:
         description: 'Use npm packages instead of building from source'
@@ -38,7 +38,7 @@ jobs:
       - name: Make build script executable
         run: chmod +x ./scripts/build-editor-preload.js
 
-      - name: Build editor-preload package
+      - name: Build editor-preload packages
         run: |
           USE_NPM_ARG=""
           if [ "${{ github.event.inputs.use_npm }}" == "true" ]; then
@@ -47,15 +47,25 @@ jobs:
           
           ./scripts/build-editor-preload.js --version=${{ github.event.inputs.version }} $USE_NPM_ARG
 
-      - name: Release editor-preload package and Sync to CDN
+      - name: Release packages and Sync to CDN
         uses: galacean/publish@main
         with:
           publish: false
           packages: |
-            editor-preload
+            editor-preload-official
+            editor-preload-ecosystem
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
           OASISBE_UPLOAD_URL: https://oasisbe.alipay.com/api/file/no-auth/crypto/upload
           OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
           OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
+          
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: editor-preload-packages
+          path: |
+            editor-preload-official/dist/browser.js
+            editor-preload-ecosystem/dist/browser.js
+          retention-days: 7

--- a/.github/workflows/release-editor-kit.yml
+++ b/.github/workflows/release-editor-kit.yml
@@ -9,7 +9,7 @@ on:
       use_npm:
         description: 'Use npm packages instead of building from source'
         type: boolean
-        default: false
+        default: true
 
 jobs:
   release:

--- a/.github/workflows/release-editor-kit.yml
+++ b/.github/workflows/release-editor-kit.yml
@@ -9,7 +9,7 @@ on:
       use_npm:
         description: 'Use npm packages instead of building from source'
         type: boolean
-        default: false
+        default: true
       build_official:
         description: 'Also build and publish official preload package'
         type: boolean

--- a/.github/workflows/release-editor-kit.yml
+++ b/.github/workflows/release-editor-kit.yml
@@ -9,7 +9,11 @@ on:
       use_npm:
         description: 'Use npm packages instead of building from source'
         type: boolean
-        default: true
+        default: false
+      build_official:
+        description: 'Also build and publish official preload package'
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -35,8 +39,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: pnpm
 
-      - name: Make build script executable
-        run: chmod +x ./scripts/build-editor-preload.js
+      - name: Make scripts executable
+        run: |
+          chmod +x ./scripts/build-editor-preload.js
+          chmod +x ./scripts/build-official-preload.js
 
       - name: Build editor-preload packages
         run: |
@@ -45,15 +51,27 @@ jobs:
             USE_NPM_ARG="--use-npm"
           fi
           
-          ./scripts/build-editor-preload.js --version=${{ github.event.inputs.version }} $USE_NPM_ARG
+          BUILD_OFFICIAL_ARG=""
+          if [ "${{ github.event.inputs.build_official }}" == "true" ]; then
+            BUILD_OFFICIAL_ARG="--build-official"
+          fi
+          
+          ./scripts/build-editor-preload.js --version=${{ github.event.inputs.version }} $USE_NPM_ARG $BUILD_OFFICIAL_ARG
+
+      - name: Prepare packages list for publishing
+        id: prepare-packages
+        run: |
+          PACKAGES="editor-preload-ecosystem"
+          if [ "${{ github.event.inputs.build_official }}" == "true" ]; then
+            PACKAGES="editor-preload-official\neditor-preload-ecosystem"
+          fi
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Release packages and Sync to CDN
         uses: galacean/publish@main
         with:
           publish: false
-          packages: |
-            editor-preload-official
-            editor-preload-ecosystem
+          packages: ${{ steps.prepare-packages.outputs.packages }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
@@ -61,11 +79,20 @@ jobs:
           OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
           OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
           
+      - name: Prepare artifact paths
+        id: prepare-artifacts
+        run: |
+          PATHS="editor-preload-ecosystem/dist/browser.js"
+          if [ "${{ github.event.inputs.build_official }}" == "true" ]; then
+            PATHS="editor-preload-official/dist/browser.js\neditor-preload-ecosystem/dist/browser.js"
+          fi
+          echo "paths<<EOF" >> $GITHUB_OUTPUT
+          echo "$PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: editor-preload-packages
-          path: |
-            editor-preload-official/dist/browser.js
-            editor-preload-ecosystem/dist/browser.js
+          path: ${{ steps.prepare-artifacts.outputs.paths }}
           retention-days: 7

--- a/.github/workflows/release-editor-kit.yml
+++ b/.github/workflows/release-editor-kit.yml
@@ -58,20 +58,13 @@ jobs:
           
           ./scripts/build-editor-preload.js --version=${{ github.event.inputs.version }} $USE_NPM_ARG $BUILD_OFFICIAL_ARG
 
-      - name: Prepare packages list for publishing
-        id: prepare-packages
-        run: |
-          PACKAGES="editor-preload-ecosystem"
-          if [ "${{ github.event.inputs.build_official }}" == "true" ]; then
-            PACKAGES="editor-preload-official\neditor-preload-ecosystem"
-          fi
-          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
-
       - name: Release packages and Sync to CDN
         uses: galacean/publish@main
         with:
           publish: false
-          packages: ${{ steps.prepare-packages.outputs.packages }}
+          packages: |
+            editor-preload-ecosystem
+            ${{ github.event.inputs.build_official == 'true' && 'editor-preload-official' || '' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
@@ -79,20 +72,11 @@ jobs:
           OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
           OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
           
-      - name: Prepare artifact paths
-        id: prepare-artifacts
-        run: |
-          PATHS="editor-preload-ecosystem/dist/browser.js"
-          if [ "${{ github.event.inputs.build_official }}" == "true" ]; then
-            PATHS="editor-preload-official/dist/browser.js\neditor-preload-ecosystem/dist/browser.js"
-          fi
-          echo "paths<<EOF" >> $GITHUB_OUTPUT
-          echo "$PATHS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: editor-preload-packages
-          path: ${{ steps.prepare-artifacts.outputs.paths }}
+          path: |
+            editor-preload-ecosystem/dist/browser.js
+            ${{ github.event.inputs.build_official == 'true' && 'editor-preload-official/dist/browser.js' || '' }}
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      build_official_preload:
+        description: 'Build and publish official preload package'
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -36,79 +41,15 @@ jobs:
       - name: Build Engine
         run: pnpm b:all
 
-      - name: Cache Engine Package
-        uses: actions/cache@v3
-        with:
-          path: ./packages/galacean
-          key: ${{ runner.os }}-engine-${{ github.sha }}
-
-      - name: Checkout Sub-repositories
+      - name: Make scripts executable
         run: |
-          git clone https://github.com/galacean/engine-toolkit.git
-          git clone https://github.com/galacean/engine-lottie.git
-          git clone https://github.com/galacean/engine-spine.git -b 4.2
+          chmod +x ./scripts/build-editor-preload.js
+          chmod +x ./scripts/build-official-preload.js
 
-      - name: Checkout editor repository
-        uses: actions/checkout@v4
-        with:
-          repository: galacean/editor
-          submodules: true
-          path: editor
-          token: ${{ secrets.CLONE_EDITOR_TOKEN }}
-
-      - name: Install and Build for editor
-        working-directory: ./editor
-        run: |
-          pnpm install --no-frozen-lockfile
-          pnpm build:decorators
-
-      - name: Install and Link Engine and Build for Toolkit
-        working-directory: ./engine-toolkit
-        run: |
-          pnpm install
-          pnpm link ../packages/galacean
-          pnpm b:all
-
-      - name: Install and Link Engine and Build for Lottie
-        working-directory: ./engine-lottie
-        run: |
-          pnpm install --ignore-workspace
-          pnpm link ../packages/galacean
-          pnpm build
-
-      - name: Install and Link Engine and Build for Spine
-        working-directory: ./engine-spine
-        run: |
-          pnpm install --ignore-workspace --frozen-lockfile=false
-          pnpm link ../packages/galacean
-          pnpm build
-
-      - name: Structure Temp Directory
-        run: |
-          mkdir -p ${{ github.workspace }}/temp
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine
-          cp -r ${{ github.workspace }}/packages/galacean/dist ${{ github.workspace }}/temp/@galacean/engine
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-xr
-          cp -r ${{ github.workspace }}/packages/xr/dist ${{ github.workspace }}/temp/@galacean/engine-xr
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-ui
-          cp -r ${{ github.workspace }}/packages/ui/dist ${{ github.workspace }}/temp/@galacean/engine-ui
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-shaderlab
-          cp -r ${{ github.workspace }}/packages/shader-lab/dist ${{ github.workspace }}/temp/@galacean/engine-shaderlab
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-shader-shaderlab
-          cp -r ${{ github.workspace }}/packages/shader-shaderlab/dist ${{ github.workspace }}/temp/@galacean/engine-shader-shaderlab
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-physics-lite
-          cp -r ${{ github.workspace }}/packages/physics-lite/dist ${{ github.workspace }}/temp/@galacean/engine-physics-lite
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-physics-physx
-          cp -r ${{ github.workspace }}/packages/physics-physx/dist ${{ github.workspace }}/temp/@galacean/engine-physics-physx
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-toolkit
-          cp -r ${{ github.workspace }}/engine-toolkit/packages/galacean-engine-toolkit/dist/umd ${{ github.workspace }}/temp/@galacean/engine-toolkit
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-lottie
-          cp -r ${{ github.workspace }}/engine-lottie/dist ${{ github.workspace }}/temp/@galacean/engine-lottie
-          mkdir -p ${{ github.workspace }}/temp/@galacean/engine-spine
-          cp -r ${{ github.workspace }}/engine-spine/dist ${{ github.workspace }}/temp/@galacean/engine-spine
-          mkdir -p ${{ github.workspace }}/temp/@galacean/editor-decorators
-          cp -r ${{ github.workspace }}/editor/packages/decorators/dist ${{ github.workspace }}/temp/@galacean/editor-decorators
-          find ${{ github.workspace }}/temp
+      # Build and publish official preload package
+      - name: Build official preload package
+        if: ${{ github.event.inputs.build_official_preload == '' || github.event.inputs.build_official_preload == 'true' }}
+        run: ./scripts/build-official-preload.js
 
       - name: Release engine packages and Sync to CDN
         uses: galacean/publish@main
@@ -119,3 +60,25 @@ jobs:
           OASISBE_UPLOAD_URL: https://oasisbe.alipay.com/api/file/no-auth/crypto/upload
           OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
           OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
+
+      - name: Release official preload package and Sync to CDN
+        if: ${{ github.event.inputs.build_official_preload == '' || github.event.inputs.build_official_preload == 'true' }}
+        uses: galacean/publish@main
+        with:
+          publish: false
+          packages: |
+            editor-preload-official
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+          OASISBE_UPLOAD_URL: https://oasisbe.alipay.com/api/file/no-auth/crypto/upload
+          OASISBE_REQUEST_HEADER: ${{secrets.OASISBE_REQUEST_HEADER}}
+          OASISBE_PUBLIC_KEY: ${{secrets.OASISBE_PUBLIC_KEY}}
+          
+      - name: Upload official preload artifact
+        if: ${{ github.event.inputs.build_official_preload == '' || github.event.inputs.build_official_preload == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: editor-preload-official
+          path: editor-preload-official/dist/browser.js
+          retention-days: 7

--- a/scripts/build-editor-preload.js
+++ b/scripts/build-editor-preload.js
@@ -1,67 +1,100 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
-const config = require("./editor-preload-config");
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const config = require('./editor-preload-config');
 
 // Parse command line arguments
 const args = process.argv.slice(2);
-const versionArg = args.find((arg) => arg.startsWith("--version="));
-const version = versionArg ? versionArg.split("=")[1] : "1.0.0";
-const useNpmArg = args.includes("--use-npm");
-const skipBuildArg = args.includes("--skip-build");
+const versionArg = args.find(arg => arg.startsWith('--version='));
+const ecosystemVersion = versionArg ? versionArg.split('=')[1] : '1.0.0';
+const useNpmArg = args.includes('--use-npm');
+const skipBuildArg = args.includes('--skip-build');
+
+// Get engine version from package.json
+const enginePackageJson = require(path.join(process.cwd(), 'package.json'));
+const engineVersion = enginePackageJson.version;
+
+console.log(`Engine version: ${engineVersion}`);
+console.log(`Ecosystem version: ${ecosystemVersion}`);
 
 // Paths
 const rootDir = process.cwd();
-const outputDir = path.join(rootDir, "editor-preload");
-const outputDistDir = path.join(outputDir, "dist");
-const outputFile = path.join(outputDistDir, "browser.js");
+const outputOfficialDir = path.join(rootDir, 'editor-preload-official');
+const outputEcosystemDir = path.join(rootDir, 'editor-preload-ecosystem');
+const outputOfficialDistDir = path.join(outputOfficialDir, 'dist');
+const outputEcosystemDistDir = path.join(outputEcosystemDir, 'dist');
+const outputOfficialFile = path.join(outputOfficialDistDir, 'browser.js');
+const outputEcosystemFile = path.join(outputEcosystemDistDir, 'browser.js');
 
-console.log(`Building editor-preload ${version}`);
-
+console.log('Creating output directories...');
 // Create output directories
-if (!fs.existsSync(outputDir)) {
-  fs.mkdirSync(outputDir, { recursive: true });
+if (!fs.existsSync(outputOfficialDir)) {
+  fs.mkdirSync(outputOfficialDir, { recursive: true });
 }
-if (!fs.existsSync(outputDistDir)) {
-  fs.mkdirSync(outputDistDir, { recursive: true });
+if (!fs.existsSync(outputOfficialDistDir)) {
+  fs.mkdirSync(outputOfficialDistDir, { recursive: true });
+}
+if (!fs.existsSync(outputEcosystemDir)) {
+  fs.mkdirSync(outputEcosystemDir, { recursive: true });
+}
+if (!fs.existsSync(outputEcosystemDistDir)) {
+  fs.mkdirSync(outputEcosystemDistDir, { recursive: true });
 }
 
-// Create package.json
-const packageJson = {
-  name: "@galacean/editor-preload",
-  version: version,
-  description: "Preloaded packages for Galacean Editor",
+// Create package.json for official package
+const officialPackageJson = {
+  name: "@galacean/editor-preload-official",
+  version: engineVersion,
+  description: "Official packages preloaded for Galacean Editor",
   main: "dist/browser.js",
   files: ["dist"]
 };
 
-fs.writeFileSync(path.join(outputDir, "package.json"), JSON.stringify(packageJson, null, 2));
+fs.writeFileSync(
+  path.join(outputOfficialDir, 'package.json'),
+  JSON.stringify(officialPackageJson, null, 2)
+);
 
-// Initialize output file with header
-fs.writeFileSync(outputFile, `// @galacean/editor-preload ${version}\n`);
+// Create package.json for ecosystem package
+const ecosystemPackageJson = {
+  name: "@galacean/editor-preload-ecosystem",
+  version: ecosystemVersion,
+  description: "Ecosystem packages preloaded for Galacean Editor",
+  main: "dist/browser.js",
+  files: ["dist"]
+};
+
+fs.writeFileSync(
+  path.join(outputEcosystemDir, 'package.json'),
+  JSON.stringify(ecosystemPackageJson, null, 2)
+);
+
+// Initialize output files with headers
+fs.writeFileSync(outputOfficialFile, `// @galacean/editor-preload-official ${engineVersion}\n`);
+fs.writeFileSync(outputEcosystemFile, `// @galacean/editor-preload-ecosystem ${ecosystemVersion}\n`);
 
 // Build first-party packages if needed
 if (!skipBuildArg) {
-  console.log("Building first-party packages...");
+  console.log('Building first-party packages...');
   try {
-    execSync("pnpm b:all", { stdio: "inherit", cwd: rootDir });
+    execSync('pnpm b:all', { stdio: 'inherit', cwd: rootDir });
   } catch (error) {
-    console.error("Failed to build first-party packages:", error);
+    console.error('Failed to build first-party packages:', error);
     process.exit(1);
   }
 }
 
 // Concatenate first-party packages
-console.log("Concatenating first-party packages...");
-config.firstParty.forEach((pkg) => {
+console.log('Concatenating first-party packages...');
+config.firstParty.forEach(pkg => {
   const browserFile = path.join(rootDir, pkg.path, pkg.browserPath);
-
+  
   if (fs.existsSync(browserFile)) {
     const content = fs.readFileSync(browserFile);
-    fs.appendFileSync(outputFile, content);
-    console.log(`Added ${pkg.name} (${browserFile})`);
+    fs.appendFileSync(outputOfficialFile, content);
+    console.log(`Added ${pkg.name} to official package (${browserFile})`);
   } else {
     console.warn(`Warning: ${browserFile} not found for ${pkg.name}`);
   }
@@ -70,63 +103,66 @@ config.firstParty.forEach((pkg) => {
 // Handle second-party packages
 if (useNpmArg) {
   // Install from npm
-  console.log("Installing second-party packages from npm...");
-
-  const tempDir = path.join(rootDir, "temp-install");
+  console.log('Installing second-party packages from npm...');
+  
+  const tempDir = path.join(rootDir, 'temp-install');
   if (!fs.existsSync(tempDir)) {
     fs.mkdirSync(tempDir, { recursive: true });
   }
-
+  
   // Create package.json for temp install
   const tempPackageJson = {
     name: "temp-install",
     private: true,
     dependencies: {}
   };
-
+  
   // Collect all package names from second-party configs
-  config.secondParty.forEach((pkg) => {
+  config.secondParty.forEach(pkg => {
     if (pkg.isMonorepo && pkg.packages) {
-      pkg.packages.forEach((subPkg) => {
-        tempPackageJson.dependencies[subPkg.name] = version;
+      pkg.packages.forEach(subPkg => {
+        tempPackageJson.dependencies[subPkg.name] = ecosystemVersion;
       });
     } else {
-      tempPackageJson.dependencies[pkg.name] = version;
+      tempPackageJson.dependencies[pkg.name] = ecosystemVersion;
     }
   });
-
-  fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify(tempPackageJson, null, 2));
-
+  
+  fs.writeFileSync(
+    path.join(tempDir, 'package.json'),
+    JSON.stringify(tempPackageJson, null, 2)
+  );
+  
   // Install packages
   try {
-    execSync("npm install", { stdio: "inherit", cwd: tempDir });
+    execSync('npm install', { stdio: 'inherit', cwd: tempDir });
   } catch (error) {
-    console.error("Failed to install second-party packages:", error);
+    console.error('Failed to install second-party packages:', error);
     process.exit(1);
   }
-
+  
   // Concatenate second-party packages
-  console.log("Concatenating second-party packages...");
-  config.secondParty.forEach((pkg) => {
+  console.log('Concatenating second-party packages...');
+  config.secondParty.forEach(pkg => {
     if (pkg.isMonorepo && pkg.packages) {
-      pkg.packages.forEach((subPkg) => {
-        const browserFile = path.join(tempDir, "node_modules", subPkg.name, subPkg.browserPath);
-
+      pkg.packages.forEach(subPkg => {
+        const browserFile = path.join(tempDir, 'node_modules', subPkg.name, subPkg.browserPath);
+        
         if (fs.existsSync(browserFile)) {
           const content = fs.readFileSync(browserFile);
-          fs.appendFileSync(outputFile, content);
-          console.log(`Added ${subPkg.name} (${browserFile})`);
+          fs.appendFileSync(outputEcosystemFile, content);
+          console.log(`Added ${subPkg.name} to ecosystem package (${browserFile})`);
         } else {
           console.warn(`Warning: ${browserFile} not found for ${subPkg.name}`);
         }
       });
     } else {
-      const browserFile = path.join(tempDir, "node_modules", pkg.name, pkg.browserPath);
-
+      const browserFile = path.join(tempDir, 'node_modules', pkg.name, pkg.browserPath);
+      
       if (fs.existsSync(browserFile)) {
         const content = fs.readFileSync(browserFile);
-        fs.appendFileSync(outputFile, content);
-        console.log(`Added ${pkg.name} (${browserFile})`);
+        fs.appendFileSync(outputEcosystemFile, content);
+        console.log(`Added ${pkg.name} to ecosystem package (${browserFile})`);
       } else {
         console.warn(`Warning: ${browserFile} not found for ${pkg.name}`);
       }
@@ -134,79 +170,79 @@ if (useNpmArg) {
   });
 } else {
   // Build from source
-  console.log("Building second-party packages from source...");
-
-  config.secondParty.forEach((pkg) => {
-    const repoDir = path.join(rootDir, path.basename(pkg.repo, ".git"));
-
+  console.log('Building second-party packages from source...');
+  
+  config.secondParty.forEach(pkg => {
+    const repoDir = path.join(rootDir, path.basename(pkg.repo, '.git'));
+    
     // Clone repo if it doesn't exist
     if (!fs.existsSync(repoDir)) {
       console.log(`Cloning ${pkg.name} from ${pkg.repo}...`);
-      const cloneCmd = pkg.branch
+      const cloneCmd = pkg.branch 
         ? `git clone ${pkg.repo} ${repoDir} -b ${pkg.branch}`
         : `git clone ${pkg.repo} ${repoDir}`;
-
+      
       try {
-        execSync(cloneCmd, { stdio: "inherit" });
+        execSync(cloneCmd, { stdio: 'inherit' });
       } catch (error) {
         console.error(`Failed to clone ${pkg.name}:`, error);
         return;
       }
     }
-
+    
     // Link engine
     console.log(`Linking engine to ${pkg.name}...`);
     try {
-      execSync("pnpm link ../packages/galacean", {
-        stdio: "inherit",
-        cwd: repoDir
+      execSync('pnpm link ../packages/galacean', { 
+        stdio: 'inherit', 
+        cwd: repoDir 
       });
     } catch (error) {
       console.warn(`Warning: Failed to link engine to ${pkg.name}:`, error);
     }
-
+    
     // Install dependencies
     console.log(`Installing dependencies for ${pkg.name}...`);
     try {
-      execSync("pnpm install", { stdio: "inherit", cwd: repoDir });
+      execSync('pnpm install', { stdio: 'inherit', cwd: repoDir });
     } catch (error) {
       console.error(`Failed to install dependencies for ${pkg.name}:`, error);
       return;
     }
-
+    
     // Build package
     if (!skipBuildArg) {
       console.log(`Building ${pkg.name}...`);
       try {
-        execSync(pkg.buildCommand, { stdio: "inherit", cwd: repoDir });
+        execSync(pkg.buildCommand, { stdio: 'inherit', cwd: repoDir });
       } catch (error) {
         console.error(`Failed to build ${pkg.name}:`, error);
         return;
       }
     }
-
+    
     // Concatenate browser files
     if (pkg.isMonorepo && pkg.packages) {
-      pkg.packages.forEach((subPkg) => {
+      pkg.packages.forEach(subPkg => {
         const packageDir = path.join(repoDir, subPkg.packagePath);
         const browserFile = path.join(packageDir, subPkg.browserPath);
-
+        
         if (fs.existsSync(browserFile)) {
           const content = fs.readFileSync(browserFile);
-          fs.appendFileSync(outputFile, content);
-          console.log(`Added ${subPkg.name} (${browserFile})`);
+          fs.appendFileSync(outputEcosystemFile, content);
+          console.log(`Added ${subPkg.name} to ecosystem package (${browserFile})`);
         } else {
           console.warn(`Warning: ${browserFile} not found for ${subPkg.name}`);
         }
       });
     } else {
-      const packageDir = pkg.packagePath === "." ? repoDir : path.join(repoDir, pkg.packagePath);
+      const packageDir = pkg.packagePath === '.' ? repoDir : path.join(repoDir, pkg.packagePath);
       const browserFile = path.join(packageDir, pkg.browserPath);
-
+      
       if (fs.existsSync(browserFile)) {
         const content = fs.readFileSync(browserFile);
-        fs.appendFileSync(outputFile, content);
-        console.log(`Added ${pkg.name} (${browserFile})`);
+        fs.appendFileSync(outputEcosystemFile, content);
+        console.log(`Added ${pkg.name} to ecosystem package (${browserFile})`);
       } else {
         console.warn(`Warning: ${browserFile} not found for ${pkg.name}`);
       }
@@ -215,6 +251,9 @@ if (useNpmArg) {
 }
 
 // Output file stats
-const stats = fs.statSync(outputFile);
-console.log(`\nCreated ${outputFile} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`);
-console.log("Done!");
+const officialStats = fs.statSync(outputOfficialFile);
+const ecosystemStats = fs.statSync(outputEcosystemFile);
+
+console.log(`\nCreated ${outputOfficialFile} (${(officialStats.size / 1024 / 1024).toFixed(2)} MB)`);
+console.log(`Created ${outputEcosystemFile} (${(ecosystemStats.size / 1024 / 1024).toFixed(2)} MB)`);
+console.log('Done!');

--- a/scripts/build-official-preload.js
+++ b/scripts/build-official-preload.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const config = require('./editor-preload-config');
+
+// Get engine version from package.json
+const enginePackageJson = require(path.join(process.cwd(), 'package.json'));
+const engineVersion = enginePackageJson.version;
+
+console.log(`Engine version: ${engineVersion}`);
+console.log('Building official preload package...');
+
+// Paths
+const rootDir = process.cwd();
+const outputOfficialDir = path.join(rootDir, 'editor-preload-official');
+const outputOfficialDistDir = path.join(outputOfficialDir, 'dist');
+const outputOfficialFile = path.join(outputOfficialDistDir, 'browser.js');
+
+// Create output directories
+console.log('Creating output directories...');
+if (!fs.existsSync(outputOfficialDir)) {
+  fs.mkdirSync(outputOfficialDir, { recursive: true });
+}
+if (!fs.existsSync(outputOfficialDistDir)) {
+  fs.mkdirSync(outputOfficialDistDir, { recursive: true });
+}
+
+// Create package.json for official package
+const officialPackageJson = {
+  name: "@galacean/editor-preload-official",
+  version: engineVersion,
+  description: "Official packages preloaded for Galacean Editor",
+  main: "dist/browser.js",
+  files: ["dist"]
+};
+
+fs.writeFileSync(
+  path.join(outputOfficialDir, 'package.json'),
+  JSON.stringify(officialPackageJson, null, 2)
+);
+
+// Initialize output file with header
+fs.writeFileSync(outputOfficialFile, `// @galacean/editor-preload-official ${engineVersion}\n`);
+
+// Concatenate first-party packages
+console.log('Concatenating first-party packages...');
+config.firstParty.forEach(pkg => {
+  const browserFile = path.join(rootDir, pkg.path, pkg.browserPath);
+  
+  if (fs.existsSync(browserFile)) {
+    const content = fs.readFileSync(browserFile);
+    fs.appendFileSync(outputOfficialFile, content);
+    console.log(`Added ${pkg.name} to official package (${browserFile})`);
+  } else {
+    console.warn(`Warning: ${browserFile} not found for ${pkg.name}`);
+  }
+});
+
+// Output file stats
+const officialStats = fs.statSync(outputOfficialFile);
+console.log(`\nCreated ${outputOfficialFile} (${(officialStats.size / 1024 / 1024).toFixed(2)} MB)`);
+console.log('Done!');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated release workflow to build, release, and upload artifacts for both official and ecosystem editor-preload packages.
	- Improved build process to generate and handle two separate editor-preload bundles with distinct versioning and packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->