### PR TITLE
Fix no scene name was given when loading the scene

### DIFF
--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -30,8 +30,8 @@ class SceneLoader extends Loader<Scene> {
       resourceManager
         // @ts-ignore
         ._request<IScene>(item.url, { ...item, type: "json" })
-        .then((data) => {
-          const scene = new Scene(engine);
+        .then((data: IScene) => {
+          const scene = new Scene(engine, data.name ?? "");
           const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
           const parser = new SceneParser(data, context, scene);
           parser._collectDependentAssets(data);

--- a/packages/loader/src/resource-deserialize/resources/schema/SceneSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/SceneSchema.ts
@@ -16,6 +16,7 @@ export enum SpecularMode {
 }
 
 export interface IScene extends IHierarchyFile {
+  name?: string;
   scene: {
     background: {
       mode: BackgroundMode;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Loaded scenes now retain and display their names when available, improving identification in UIs, logs, and debugging.
  - Added support for scene name metadata in scene files.

- Refactor
  - Scene creation now includes a name parameter; creating scenes without a name may no longer be supported in some workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->