### PR TITLE
Fix illegal url

### DIFF
--- a/packages/core/src/asset/request.ts
+++ b/packages/core/src/asset/request.ts
@@ -65,6 +65,7 @@ function requestRes<T>(url: string, config: RequestConfig): AssetPromise<T> {
         return;
       }
       const result = xhr.response;
+      // For example, if the response body is a document but responseType is set to JSON, it returns null.
       if (!result) {
         reject(new Error(`Request ${url} response is empty, please check the config.`));
         return;

--- a/packages/core/src/asset/request.ts
+++ b/packages/core/src/asset/request.ts
@@ -56,17 +56,17 @@ function requestRes<T>(url: string, config: RequestConfig): AssetPromise<T> {
     const isImg = config.type === "image";
     xhr.timeout = config.timeout;
     config.method = config.method ?? "get";
+    xhr.withCredentials = config.credentials === "include";
     // @ts-ignore
     xhr.responseType = isImg ? "blob" : config.type;
     xhr.onload = () => {
       if (xhr.status < 200 || xhr.status >= 300) {
-        reject(new Error(`request failed from: ${url}`));
+        reject(new Error(`Request failed from: ${url}`));
         return;
       }
-      const responseType = xhr.responseType;
-      let result = responseType == "" || responseType == "text" ? xhr.responseText : xhr.response;
+      const result = xhr.response;
       if (!result) {
-        reject(new Error(`request ${url} response is empty, please check the url`));
+        reject(new Error(`Request ${url} response is empty, please check the config.`));
         return;
       }
       if (isImg) {
@@ -110,7 +110,6 @@ function requestRes<T>(url: string, config: RequestConfig): AssetPromise<T> {
       }
     };
     xhr.open(config.method, url, true);
-    xhr.withCredentials = config.credentials === "include";
     const headers = config.headers;
     if (headers) {
       Object.keys(headers).forEach((name) => {

--- a/packages/core/src/asset/request.ts
+++ b/packages/core/src/asset/request.ts
@@ -64,7 +64,7 @@ function requestRes<T>(url: string, config: RequestConfig): AssetPromise<T> {
         return;
       }
       const responseType = xhr.responseType;
-      let result = (responseType == '' || responseType == 'text') ? xhr.responseText : xhr.response;
+      let result = responseType == "" || responseType == "text" ? xhr.responseText : xhr.response;
       if (!result) {
         reject(new Error(`request ${url} response is empty, please check the url`));
         return;

--- a/packages/loader/src/PrefabLoader.ts
+++ b/packages/loader/src/PrefabLoader.ts
@@ -17,7 +17,7 @@ export class PrefabLoader extends Loader<PrefabResource> {
         })
         .then((data) => {
           PrefabParser.parse(engine, item.url, data).then(resolve).catch(reject);
-        }, reject)
+        }, reject);
     });
   }
 }

--- a/packages/loader/src/PrefabLoader.ts
+++ b/packages/loader/src/PrefabLoader.ts
@@ -17,7 +17,7 @@ export class PrefabLoader extends Loader<PrefabResource> {
         })
         .then((data) => {
           PrefabParser.parse(engine, item.url, data).then(resolve).catch(reject);
-        });
+        }, reject)
     });
   }
 }


### PR DESCRIPTION
这个问题由三个原因导致：

- 开发者将 esourceManager.retryCount 设置成了 0，这个 retryCount 属性容易让人误解，逻辑里实现的实际是 tryCount（retryCount 为 3，应该是请求一次重试三次，共四次？不如直接改成 tryCount 避免歧义），如果设置成 0，一次都不会去加载，这部分 1.6 优化，因为会断熔。
- 这个项目请求路径不正确时，会重定向到正确的路径（http://localhost:4000/UI/UIPrefab/Common/Mask/BlackMask 会重定向到 http://localhost:4000/） ，表现是 status 正确但内容不对，这里 throw 了 error，真实项目中由服务端去控制返回 404 会更好
- PrefabLoader 本身没有合理调用 reject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for asset requests with clearer messages and immediate rejection on empty responses or failed HTTP status.
  - Enhanced error propagation in asset loading to ensure request failures are properly reported and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->