### PR TITLE
refactor: create magenta material

### DIFF
--- a/packages/core/src/BasicResources.ts
+++ b/packages/core/src/BasicResources.ts
@@ -23,6 +23,7 @@ import { StencilOperation } from "./shader/enums/StencilOperation";
 import { Texture, Texture2D, TextureCube, TextureCubeFace } from "./texture";
 import { Texture2DArray } from "./texture/Texture2DArray";
 import { TextureFormat } from "./texture/enums/TextureFormat";
+import { Color } from "@galacean/engine-math";
 
 /**
  * @internal
@@ -118,6 +119,9 @@ export class BasicResources {
   readonly textDefaultMaterial: Material;
   readonly spriteMaskDefaultMaterial: Material;
 
+  readonly meshMagentaMaterial: Material;
+  readonly particleMagentaMaterial: Material;
+
   private _blinnPhongMaterial: BlinnPhongMaterial;
   private _prefilteredDFGTexture: Texture2D;
 
@@ -195,6 +199,9 @@ export class BasicResources {
     this.spriteDefaultMaterial = this._create2DMaterial(engine, Shader.find("Sprite"));
     this.textDefaultMaterial = this._create2DMaterial(engine, Shader.find("Text"));
     this.spriteMaskDefaultMaterial = this._createSpriteMaskMaterial(engine);
+
+    this.meshMagentaMaterial = this._createMagentaMaterial(engine, "unlit");
+    this.particleMagentaMaterial = this._createMagentaMaterial(engine, "particle-shader");
   }
 
   /**
@@ -309,6 +316,13 @@ export class BasicResources {
     renderState.rasterState.cullMode = CullMode.Off;
     renderState.renderQueueType = RenderQueueType.Transparent;
     material.isGCIgnored = true;
+    return material;
+  }
+
+  private _createMagentaMaterial(engine: Engine, shaderName: string): Material {
+    const material = new Material(engine, Shader.find(shaderName));
+    material.isGCIgnored = true;
+    material.shaderData.setColor("material_BaseColor", new Color(1.0, 0.0, 1.01, 1.0));
     return material;
   }
 

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -96,10 +96,6 @@ export class Engine extends EventDispatcher {
   _renderContext: RenderContext = new RenderContext();
 
   /* @internal */
-  _meshMagentaMaterial: Material;
-  /* @internal */
-  _particleMagentaMaterial: Material;
-  /* @internal */
   _depthTexture2D: Texture2D;
 
   /* @internal */
@@ -264,16 +260,6 @@ export class Engine extends EventDispatcher {
     if (!hardwareRenderer.canIUse(GLCapabilityType.sRGB)) {
       this._macroCollection.enable(Engine._noSRGBSupportMacro);
     }
-
-    const meshMagentaMaterial = new Material(this, Shader.find("unlit"));
-    meshMagentaMaterial.isGCIgnored = true;
-    meshMagentaMaterial.shaderData.setColor("material_BaseColor", new Color(1.0, 0.0, 1.01, 1.0));
-    this._meshMagentaMaterial = meshMagentaMaterial;
-
-    const particleMagentaMaterial = new Material(this, Shader.find("particle-shader"));
-    particleMagentaMaterial.isGCIgnored = true;
-    particleMagentaMaterial.shaderData.setColor("material_BaseColor", new Color(1.0, 0.0, 1.01, 1.0));
-    this._particleMagentaMaterial = particleMagentaMaterial;
 
     this._basicResources = new BasicResources(this);
     this._particleBufferUtils = new ParticleBufferUtils(this);

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -158,7 +158,7 @@ export class MeshRenderer extends Renderer {
         continue;
       }
       if (material.destroyed || material.shader.destroyed) {
-        material = this.engine._meshMagentaMaterial;
+        material = this.engine._basicResources.meshMagentaMaterial;
       }
 
       const subRenderElement = subRenderElementPool.get();

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -227,7 +227,7 @@ export class ParticleRenderer extends Renderer {
     }
 
     if (material.destroyed || material.shader.destroyed) {
-      material = this.engine._particleMagentaMaterial;
+      material = this.engine._basicResources.particleMagentaMaterial;
     }
 
     const engine = this._engine;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

**Code refactoring** - Architectural improvement to centralize default material management.

### What is the current behavior? (You can also link to an open issue here)

Currently, the Engine class directly manages magenta materials (`_meshMagentaMaterial` and `_particleMagentaMaterial`) in its constructor, which creates inconsistency in the codebase:

- Most default materials (like `spriteDefaultMaterial`, `textDefaultMaterial`, `blitMaterial`) are managed by the `BasicResources` class
- Magenta materials (used as fallback when materials/shaders are destroyed) are managed directly in Engine
- This violates the single responsibility principle and creates duplicated material creation logic

### What is the new behavior (if this is a feature change)?

Now all default materials are consistently managed by the `BasicResources` class:

- Added `meshMagentaMaterial` and `particleMagentaMaterial` properties to `BasicResources`
- Created a reusable `_createMagentaMaterial()` helper method to eliminate code duplication
- Updated references in `MeshRenderer` and `ParticleRenderer` to use materials from `_basicResources`
- Removed redundant material creation code from Engine constructor

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

**No breaking changes for public APIs.** 

The changes only affect internal implementation details. Users who were accessing the magenta materials through Engine's internal properties (which were marked as `@internal`) would need to update their code, but this is not considered a breaking change as internal APIs are not part of the public contract.

### Other information:

- **Benefits**: Improved code consistency, better separation of concerns, reduced code duplication
- **Architecture**: Aligns with the existing pattern where `BasicResources` manages all engine default resources
- **Maintainability**: Centralized material lifecycle management makes the code easier to understand and maintain
- **No performance impact**: This is purely a structural improvement with no runtime behavior changes