### PR TITLE
fix scalableAmbientOcclusion material destroy error

### DIFF
--- a/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
+++ b/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
@@ -106,10 +106,10 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
     // projection[0][0] is at index 0 (X scaling)
     // projection[1][1] is at index 5 (Y scaling)
     // The inverse values we need are:
-    const invProjectionSacleX = 1.0 / projectionScaleX;
+    const invProjectionScaleX = 1.0 / projectionScaleX;
     const invProjectionScaleY = 1.0 / projectionScaleY;
 
-    const invProjScaleXY = this._invProjScaleXY.set(invProjectionSacleX * 2.0, invProjectionScaleY * 2.0);
+    const invProjScaleXY = this._invProjScaleXY.set(invProjectionScaleX * 2.0, invProjectionScaleY * 2.0);
     shaderData.setVector2(ScalableAmbientObscurancePass._invProjScaleXYProp, invProjScaleXY);
 
     const { quality, radius } = ambientOcclusion;
@@ -168,9 +168,6 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
       this._blurRenderTarget = null;
     }
     this._depthRenderTarget = null;
-    const material = this._material;
-    material._addReferCount(-1);
-    material.destroy();
   }
 
   private _updateBlurKernel(blurShaderData: ShaderData, quality: AmbientOcclusionQuality): void {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected projection scaling in Ambient Occlusion rendering, improving visual accuracy and reducing potential artifacts.

* **Performance & Stability**
  * Updated resource handling in the Ambient Occlusion pass to enhance stability during scene teardown and rendering lifecycle.

No user-facing behavior changes are expected beyond improved image quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->