### PR TITLE
Prevent ResourceManager test failures due to unhandled rejection…

### DIFF
--- a/packages/core/src/asset/AssetPromise.ts
+++ b/packages/core/src/asset/AssetPromise.ts
@@ -209,13 +209,20 @@ export class AssetPromise<T> implements PromiseLike<T> {
   }
 
   /**
-   * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
-   * resolved value cannot be modified from the callback.
-   * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
-   * @returns A Promise for the completion of the callback.
+   * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected).
+   * The callback result is ignored and the original value/reason is preserved per Promise spec.
+   * Returns an AssetPromise to keep chainability with AssetPromise methods.
+   * @param onFinally - The callback to execute when the Promise is settled.
+   * @returns An AssetPromise for the completion of the callback.
    */
-  finally(onFinally?: () => void): Promise<T> {
-    return this._promise.finally(onFinally);
+  finally(onFinally?: () => void | PromiseLike<void>): AssetPromise<T> {
+    return this.then(
+      (value) => AssetPromise.resolve(onFinally?.()).then(() => value),
+      (reason) =>
+        AssetPromise.resolve(onFinally?.()).then(() => {
+          throw reason;
+        })
+    );
   }
 
   /**

--- a/packages/core/src/asset/AssetPromise.ts
+++ b/packages/core/src/asset/AssetPromise.ts
@@ -215,7 +215,7 @@ export class AssetPromise<T> implements PromiseLike<T> {
    * @param onFinally - The callback to execute when the Promise is settled.
    * @returns An AssetPromise for the completion of the callback.
    */
-  finally(onFinally?: () => void | PromiseLike<void>): AssetPromise<T> {
+  finally(onFinally?: () => void): AssetPromise<T> {
     return this.then(
       (value) => AssetPromise.resolve(onFinally?.()).then(() => value),
       (reason) =>

--- a/packages/core/src/asset/AssetPromise.ts
+++ b/packages/core/src/asset/AssetPromise.ts
@@ -217,11 +217,14 @@ export class AssetPromise<T> implements PromiseLike<T> {
    */
   finally(onFinally?: () => void): AssetPromise<T> {
     return this.then(
-      (value) => AssetPromise.resolve(onFinally?.()).then(() => value),
-      (reason) =>
-        AssetPromise.resolve(onFinally?.()).then(() => {
-          throw reason;
-        })
+      (value) => {
+        onFinally?.();
+        return value;
+      },
+      (reason) => {
+        onFinally?.();
+        throw reason;
+      }
     );
   }
 

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -158,9 +158,13 @@ export class GLTFParserContext {
   _addTaskCompletePromise(taskPromise: AssetPromise<any>): void {
     const task = this._progress.taskComplete;
     task.total += 1;
-    taskPromise.finally(() => {
-      this._setTaskCompleteProgress(++task.loaded, task.total);
-    });
+    taskPromise
+      .finally(() => {
+        this._setTaskCompleteProgress(++task.loaded, task.total);
+      })
+      .catch((e) => {
+        Logger.error("GLTFParserContext", `Failed to load task: ${e}`);
+      });
   }
 
   private _handleSubAsset<T>(

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -163,7 +163,7 @@ export class GLTFParserContext {
         this._setTaskCompleteProgress(++task.loaded, task.total);
       })
       .catch((e) => {
-        Logger.error("GLTFParserContext", `Failed to load task: ${e}`);
+        // Need catch to avoid unhandled rejection
       });
   }
 


### PR DESCRIPTION
… (not-found)

### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finalization callbacks now reliably run after asset load success or failure, preventing rare stalls and preserving promise chainability.
  * Progress updates for model imports remain consistent even when individual tasks fail, avoiding unhandled rejections and improving pipeline stability.

* **Documentation**
  * Clarified that finalization callbacks do not alter results and that asset-loading promises remain chainable.
  * Note: the promise-returning API for asset finalization was updated to preserve chainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->