### PR TITLE
Fix SAO precison bug

### DIFF
--- a/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
+++ b/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
@@ -203,8 +203,8 @@ export class BasicRenderPipeline {
 
     // Scalable ambient obscurance pass
     // Before opaque pass so materials can sample ambient occlusion in BRDF
-    if (ambientOcclusionEnabled && supportDepthTexture) {
-      const saoPass = this._saoPass;
+    const saoPass = this._saoPass;
+    if (ambientOcclusionEnabled && supportDepthTexture && saoPass.isSupported) {
       saoPass.onConfig(camera, this._depthOnlyPass.renderTarget);
       saoPass.onRender(context);
     } else {

--- a/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
+++ b/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
@@ -29,6 +29,8 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
   private static _powerProp = ShaderProperty.getByName("material_power");
   private static _invProjScaleXYProp = ShaderProperty.getByName("material_invProjScaleXY");
 
+  readonly isSupported: boolean;
+
   // Shader properties for bilateral blur
   private static _farPlaneOverEdgeDistanceProp = ShaderProperty.getByName("material_farPlaneOverEdgeDistance");
   private static _kernelProp = ShaderProperty.getByName("material_kernel");
@@ -52,6 +54,7 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
     const material = new Material(engine, Shader.find(ScalableAmbientObscurancePass.SHADER_NAME));
     material._addReferCount(1);
     this._material = material;
+    this.isSupported = this.engine._hardwareRenderer.capability.isFragmentHighPrecision;
   }
 
   onConfig(camera: Camera, depthRenderTarget: RenderTarget): void {

--- a/packages/core/src/lighting/ambientOcclusion/shaders/ScalableAmbientOcclusion.glsl
+++ b/packages/core/src/lighting/ambientOcclusion/shaders/ScalableAmbientOcclusion.glsl
@@ -7,7 +7,7 @@
 
 varying vec2 v_uv;
 uniform vec4 renderer_texelSize;    // x: 1/width, y: 1/height, z: width, w: height
-uniform sampler2D renderer_BlitTexture; // Camera_DepthTexture
+uniform highp sampler2D renderer_BlitTexture; // Camera_DepthTexture
 
 // float inc = (1.0f / (SAMPLE_COUNT - 0.5f)) * SPIRAL_TURNS * 2.0 * PI
 // const vec2 angleIncCosSin = vec2(cos(inc), sin(inc))
@@ -50,7 +50,7 @@ float depthToViewZ(float depth) {
 // reconstructing normal from depth buffer
 // https://atyuwen.github.io/posts/normal-reconstruction
 // https://wickedengine.net/2019/09/22/improved-normal-reconstruction-from-depth/
-vec3 computeViewSpaceNormal(vec2 uv, sampler2D depthTexture, float depth, vec3 viewPos, vec2 texel, vec2 invProjScaleXY) {
+vec3 computeViewSpaceNormal(vec2 uv, highp sampler2D depthTexture, float depth, vec3 viewPos, vec2 texel, vec2 invProjScaleXY) {
     vec3 normal = vec3(0.0);
 #if SSAO_QUALITY == 0 || SSAO_QUALITY == 1
         vec2 uvdx = uv + vec2(texel.x, 0.0);

--- a/packages/rhi-webgl/src/GLCapability.ts
+++ b/packages/rhi-webgl/src/GLCapability.ts
@@ -72,6 +72,11 @@ export class GLCapability {
     return this._maxAntiAliasing;
   }
 
+  get isFragmentHighPrecision(): boolean {
+    const gl = this._rhi.gl;
+    return gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision !== 0;
+  }
+
   get rhi() {
     return this._rhi;
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Case（Redmi 10X 4G）：
![Image](https://github.com/user-attachments/assets/92ed7a70-1039-4e55-8a26-616b6b9fec48)

Depth Texture is 24Bit，need highp sampler, some mobile device  sampler default precison maybe mediump 

精度级别 | 范围（最小要求） | 精度（最小要求） | 有效位数（最小）
-- | -- | -- | --
lowp | [-2, 2] | 2^-8 | 8 位
mediump | [-2^14, 2^14] | 2^-10 | 10 位
highp | [-2^62, 2^62] | 2^-16 | 16 位

<br class="Apple-interchange-newline">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of device fragment shader precision to determine Ambient Occlusion availability.
  * Ambient Occlusion now activates only on devices that fully support it, improving compatibility across hardware.

* **Bug Fixes**
  * Prevents Ambient Occlusion from enabling on unsupported devices, avoiding rendering glitches and potential instability.

* **Refactor**
  * Streamlined render pipeline logic to conditionally run Ambient Occlusion setup and rendering only when requirements are met, releasing resources otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->