### PR TITLE
 Fixed the issue where get `LocalMatrix` before clone operation would cause the dirtyFlag to be incorrect.

### DIFF
--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -597,6 +597,7 @@ export class Transform extends Component {
     rotation._onValueChanged = target._onRotationChanged;
     // @ts-ignore
     scale._onValueChanged = target._onScaleChanged;
+    target._setDirtyFlagTrue(TransformModifyFlags.LocalQuat | TransformModifyFlags.LocalMatrix);
   }
 
   protected _onLocalMatrixChanging(): void {

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -597,6 +597,8 @@ export class Transform extends Component {
     rotation._onValueChanged = target._onRotationChanged;
     // @ts-ignore
     scale._onValueChanged = target._onScaleChanged;
+
+    // When cloning, other components may obtain properties such as `rotationQuaternion` in the constructor, local related dirty flags need to be corrected
     target._setDirtyFlagTrue(TransformModifyFlags.LocalQuat | TransformModifyFlags.LocalMatrix);
   }
 

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -533,6 +533,7 @@ describe("Entity", async () => {
       const entityChild = entityParent.createChild("child");
       const entityGrandson = entityChild.createChild("grandson");
       entityGrandson.transform.rotation.set(90, 0, 0);
+      // DynamicCollider 组件在构造函数中会获取 worldRotationQuaternion
       entityGrandson.addComponent(DynamicCollider);
       const entityChildClone = entityParent.clone().children[0];
       const entityGrandsonClone = entityChildClone.children[0];

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -531,11 +531,16 @@ describe("Entity", async () => {
       const entityParent = new Entity(engine, "parent");
       const entityChild = entityParent.createChild("child");
       const entityGrandson = entityChild.createChild("grandson");
+      entityGrandson.transform.position.set(1, 2, 3);
       entityGrandson.addComponent(Sample)
       const entityChildClone = entityParent.clone().children[0];
       const entityGrandsonClone = entityChildClone.children[0];
       // @ts-ignore
       expect(entityChildClone.transform.instanceId).eq(entityGrandsonClone.transform._getParentTransform()?.instanceId);
+      const entityGrandsonCloneLocalMatrixElements = entityGrandsonClone.transform.localMatrix.elements;
+      expect(entityGrandsonCloneLocalMatrixElements[12]).eq(1);
+      expect(entityGrandsonCloneLocalMatrixElements[13]).eq(2);
+      expect(entityGrandsonCloneLocalMatrixElements[14]).eq(3);
     });
   });
 
@@ -658,6 +663,7 @@ class Sample extends Script {
 
   constructor(entity: Entity) {
     super(entity);
+    const localMatrix = this.entity.transform.localMatrix
     this._onSelfTransformChanged = this._onSelfTransformChanged.bind(this);
     // @ts-ignore
     this.entity._updateFlagManager.addListener(this._onSelfTransformChanged);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Cloning now forces recalculation of local rotation and transform matrix so cloned objects retain correct local orientation and matrices, including nested children.

- Tests
  - Tests updated to enable physics and validate cloned descendants preserve expected rotation/quaternion and parent linkage; removed outdated test scaffolding and improved clone-related transform coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->