### PR TITLE
Fix transparency objects `DepthTexture` and `SAO`

### DIFF
--- a/e2e/case/camera-ssao.ts
+++ b/e2e/case/camera-ssao.ts
@@ -76,7 +76,7 @@ WebGLEngine.create({ canvas: "canvas", graphicDeviceOptions: { webGLMode: WebGLM
   capsuleMaterial.baseColor = new Color(1, 1, 1, 0.5);
   capsule.transform.setPosition(1, 0.9, 0.1);
   capsule.transform.setRotation(30, 30, 0);
-  const capsuleMeshRenderer = box.addComponent(MeshRenderer);
+  const capsuleMeshRenderer = capsule.addComponent(MeshRenderer);
   capsuleMeshRenderer.mesh = PrimitiveMesh.createCapsule(engine);
   capsuleMeshRenderer.setMaterial(capsuleMaterial);
 

--- a/e2e/case/camera-ssao.ts
+++ b/e2e/case/camera-ssao.ts
@@ -70,6 +70,16 @@ WebGLEngine.create({ canvas: "canvas", graphicDeviceOptions: { webGLMode: WebGLM
   boxMeshRenderer.mesh = PrimitiveMesh.createCuboid(engine);
   boxMeshRenderer.setMaterial(boxMaterial);
 
+  const capsule = rootEntity.createChild("capsule");
+  const capsuleMaterial = new PBRMaterial(engine);
+  capsuleMaterial.isTransparent = true;
+  capsuleMaterial.baseColor = new Color(1, 1, 1, 0.5);
+  capsule.transform.setPosition(1, 0.9, 0.1);
+  capsule.transform.setRotation(30, 30, 0);
+  const capsuleMeshRenderer = box.addComponent(MeshRenderer);
+  capsuleMeshRenderer.mesh = PrimitiveMesh.createCapsule(engine);
+  capsuleMeshRenderer.setMaterial(capsuleMaterial);
+
   engine.resourceManager
     .load<AmbientLight>({
       type: AssetType.Env,

--- a/e2e/fixtures/originImage/Camera_camera-ssao.jpg
+++ b/e2e/fixtures/originImage/Camera_camera-ssao.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d24097987a264894a1df7912a2fc24b086c6af87920c4fbd0f1d20184c412a4
-size 327638
+oid sha256:c076d7393622bbddf96d02704d0d141228c7339a2967e8eab0daee12669edfd4
+size 344735

--- a/packages/core/src/shader/ShaderPool.ts
+++ b/packages/core/src/shader/ShaderPool.ts
@@ -51,7 +51,7 @@ export class ShaderPool {
     });
     depthOnlyPass._renderState = new RenderState();
     depthOnlyPass._renderStateDataMap[RenderStateElementKey.RenderQueueType] = BaseMaterial._depthOnlyRenderQueueProp;
-    
+
     const basePasses = [shadowCasterPass, depthOnlyPass];
 
     const forwardPassTags = {

--- a/packages/core/src/shader/ShaderPool.ts
+++ b/packages/core/src/shader/ShaderPool.ts
@@ -49,6 +49,9 @@ export class ShaderPool {
     const depthOnlyPass = new ShaderPass("DepthOnly", depthOnlyVs, depthOnlyFs, {
       pipelineStage: PipelineStage.DepthOnly
     });
+    depthOnlyPass._renderState = new RenderState();
+    depthOnlyPass._renderStateDataMap[RenderStateElementKey.RenderQueueType] = BaseMaterial._depthOnlyRenderQueueProp;
+    
     const basePasses = [shadowCasterPass, depthOnlyPass];
 
     const forwardPassTags = {

--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -8,6 +8,16 @@
 
 uniform sampler2D camera_AOTexture;
 
+float evaluateAmbientOcclusion(vec2 uv)
+{
+    #ifdef MATERIAL_IS_TRANSPARENT
+        return 1.0;
+    #else
+        return texture2D(camera_AOTexture, uv).r;
+    #endif
+}
+
+
 float computeSpecularOcclusion(float ambientOcclusion, float roughness, float dotNV ) {
     return saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );
 }
@@ -173,8 +183,8 @@ void initMaterial(out Material material, inout Geometry geometry){
             diffuseAO = ((texture2D(material_OcclusionTexture, aoUV)).r - 1.0) * material_OcclusionIntensity + 1.0;
         #endif
 
-         #ifdef SCENE_ENABLE_AMBIENT_OCCLUSION                    
-            float ambientAO = texture2D(camera_AOTexture,(v_PositionCS.xy / v_PositionCS.w) * 0.5 + 0.5).r;
+         #ifdef SCENE_ENABLE_AMBIENT_OCCLUSION
+            float ambientAO = evaluateAmbientOcclusion((v_PositionCS.xy / v_PositionCS.w) * 0.5 + 0.5);
             diffuseAO = min(diffuseAO, ambientAO);
         #endif
 
@@ -240,7 +250,7 @@ void initMaterial(out Material material, inout Geometry geometry){
                 #endif
             #endif    
         #endif
-
 }
+
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improves depth-only and shadow rendering for transparent and alpha-cutout materials, reducing artifacts and improving visual consistency (including SSAO and depth prepass).

- Tests
  - Adds an end-to-end scene with a transparent capsule to validate SSAO and depth-pass behavior across rendering passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->