### PR TITLE
Fix resolve hanging when component references are deleted in PrefabLoader

### DIFF
--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -36,6 +36,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     this._parseComponents = this._parseComponents.bind(this);
     this._parsePrefabModification = this._parsePrefabModification.bind(this);
     this._parseAddedComponents = this._parseAddedComponents.bind(this);
+    this._parseComponentsPropsAndMethods = this._parseComponentsPropsAndMethods.bind(this);
     this._parsePrefabRemovedEntities = this._parsePrefabRemovedEntities.bind(this);
     this._parsePrefabRemovedComponents = this._parsePrefabRemovedComponents.bind(this);
     this._clearAndResolve = this._clearAndResolve.bind(this);
@@ -51,8 +52,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     this._parseEntities()
       .then(this._organizeEntities)
       .then(this._parseComponents)
-      .then(this._parsePrefabModification)
       .then(this._parseAddedComponents)
+      .then(this._parseComponentsPropsAndMethods)
+      .then(this._parsePrefabModification)
       .then(this._parsePrefabRemovedEntities)
       .then(this._parsePrefabRemovedComponents)
       .then(this._clearAndResolve)
@@ -83,21 +85,18 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     });
   }
 
-  private _parseComponents(): Promise<any[]> {
+  private _parseComponents(): void {
     const entitiesConfig = this.data.entities;
     const entityMap = this.context.entityMap;
 
-    const promises = [];
     for (let i = 0, l = entitiesConfig.length; i < l; i++) {
       const entityConfig = entitiesConfig[i];
       if ((entityConfig as IStrippedEntity).strippedId) {
         continue;
       }
       const entity = entityMap.get(entityConfig.id);
-      this._addComponents(entity, entityConfig.components, promises);
+      this._addComponents(entity, entityConfig.components);
     }
-
-    return Promise.all(promises);
   }
 
   private _parsePrefabModification() {
@@ -134,84 +133,70 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     return Promise.all(promises);
   }
 
-  private _parseAddedComponents() {
+  private _parseAddedComponents(): void {
     const entityMap = this.context.entityMap;
     const entityConfigMap = this.context.entityConfigMap;
     const strippedIds = this.context.strippedIds;
-    const promises = [];
 
     for (let i = 0, n = strippedIds.length; i < n; i++) {
       const entityConfig = entityConfigMap.get(strippedIds[i]) as IStrippedEntity;
       const prefabContext = this._prefabContextMap.get(entityMap.get(entityConfig.prefabInstanceId));
       const entity = prefabContext.entityMap.get(entityConfig.prefabSource.entityId);
-      this._addComponents(entity, entityConfig.components, promises);
+      this._addComponents(entity, entityConfig.components);
     }
-    for (const waitingList of this.context.componentWaitingMap.values()) {
-      waitingList.forEach((resolve) => resolve(null));
-    }
-
-    return Promise.all(promises);
   }
 
   private _parsePrefabRemovedEntities() {
     const entitiesConfig = this.data.entities;
     const entityMap = this.context.entityMap;
 
-    const promises = [];
     for (let i = 0, l = entitiesConfig.length; i < l; i++) {
       const entityConfig = entitiesConfig[i];
       const { id, removedEntities } = entityConfig as IRefEntity;
 
       if (removedEntities?.length) {
         const rootEntity = entityMap.get(id);
-        promises.push(
-          ...removedEntities.map((target) => {
-            const { entityId } = target;
-            const context = this._prefabContextMap.get(rootEntity);
-            const targetEntity = context.entityMap.get(entityId);
-            if (targetEntity) {
-              targetEntity.destroy();
-            }
-          })
-        );
+        for (let j = 0, m = removedEntities.length; j < m; j++) {
+          const target = removedEntities[j];
+          const { entityId } = target;
+          const context = this._prefabContextMap.get(rootEntity);
+          const targetEntity = context.entityMap.get(entityId);
+          if (targetEntity) {
+            targetEntity.destroy();
+          }
+        }
       }
     }
-
-    return Promise.all(promises);
   }
 
   private _parsePrefabRemovedComponents() {
     const entitiesConfig = this.data.entities;
     const entityMap = this.context.entityMap;
 
-    const promises = [];
     for (let i = 0, l = entitiesConfig.length; i < l; i++) {
       const entityConfig = entitiesConfig[i];
       const { id, removedComponents } = entityConfig as IRefEntity;
 
       if (removedComponents?.length) {
         const rootEntity = entityMap.get(id);
-        promises.concat(
-          ...removedComponents.map((target) => {
-            const { componentId } = target;
-            const context = this._prefabContextMap.get(rootEntity);
-            const targetComponent = context.components.get(componentId);
-            if (targetComponent) {
-              targetComponent.destroy();
-            }
-          })
-        );
+        for (let j = 0, m = removedComponents.length; j < m; j++) {
+          const target = removedComponents[j];
+          const { componentId } = target;
+          const context = this._prefabContextMap.get(rootEntity);
+          const targetComponent = context.components.get(componentId);
+          if (targetComponent) {
+            targetComponent.destroy();
+          }
+        }
       }
     }
-
-    return Promise.all(promises);
   }
 
   private _organizeEntities(): void {
     const { rootIds, strippedIds } = this.context;
     const parentIds = rootIds.concat(strippedIds);
-    for (const parentId of parentIds) {
-      this._parseChildren(parentId);
+    for (let i = 0, l = parentIds.length; i < l; i++) {
+      this._parseChildren(parentIds[i]);
     }
     for (let i = 0; i < rootIds.length; i++) {
       this._handleRootEntity(rootIds[i]);
@@ -299,20 +284,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     }
   }
 
-  private _addComponents(
-    entity: Entity,
-    components: IEntity["components"],
-    promises: Promise<void>[]
-  ): Promise<void>[] {
+  private _addComponents(entity: Entity, components: IEntity["components"]): void {
     for (let i = 0, n = components.length; i < n; i++) {
       const componentConfig = components[i];
       const key = !componentConfig.refId ? componentConfig.class : componentConfig.refId;
       const component = entity.addComponent(Loader.getClass(key));
-      this.context.addComponent(componentConfig.id, component);
-      const promise = this._reflectionParser.parsePropsAndMethods(component, componentConfig);
-      promises.push(promise);
+      this.context.components.set(componentConfig.id, component);
+      this.context.componentConfigMap.set(componentConfig.id, componentConfig);
     }
-    return promises;
   }
 
   private _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
@@ -353,5 +332,18 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       const childPath = path ? `${path}/${i}` : `${i}`;
       this._generateInstanceContext(child, context, childPath);
     }
+  }
+
+  private _parseComponentsPropsAndMethods(): Promise<any[]> {
+    const promises = [];
+
+    for (const [componentId, component] of this.context.components) {
+      const componentConfig = this.context.componentConfigMap.get(componentId);
+      if (componentConfig) {
+        promises.push(this._reflectionParser.parsePropsAndMethods(component, componentConfig));
+      }
+    }
+
+    return Promise.all(promises);
   }
 }

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -285,12 +285,15 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   }
 
   private _addComponents(entity: Entity, components: IEntity["components"]): void {
+    const context = this.context;
+
     for (let i = 0, n = components.length; i < n; i++) {
       const componentConfig = components[i];
       const key = !componentConfig.refId ? componentConfig.class : componentConfig.refId;
+      const componentId = componentConfig.id;
       const component = entity.addComponent(Loader.getClass(key));
-      this.context.components.set(componentConfig.id, component);
-      this.context.componentConfigMap.set(componentConfig.id, componentConfig);
+      context.components.set(componentId, component);
+      context.componentConfigMap.set(componentId, componentConfig);
     }
   }
 
@@ -335,10 +338,11 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   }
 
   private _parseComponentsPropsAndMethods(): Promise<any[]> {
+    const context = this.context;
     const promises = [];
 
-    for (const [componentId, component] of this.context.components) {
-      const componentConfig = this.context.componentConfigMap.get(componentId);
+    for (const [componentId, component] of context.components) {
+      const componentConfig = context.componentConfigMap.get(componentId);
       if (componentConfig) {
         promises.push(this._reflectionParser.parsePropsAndMethods(component, componentConfig));
       }

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -172,6 +172,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   private _parsePrefabRemovedComponents() {
     const entitiesConfig = this.data.entities;
     const entityMap = this.context.entityMap;
+    const prefabContextMap = this._prefabContextMap;
 
     for (let i = 0, l = entitiesConfig.length; i < l; i++) {
       const entityConfig = entitiesConfig[i];
@@ -182,7 +183,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
         for (let j = 0, m = removedComponents.length; j < m; j++) {
           const target = removedComponents[j];
           const { componentId } = target;
-          const context = this._prefabContextMap.get(rootEntity);
+          const context = prefabContextMap.get(rootEntity);
           const targetComponent = context.components.get(componentId);
           if (targetComponent) {
             targetComponent.destroy();
@@ -286,14 +287,16 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _addComponents(entity: Entity, components: IEntity["components"]): void {
     const context = this.context;
+    const componentMap = context.components;
+    const componentConfigMap = context.componentConfigMap;
 
     for (let i = 0, n = components.length; i < n; i++) {
       const componentConfig = components[i];
       const key = !componentConfig.refId ? componentConfig.class : componentConfig.refId;
       const componentId = componentConfig.id;
       const component = entity.addComponent(Loader.getClass(key));
-      context.components.set(componentId, component);
-      context.componentConfigMap.set(componentId, componentConfig);
+      componentMap.set(componentId, component);
+      componentConfigMap.set(componentId, componentConfig);
     }
   }
 
@@ -339,12 +342,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _parseComponentsPropsAndMethods(): Promise<any[]> {
     const context = this.context;
+    const componentConfigMap = context.componentConfigMap;
+    const reflectionParser = this._reflectionParser;
     const promises = [];
 
     for (const [componentId, component] of context.components) {
-      const componentConfig = context.componentConfigMap.get(componentId);
+      const componentConfig = componentConfigMap.get(componentId);
       if (componentConfig) {
-        promises.push(this._reflectionParser.parsePropsAndMethods(component, componentConfig));
+        promises.push(reflectionParser.parsePropsAndMethods(component, componentConfig));
       }
     }
 

--- a/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
@@ -12,9 +12,9 @@ export class ParserContext<T extends IHierarchyFile, I extends EngineObject> {
   entityMap: Map<string, Entity> = new Map();
   entityConfigMap: Map<string, IEntity> = new Map();
   components: Map<string, Component> = new Map();
+  componentConfigMap: Map<string, any> = new Map();
   rootIds: string[] = [];
   strippedIds: string[] = [];
-  componentWaitingMap: Map<string, Function[]> = new Map();
 
   readonly resourceManager: ResourceManager;
 
@@ -26,34 +26,10 @@ export class ParserContext<T extends IHierarchyFile, I extends EngineObject> {
     this.resourceManager = engine.resourceManager;
   }
 
-  addComponent(id: string, component: Component) {
-    this.components.set(id, component);
-    const waitingList = this.componentWaitingMap.get(id);
-    if (waitingList?.length) {
-      waitingList.forEach((resolve) => resolve(component));
-      this.componentWaitingMap.delete(id);
-    }
-  }
-
-  getComponentByRef(ref: IComponentRef): Promise<Component> {
-    return new Promise((resolve, reject) => {
-      const component = this.components.get(ref.componentId);
-      if (component) {
-        resolve(component);
-      } else {
-        const resolves = this.componentWaitingMap.get(ref.componentId);
-        if (resolves) {
-          resolves.push(resolve);
-        } else {
-          this.componentWaitingMap.set(ref.componentId, [resolve]);
-        }
-      }
-    });
-  }
-
   clear() {
     this.entityMap.clear();
     this.components.clear();
+    this.componentConfigMap.clear();
     this.entityConfigMap.clear();
     this.rootIds.length = 0;
     this.strippedIds.length = 0;

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -114,7 +114,7 @@ export class ReflectionParser {
           return resource;
         });
       } else if (ReflectionParser._isComponentRef(value)) {
-        return this._context.getComponentByRef(value);
+        return Promise.resolve(this._context.components.get(value.componentId) ?? null);
       } else if (ReflectionParser._isEntityRef(value)) {
         // entity reference
         return Promise.resolve(this._context.entityMap.get(value.entityId));

--- a/tests/src/loader/SceneParser.test.ts
+++ b/tests/src/loader/SceneParser.test.ts
@@ -1,0 +1,33 @@
+import { registerGUI } from "@galacean/engine-ui";
+registerGUI();
+import "@galacean/engine-loader";
+import { AssetType } from "@galacean/engine-core";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import { describe, beforeAll, afterAll, expect, it } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async function () {
+  const canvasDOM = document.createElement("canvas");
+  canvasDOM.width = 1024;
+  canvasDOM.height = 1024;
+  engine = await WebGLEngine.create({ canvas: canvasDOM });
+});
+
+afterAll(() => {
+  engine?.destroy();
+});
+
+describe("ProjectLoader Component Reference Tests", function () {
+  it("should load project successfully with component be deleted", async () => {
+    await engine.resourceManager.load({
+      type: AssetType.Project,
+      // button.Color.target be deleted
+      url: "https://mdn.alipayobjects.com/oasis_be/afts/file/A*hPs1Q4KdkBsAAAAAQNAAAAgAekp5AQ/project.json"
+    });
+    const scene = engine.sceneManager.scenes[0];
+
+    const entities = scene.rootEntities;
+    expect(entities.length).eq(5);
+  });
+});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

**Bug fix** - Fixes an issue where ProjectLoader and PrefabLoader fail to load when component references are deleted in prefabs.

### What is the current behavior? (You can also link to an open issue here)

When prefabs or scenes contain references to deleted components:
- ProjectLoader hangs indefinitely during project loading
- Component properties are parsed immediately during component creation
- Component references fail to resolve because target components haven't been created yet
- `Promise.all` in `_parseComponentsPropsAndMethods` waits indefinitely for non-existent components

### What is the new behavior (if this is a feature change)?

Fixed behavior:
- Changed the loading order: create all components first, then parse their properties
- Separated component creation from property parsing in `_addComponents` method
- All components are instantiated and added to context before any property parsing begins
- Component references can now resolve properly since all components exist when properties are parsed
- Added cleanup mechanism for any remaining unresolved references

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

**No breaking changes** - This is a backward-compatible bug fix:
- Existing valid component references continue to work normally
- Only changes the internal loading order for better reference resolution
- No code changes required from users

### Other information:

**Technical Details:**
- Modified `HierarchyParser._addComponents` to only create component instances without parsing properties
- Moved property parsing logic to `_parseComponentsPropsAndMethods` method
- Ensured all components are created before any property parsing begins
- Added test cases to verify ProjectLoader can handle projects with deleted component references

**Test Coverage:**
- Uses real project data for testing (scenario with deleted button.Color.target)
- Verifies correct scene structure after loading completion
- Ensures no infinite hanging occurs during component reference resolution

**Impact Scope:**
- Primarily affects `@galacean/engine-loader` package
- Involves ProjectLoader, PrefabLoader, HierarchyParser components
- Improves component reference resolution by ensuring proper creation order
- Enhances engine robustness when handling corrupted or incomplete resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing or deleted component references during scene loading to prevent errors.
- **Refactor**
	- Streamlined component property and method parsing for better reliability and performance.
	- Simplified internal management of components and their configurations.
- **Tests**
	- Added a new test to ensure scenes load correctly even when certain component references are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->