### PR TITLE
Recover `scripts/build-editor-preload.js` for 1.5

### DIFF
--- a/scripts/build-editor-preload.js
+++ b/scripts/build-editor-preload.js
@@ -106,7 +106,7 @@ if (useNpmArg) {
 
   // Install packages
   try {
-    execSync("pnpm install", { stdio: "inherit", cwd: tempDir });
+    execSync("npm install", { stdio: "inherit", cwd: tempDir });
   } catch (error) {
     console.error("Failed to install second-party packages:", error);
     process.exit(1);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal install step to use npm instead of pnpm in the editor preloading workflow, improving compatibility across environments and reducing setup friction for contributors.
  * Preserved existing error handling and control flow to ensure consistent behavior during installation.
  * No changes to public APIs or end-user functionality; this affects only the build/install process.
  * Expect smoother local builds without requiring pnpm to be installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->