### PR TITLE
fix(physics): make PhysX mesh collider updates atomic

### DIFF
--- a/packages/core/src/physics/CharacterController.ts
+++ b/packages/core/src/physics/CharacterController.ts
@@ -18,7 +18,7 @@ export class CharacterController extends Collider {
 
   /**
    * The step offset for the controller, the value must be greater than or equal to 0.
-   * @remarks Character can overcome obstacle less than the height(stepOffset + contractOffset of the shape).
+   * @remarks Character can overcome obstacle less than the height(stepOffset + contactOffset of the shape).
    */
   get stepOffset(): number {
     return this._stepOffset;

--- a/packages/core/src/physics/CharacterController.ts
+++ b/packages/core/src/physics/CharacterController.ts
@@ -4,7 +4,7 @@ import { Engine } from "../Engine";
 import { Entity } from "../Entity";
 import { Collider } from "./Collider";
 import { ControllerNonWalkableMode } from "./enums/ControllerNonWalkableMode";
-import { ColliderShape } from "./shape";
+import { BoxColliderShape, CapsuleColliderShape } from "./shape";
 import { ignoreClone } from "../clone/CloneDecorators";
 
 /**
@@ -106,9 +106,16 @@ export class CharacterController extends Collider {
    * Add collider shape on this controller.
    * @param shape - Collider shape
    */
-  override addShape(shape: ColliderShape): void {
+  override addShape(shape: BoxColliderShape | CapsuleColliderShape): void {
     if (this._shapes.length > 0) {
       throw "only allow single shape on controller!";
+    }
+    if (!(shape instanceof BoxColliderShape || shape instanceof CapsuleColliderShape)) {
+      throw new Error("CharacterController only supports BoxColliderShape or CapsuleColliderShape.");
+    }
+    const contactOffset = shape.contactOffset;
+    if (!Number.isFinite(contactOffset) || contactOffset <= 0) {
+      throw new Error("CharacterController contactOffset must be a positive finite number.");
     }
     super.addShape(shape);
     this._updateFlag.flag = true;

--- a/packages/core/src/physics/Collider.ts
+++ b/packages/core/src/physics/Collider.ts
@@ -157,22 +157,6 @@ export class Collider extends Component implements ICloneHook<Collider> {
     }
   }
 
-  /**
-   * @internal
-   */
-  _setNativeShapeAttached(shape: ColliderShape, attached: boolean): void {
-    const nativeShape = shape._nativeShape;
-    if (nativeShape && shape._isShapeAttached !== attached) {
-      if (attached) {
-        nativeShape.setWorldScale(this.entity.transform.lossyWorldScale);
-        this._nativeCollider.addShape(nativeShape);
-      } else {
-        this._nativeCollider.removeShape(nativeShape);
-      }
-      shape._isShapeAttached = attached;
-    }
-  }
-
   protected _syncNative(): void {
     for (let i = 0, n = this.shapes.length; i < n; i++) {
       this._addNativeShape(this.shapes[i]);
@@ -196,12 +180,17 @@ export class Collider extends Component implements ICloneHook<Collider> {
   }
 
   protected _addNativeShape(shape: ColliderShape): void {
-    this._setNativeShapeAttached(shape, true);
+    if (shape._nativeShape) {
+      shape._nativeShape.setWorldScale(this.entity.transform.lossyWorldScale);
+      this._nativeCollider.addShape(shape._nativeShape);
+    }
     shape._collider = this;
   }
 
   protected _removeNativeShape(shape: ColliderShape): void {
-    this._setNativeShapeAttached(shape, false);
+    if (shape._nativeShape) {
+      this._nativeCollider.removeShape(shape._nativeShape);
+    }
     shape._collider = null;
   }
 

--- a/packages/core/src/physics/DynamicCollider.ts
+++ b/packages/core/src/physics/DynamicCollider.ts
@@ -3,7 +3,7 @@ import { Quaternion, Vector3 } from "@galacean/engine-math";
 import { ignoreClone } from "../clone/CloneDecorators";
 import { Engine } from "../Engine";
 import { Entity } from "../Entity";
-import { Collider } from "./Collider";
+import { RigidCollider } from "./RigidCollider";
 import { ColliderShapeChangeFlag } from "./enums/ColliderShapeChangeFlag";
 import { ColliderShape } from "./shape/ColliderShape";
 import { MeshColliderShape } from "./shape/MeshColliderShape";
@@ -11,7 +11,7 @@ import { MeshColliderShape } from "./shape/MeshColliderShape";
 /**
  * A dynamic collider can act with self-defined movement or physical force.
  */
-export class DynamicCollider extends Collider {
+export class DynamicCollider extends RigidCollider {
   private static _tempVector3 = new Vector3();
   private static _tempQuat = new Quaternion();
 
@@ -33,7 +33,7 @@ export class DynamicCollider extends Collider {
   private _isKinematic = false;
   private _constraints: DynamicColliderConstraints = 0;
   private _collisionDetectionMode: CollisionDetectionMode = CollisionDetectionMode.Discrete;
-  private _sleepThreshold = 5e-3;
+  private _sleepThreshold: number | undefined;
   private _automaticCenterOfMass = true;
   private _automaticInertiaTensor = true;
 
@@ -221,9 +221,11 @@ export class DynamicCollider extends Collider {
 
   /**
    * The mass-normalized energy threshold, below which objects start going to sleep.
+   * @remarks The default is determined by the physics backend. PhysX uses
+   * `5e-5 * tolerancesScale.speed * tolerancesScale.speed`.
    */
   get sleepThreshold(): number {
-    return this._sleepThreshold;
+    return this._sleepThreshold ?? Engine._nativePhysics?.getDefaultSleepThreshold?.() ?? 5e-3;
   }
 
   set sleepThreshold(value: number) {
@@ -498,7 +500,9 @@ export class DynamicCollider extends Collider {
     }
     (<IDynamicCollider>this._nativeCollider).setMaxAngularVelocity(this._maxAngularVelocity);
     (<IDynamicCollider>this._nativeCollider).setMaxDepenetrationVelocity(this._maxDepenetrationVelocity);
-    (<IDynamicCollider>this._nativeCollider).setSleepThreshold(this._sleepThreshold);
+    if (this._sleepThreshold !== undefined) {
+      (<IDynamicCollider>this._nativeCollider).setSleepThreshold(this._sleepThreshold);
+    }
     (<IDynamicCollider>this._nativeCollider).setSolverIterations(this._solverIterations);
     (<IDynamicCollider>this._nativeCollider).setUseGravity(this._useGravity);
     (<IDynamicCollider>this._nativeCollider).setConstraints(this._constraints);

--- a/packages/core/src/physics/PhysicsMaterial.ts
+++ b/packages/core/src/physics/PhysicsMaterial.ts
@@ -21,8 +21,8 @@ export class PhysicsMaterial {
       this._staticFriction,
       this._dynamicFriction,
       this._bounciness,
-      this._bounceCombine,
-      this._frictionCombine
+      this._frictionCombine,
+      this._bounceCombine
     );
   }
 

--- a/packages/core/src/physics/RigidCollider.ts
+++ b/packages/core/src/physics/RigidCollider.ts
@@ -1,0 +1,31 @@
+import { IColliderShape, IRigidCollider } from "@galacean/engine-design";
+import { Collider } from "./Collider";
+import { ColliderShapeChangeFlag } from "./enums/ColliderShapeChangeFlag";
+import { ColliderShape } from "./shape/ColliderShape";
+
+export abstract class RigidCollider extends Collider {
+  /** @internal */
+  declare _nativeCollider: IRigidCollider;
+
+  /** @internal */
+  _replaceNativeShape(shape: ColliderShape, nativeShape: IColliderShape | null): void {
+    const previousShape = shape._nativeShape;
+    if (previousShape === nativeShape) return;
+
+    try {
+      if (previousShape && nativeShape) {
+        this._nativeCollider.replaceShape(previousShape, nativeShape);
+      } else if (previousShape) {
+        this._nativeCollider.removeShape(previousShape);
+      } else if (nativeShape) {
+        this._nativeCollider.addShape(nativeShape);
+      }
+    } catch (error) {
+      nativeShape?.destroy();
+      throw error;
+    }
+    shape._nativeShape = nativeShape;
+    previousShape?.destroy();
+    this._handleShapesChanged(ColliderShapeChangeFlag.Property);
+  }
+}

--- a/packages/core/src/physics/StaticCollider.ts
+++ b/packages/core/src/physics/StaticCollider.ts
@@ -1,12 +1,12 @@
 import { Engine } from "../Engine";
 import { Entity } from "../Entity";
-import { Collider } from "./Collider";
+import { RigidCollider } from "./RigidCollider";
 
 /**
  * A static collider component that will not move.
  * @remarks Mostly used for object which always stays at the same place and never moves around.
  */
-export class StaticCollider extends Collider {
+export class StaticCollider extends RigidCollider {
   /**
    * @internal
    */

--- a/packages/core/src/physics/shape/ColliderShape.ts
+++ b/packages/core/src/physics/shape/ColliderShape.ts
@@ -20,17 +20,14 @@ export abstract class ColliderShape extends DataObject implements ICloneHook<Col
   /** @internal */
   @ignoreClone
   _nativeShape: IColliderShape;
-  /** @internal */
-  @ignoreClone
-  _isShapeAttached: boolean = false;
-
   @ignoreClone
   protected _id: number;
+  @ignoreClone
   protected _material: PhysicsMaterial;
   private _isTrigger: boolean = false;
   private _rotation: Vector3 = new Vector3();
   private _position: Vector3 = new Vector3();
-  private _contactOffset: number = 0.02;
+  private _contactOffset: number | undefined;
 
   /**
    * @internal
@@ -55,10 +52,10 @@ export abstract class ColliderShape extends DataObject implements ICloneHook<Col
 
   /**
    * Contact offset for this shape, the value must be greater than or equal to 0.
-   * @defaultValue 0.02
+   * @remarks The default is determined by the physics backend. PhysX uses `0.02 * tolerancesScale.length`.
    */
   get contactOffset(): number {
-    return this._contactOffset;
+    return this._contactOffset ?? Engine._nativePhysics?.getDefaultContactOffset?.() ?? 0.02;
   }
 
   set contactOffset(value: number) {
@@ -169,7 +166,10 @@ export abstract class ColliderShape extends DataObject implements ICloneHook<Col
    * @inheritdoc
    */
   _onClone(target: ColliderShape): void {
+    const defaultMaterial = target._material;
+    target._material = this._material;
     target._syncNative();
+    defaultMaterial.destroy();
   }
 
   /**
@@ -184,14 +184,21 @@ export abstract class ColliderShape extends DataObject implements ICloneHook<Col
   }
 
   protected _syncNative(): void {
-    if (!this._nativeShape) return;
-    this._nativeShape.setPosition(this._position);
-    this._nativeShape.setRotation(this._rotation);
-    this._nativeShape.setContactOffset(this._contactOffset);
-    this._nativeShape.setIsTrigger(this._isTrigger);
-    this._nativeShape.setMaterial(this._material._nativeMaterial);
+    const nativeShape = this._nativeShape;
+    if (!nativeShape) return;
+    this._syncNativeShape(nativeShape);
 
     this._collider?._handleShapesChanged(ColliderShapeChangeFlag.Property);
+  }
+
+  protected _syncNativeShape(nativeShape: IColliderShape): void {
+    nativeShape.setPosition(this._position);
+    nativeShape.setRotation(this._rotation);
+    if (this._contactOffset !== undefined) {
+      nativeShape.setContactOffset(this._contactOffset);
+    }
+    nativeShape.setIsTrigger(this._isTrigger);
+    nativeShape.setMaterial(this._material._nativeMaterial);
   }
 
   @ignoreClone

--- a/packages/core/src/physics/shape/ColliderShape.ts
+++ b/packages/core/src/physics/shape/ColliderShape.ts
@@ -59,10 +59,13 @@ export abstract class ColliderShape extends DataObject implements ICloneHook<Col
   }
 
   set contactOffset(value: number) {
+    if (!Number.isFinite(value)) {
+      throw new Error("ColliderShape contactOffset must be finite.");
+    }
     value = Math.max(0, value);
     if (this._contactOffset !== value) {
-      this._contactOffset = value;
       this._nativeShape?.setContactOffset(value);
+      this._contactOffset = value;
     }
   }
 

--- a/packages/core/src/physics/shape/MeshColliderShape.ts
+++ b/packages/core/src/physics/shape/MeshColliderShape.ts
@@ -1,24 +1,35 @@
 import { IMeshColliderShape } from "@galacean/engine-design";
-import { Engine } from "../../Engine";
-import { ModelMesh } from "../../mesh/ModelMesh";
 import { Vector3 } from "@galacean/engine-math";
-import { ignoreClone } from "../../clone/CloneDecorators";
+import { Engine } from "../../Engine";
+import { assignmentClone } from "../../clone/CloneDecorators";
+import { ModelMesh } from "../../mesh/ModelMesh";
 import { DynamicCollider } from "../DynamicCollider";
 import { MeshColliderShapeCookingFlag } from "../enums/MeshColliderShapeCookingFlag";
+import { RigidCollider } from "../RigidCollider";
 import { ColliderShape } from "./ColliderShape";
+
+type MeshData = {
+  positions: Vector3[];
+  indices: Uint8Array | Uint16Array | Uint32Array | null;
+};
 
 /**
  * Collider shape based on mesh geometry, supporting both convex hull and triangle mesh modes.
  */
 export class MeshColliderShape extends ColliderShape {
-  @ignoreClone
+  private static readonly _unitScale = new Vector3(1, 1, 1);
+
+  @assignmentClone
   private _mesh: ModelMesh = null;
   private _isConvex = false;
-  @ignoreClone
+  @assignmentClone
   private _positions: Vector3[] = null;
-  @ignoreClone
+  @assignmentClone
   private _indices: Uint8Array | Uint16Array | Uint32Array | null = null;
   private _cookingFlags = MeshColliderShapeCookingFlag.Cleaning | MeshColliderShapeCookingFlag.VertexWelding;
+
+  /** @internal */
+  declare _collider: RigidCollider;
 
   /**
    * Cooking flags for this mesh collider shape.
@@ -29,12 +40,16 @@ export class MeshColliderShape extends ColliderShape {
 
   set cookingFlags(value: MeshColliderShapeCookingFlag) {
     if (this._cookingFlags !== value) {
-      this._cookingFlags = value;
-      if (this._nativeShape) {
-        this._updateNativeShapeData();
-      } else if (this._mesh && this._extractMeshData(this._mesh)) {
-        this._createNativeShape();
+      if (!this._mesh) {
+        this._cookingFlags = value;
+        return;
       }
+
+      const nativeShape = this._createNativeShape(this._positions, this._indices, this._isConvex, value);
+      if (!nativeShape) return;
+
+      this._replaceNativeShape(nativeShape);
+      this._cookingFlags = value;
     }
   }
 
@@ -50,17 +65,28 @@ export class MeshColliderShape extends ColliderShape {
 
   set isConvex(value: boolean) {
     if (this._isConvex !== value) {
-      this._isConvex = value;
       const mesh = this._mesh;
-      if (mesh) {
-        // PxShape.setGeometry requires matching geometry type, so recreate when isConvex changes
-        this._destroyNativeShape();
-        if (this._extractMeshData(mesh)) {
-          this._createNativeShape();
-        } else {
-          this._clearMeshData();
-        }
+      if (!mesh) {
+        this._isConvex = value;
+        return;
       }
+
+      let positions = this._positions;
+      let indices = this._indices;
+      if (!value && !indices) {
+        const meshData = this._getMeshData(mesh, false);
+        if (!meshData) return;
+        positions = meshData.positions;
+        indices = meshData.indices;
+      }
+
+      const nativeShape = this._createNativeShape(positions, indices, value, this._cookingFlags);
+      if (!nativeShape) return;
+
+      this._replaceNativeShape(nativeShape);
+      this._isConvex = value;
+      this._positions = positions;
+      this._indices = indices;
     }
   }
 
@@ -74,19 +100,29 @@ export class MeshColliderShape extends ColliderShape {
 
   set mesh(value: ModelMesh) {
     if (this._mesh !== value) {
+      if (value) {
+        const meshData = this._getMeshData(value, this._isConvex);
+        if (!meshData) return;
+
+        const nativeShape = this._createNativeShape(
+          meshData.positions,
+          meshData.indices,
+          this._isConvex,
+          this._cookingFlags
+        );
+        if (!nativeShape) return;
+
+        this._replaceNativeShape(nativeShape);
+        this._positions = meshData.positions;
+        this._indices = meshData.indices;
+      } else {
+        this._replaceNativeShape(null);
+        this._clearMeshData();
+      }
+
       this._mesh?._addReferCount(-1);
       value?._addReferCount(1);
       this._mesh = value;
-      if (value && this._extractMeshData(value)) {
-        if (this._nativeShape) {
-          this._updateNativeShapeData();
-        } else {
-          this._createNativeShape();
-        }
-      } else {
-        this._destroyNativeShape();
-        this._clearMeshData();
-      }
     }
   }
 
@@ -99,14 +135,6 @@ export class MeshColliderShape extends ColliderShape {
       return -1;
     }
     return super.getClosestPoint(point, outClosestPoint);
-  }
-
-  /**
-   * @inheritdoc
-   */
-  override _onClone(target: MeshColliderShape): void {
-    target.mesh = this._mesh;
-    super._onClone(target);
   }
 
   /**
@@ -126,76 +154,83 @@ export class MeshColliderShape extends ColliderShape {
     this._indices = null;
   }
 
-  private _destroyNativeShape(): void {
-    if (this._nativeShape) {
-      this._collider?._setNativeShapeAttached(this, false);
-      this._nativeShape.destroy();
-      this._nativeShape = null;
-    }
-  }
-
-  private _extractMeshData(mesh: ModelMesh): boolean {
+  private _getMeshData(mesh: ModelMesh, isConvex: boolean): MeshData | null {
     if (!mesh.accessible) {
       console.warn("MeshColliderShape: Mesh data is not accessible. Set 'keepMeshData' before uploading.");
-      return false;
+      return null;
     }
 
     const positions = mesh.getPositions();
     if (!positions || positions.length === 0) {
       console.warn("MeshColliderShape: Mesh has no position data.");
-      return false;
+      return null;
     }
 
-    this._positions = positions;
-    this._indices = null;
-
-    if (!this._isConvex) {
-      const indices = mesh.getIndices();
+    let indices: Uint8Array | Uint16Array | Uint32Array | null = null;
+    if (!isConvex) {
+      indices = mesh.getIndices();
       if (!indices) {
         console.warn("MeshColliderShape: Non-convex mesh requires indices.");
-        return false;
+        return null;
       }
-      this._indices = indices;
     }
 
-    return true;
+    return { positions, indices };
   }
 
-  private _updateNativeShapeData(): void {
-    const succeeded = (<IMeshColliderShape>this._nativeShape).setMeshData(
-      this._positions,
-      this._indices,
-      this._isConvex,
-      this._cookingFlags
-    );
-    this._collider?._setNativeShapeAttached(this, succeeded);
-  }
-
-  private _createNativeShape(): void {
+  private _createNativeShape(
+    positions: Vector3[],
+    indices: Uint8Array | Uint16Array | Uint32Array | null,
+    isConvex: boolean,
+    cookingFlags: MeshColliderShapeCookingFlag
+  ): IMeshColliderShape | null {
     // Non-convex MeshColliderShape is only supported on StaticCollider or kinematic DynamicCollider
-    if (!this._isConvex && this._collider instanceof DynamicCollider && !this._collider.isKinematic) {
+    if (!isConvex && this._collider instanceof DynamicCollider && !this._collider.isKinematic) {
       console.error("MeshColliderShape: Non-convex mesh is not supported on non-kinematic DynamicCollider.");
-      return;
+      return null;
     }
 
     const nativeShape = Engine._nativePhysics.createMeshColliderShape(
       this._id,
-      this._positions,
-      this._indices,
-      this._isConvex,
+      positions,
+      indices,
+      isConvex,
       this._material._nativeMaterial,
-      this._cookingFlags
+      cookingFlags,
+      this._collider?.entity.transform.lossyWorldScale ?? MeshColliderShape._unitScale
     );
 
-    if (!nativeShape) {
-      return;
+    if (nativeShape) this._syncNativeShape(nativeShape);
+    return nativeShape;
+  }
+
+  private _replaceNativeShape(nativeShape: IMeshColliderShape | null): void {
+    if (this._collider) {
+      this._collider._replaceNativeShape(this, nativeShape);
+    } else {
+      this._nativeShape?.destroy();
+      this._nativeShape = nativeShape;
     }
+  }
 
-    this._nativeShape = nativeShape;
-
-    // Sync base class properties (position, rotation, contactOffset, isTrigger, material)
-    super._syncNative();
-
-    this._collider?._setNativeShapeAttached(this, true);
+  /**
+   * @inheritdoc
+   */
+  override _onClone(target: MeshColliderShape): void {
+    super._onClone(target);
+    const mesh = target._mesh;
+    if (mesh) {
+      const nativeShape =
+        target._positions &&
+        target._createNativeShape(target._positions, target._indices, target._isConvex, target._cookingFlags);
+      if (!nativeShape) {
+        target._mesh = null;
+        target._nativeShape = null;
+        target._clearMeshData();
+        return;
+      }
+      target._nativeShape = nativeShape;
+      mesh._addReferCount(1);
+    }
   }
 }

--- a/packages/core/src/physics/shape/MeshColliderShape.ts
+++ b/packages/core/src/physics/shape/MeshColliderShape.ts
@@ -23,9 +23,7 @@ export class MeshColliderShape extends ColliderShape {
   private _mesh: ModelMesh = null;
   private _isConvex = false;
   @assignmentClone
-  private _positions: Vector3[] = null;
-  @assignmentClone
-  private _indices: Uint8Array | Uint16Array | Uint32Array | null = null;
+  private _meshData: MeshData | null = null;
   private _cookingFlags = MeshColliderShapeCookingFlag.Cleaning | MeshColliderShapeCookingFlag.VertexWelding;
 
   /** @internal */
@@ -45,7 +43,8 @@ export class MeshColliderShape extends ColliderShape {
         return;
       }
 
-      const nativeShape = this._createNativeShape(this._positions, this._indices, this._isConvex, value);
+      const { positions, indices } = this._meshData;
+      const nativeShape = this._createNativeShape(positions, indices, this._isConvex, value);
       if (!nativeShape) return;
 
       this._replaceNativeShape(nativeShape);
@@ -56,7 +55,7 @@ export class MeshColliderShape extends ColliderShape {
   /**
    * Whether to use convex mesh mode.
    * @remarks
-   * - When true, generates a convex hull from the mesh vertices. Works with all collider types.
+   * - When true, generates a convex hull from the mesh vertices. Works with StaticCollider or DynamicCollider.
    * - When false, uses the original triangle mesh. Only works with StaticCollider or kinematic DynamicCollider, and the mesh must have indices.
    */
   get isConvex(): boolean {
@@ -71,22 +70,18 @@ export class MeshColliderShape extends ColliderShape {
         return;
       }
 
-      let positions = this._positions;
-      let indices = this._indices;
-      if (!value && !indices) {
-        const meshData = this._getMeshData(mesh, false);
+      let meshData = this._meshData;
+      if (!value && !meshData.indices) {
+        meshData = this._getMeshData(mesh, false);
         if (!meshData) return;
-        positions = meshData.positions;
-        indices = meshData.indices;
       }
 
-      const nativeShape = this._createNativeShape(positions, indices, value, this._cookingFlags);
+      const nativeShape = this._createNativeShape(meshData.positions, meshData.indices, value, this._cookingFlags);
       if (!nativeShape) return;
 
       this._replaceNativeShape(nativeShape);
       this._isConvex = value;
-      this._positions = positions;
-      this._indices = indices;
+      this._meshData = meshData;
     }
   }
 
@@ -113,11 +108,10 @@ export class MeshColliderShape extends ColliderShape {
         if (!nativeShape) return;
 
         this._replaceNativeShape(nativeShape);
-        this._positions = meshData.positions;
-        this._indices = meshData.indices;
+        this._meshData = meshData;
       } else {
         this._replaceNativeShape(null);
-        this._clearMeshData();
+        this._meshData = null;
       }
 
       this._mesh?._addReferCount(-1);
@@ -146,12 +140,7 @@ export class MeshColliderShape extends ColliderShape {
       this._mesh._addReferCount(-1);
       this._mesh = null;
     }
-    this._clearMeshData();
-  }
-
-  private _clearMeshData(): void {
-    this._positions = null;
-    this._indices = null;
+    this._meshData = null;
   }
 
   private _getMeshData(mesh: ModelMesh, isConvex: boolean): MeshData | null {
@@ -220,13 +209,14 @@ export class MeshColliderShape extends ColliderShape {
     super._onClone(target);
     const mesh = target._mesh;
     if (mesh) {
+      const meshData = target._meshData;
       const nativeShape =
-        target._positions &&
-        target._createNativeShape(target._positions, target._indices, target._isConvex, target._cookingFlags);
+        meshData &&
+        target._createNativeShape(meshData.positions, meshData.indices, target._isConvex, target._cookingFlags);
       if (!nativeShape) {
         target._mesh = null;
         target._nativeShape = null;
-        target._clearMeshData();
+        target._meshData = null;
         return;
       }
       target._nativeShape = nativeShape;

--- a/packages/core/src/physics/shape/MeshColliderShape.ts
+++ b/packages/core/src/physics/shape/MeshColliderShape.ts
@@ -155,13 +155,10 @@ export class MeshColliderShape extends ColliderShape {
       return null;
     }
 
-    let indices: Uint8Array | Uint16Array | Uint32Array | null = null;
-    if (!isConvex) {
-      indices = mesh.getIndices();
-      if (!indices) {
-        console.warn("MeshColliderShape: Non-convex mesh requires indices.");
-        return null;
-      }
+    const indices = mesh.getIndices();
+    if (!isConvex && !indices) {
+      console.warn("MeshColliderShape: Non-convex mesh requires indices.");
+      return null;
     }
 
     return { positions, indices };
@@ -182,7 +179,7 @@ export class MeshColliderShape extends ColliderShape {
     const nativeShape = Engine._nativePhysics.createMeshColliderShape(
       this._id,
       positions,
-      indices,
+      isConvex ? null : indices,
       isConvex,
       this._material._nativeMaterial,
       cookingFlags,

--- a/packages/design/src/physics/IDynamicCollider.ts
+++ b/packages/design/src/physics/IDynamicCollider.ts
@@ -1,10 +1,10 @@
 import { Quaternion, Vector3 } from "@galacean/engine-math";
-import { ICollider } from "./ICollider";
+import { IRigidCollider } from "./IRigidCollider";
 
 /**
  * Interface of physics dynamic collider.
  */
-export interface IDynamicCollider extends ICollider {
+export interface IDynamicCollider extends IRigidCollider {
   /**
    * Set global transform of collider.
    * @param position - The global position

--- a/packages/design/src/physics/IPhysics.ts
+++ b/packages/design/src/physics/IPhysics.ts
@@ -37,6 +37,16 @@ export interface IPhysics {
   createPhysicsScene(physicsManager: IPhysicsManager): IPhysicsScene;
 
   /**
+   * Get the default contact offset for collider shapes.
+   */
+  getDefaultContactOffset?(): number;
+
+  /**
+   * Get the default sleep threshold for dynamic colliders.
+   */
+  getDefaultSleepThreshold?(): number;
+
+  /**
    * Create dynamic collider.
    * @param position - The global position
    * @param rotation - The global rotation
@@ -116,6 +126,7 @@ export interface IPhysics {
    * @param isConvex - Whether to create convex mesh (true) or triangle mesh (false)
    * @param material - The material of this shape
    * @param cookingFlags - Cooking flags
+   * @param worldScale - World scale of the shape
    */
   createMeshColliderShape(
     uniqueID: number,
@@ -123,7 +134,8 @@ export interface IPhysics {
     indices: Uint8Array | Uint16Array | Uint32Array | null,
     isConvex: boolean,
     material: IPhysicsMaterial,
-    cookingFlags: number
+    cookingFlags: number,
+    worldScale: Vector3
   ): IMeshColliderShape | null;
 
   /**

--- a/packages/design/src/physics/IRigidCollider.ts
+++ b/packages/design/src/physics/IRigidCollider.ts
@@ -1,0 +1,15 @@
+import { ICollider } from "./ICollider";
+import { IColliderShape } from "./shape";
+
+/**
+ * Interface of a rigid collider.
+ */
+export interface IRigidCollider extends ICollider {
+  /**
+   * Atomically replace an attached shape with the same logical identity.
+   * @param previousShape - The currently attached shape
+   * @param newShape - The replacement shape
+   * @remarks If attachment fails, the previous shape and its event state remain unchanged.
+   */
+  replaceShape(previousShape: IColliderShape, newShape: IColliderShape): void;
+}

--- a/packages/design/src/physics/IStaticCollider.ts
+++ b/packages/design/src/physics/IStaticCollider.ts
@@ -1,10 +1,10 @@
 import { Quaternion, Vector3 } from "@galacean/engine-math";
-import { ICollider } from "./ICollider";
+import { IRigidCollider } from "./IRigidCollider";
 
 /**
  * Interface of physics static collider.
  */
-export interface IStaticCollider extends ICollider {
+export interface IStaticCollider extends IRigidCollider {
   /**
    * Set global transform of collider.
    * @param position - The global position

--- a/packages/design/src/physics/index.ts
+++ b/packages/design/src/physics/index.ts
@@ -5,6 +5,7 @@ export type { IPhysics } from "./IPhysics";
 export type { IPhysicsMaterial } from "./IPhysicsMaterial";
 export type { IPhysicsScene } from "./IPhysicsScene";
 export type { IPhysicsManager } from "./IPhysicsManager";
+export type { IRigidCollider } from "./IRigidCollider";
 export type { IStaticCollider } from "./IStaticCollider";
 export type { ICollision } from "./ICollision";
 export type { IContactEvent, ITriggerEvent, IPhysicsEvents } from "./IPhysicsEvents";

--- a/packages/design/src/physics/shape/IMeshColliderShape.ts
+++ b/packages/design/src/physics/shape/IMeshColliderShape.ts
@@ -1,22 +1,6 @@
-import { Vector3 } from "@galacean/engine-math";
 import { IColliderShape } from "./IColliderShape";
 
 /**
  * Interface for mesh collider shape.
  */
-export interface IMeshColliderShape extends IColliderShape {
-  /**
-   * Set mesh data for this collider shape.
-   * @param positions - Vertex positions
-   * @param indices - The index array (Uint16Array or Uint32Array), required for triangle mesh
-   * @param isConvex - Whether to use convex mesh (true) or triangle mesh (false)
-   * @param cookingFlags - Cooking flags
-   * @returns Whether the mesh data was successfully set
-   */
-  setMeshData(
-    positions: Vector3[],
-    indices: Uint8Array | Uint16Array | Uint32Array | null,
-    isConvex: boolean,
-    cookingFlags: number
-  ): boolean;
-}
+export type IMeshColliderShape = IColliderShape;

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -94,7 +94,6 @@ export class PhysXCharacterController implements ICharacterController {
     this._pxManager && this._createPXController(this._pxManager, shape);
     this._shape = shape;
     shape._controllers.add(this);
-    this._pxController?.setContactOffset(shape._contractOffset);
     this._scene?._addColliderShape(shape._id);
   }
 
@@ -159,6 +158,7 @@ export class PhysXCharacterController implements ICharacterController {
     this._pxController = pxManager._getControllerManager().createController(desc);
     desc.delete();
 
+    this._pxController.setContactOffset(shape._contactOffset);
     this._pxController.setUUID(shape._id);
 
     this._updateNativePosition();

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -155,10 +155,10 @@ export class PhysXCharacterController implements ICharacterController {
     }
 
     desc.setMaterial(shape._pxMaterial);
+    desc.contactOffset = shape._contactOffset;
     this._pxController = pxManager._getControllerManager().createController(desc);
     desc.delete();
 
-    this._pxController.setContactOffset(shape._contactOffset);
     this._pxController.setUUID(shape._id);
 
     this._updateNativePosition();

--- a/packages/physics-physx/src/PhysXCollider.ts
+++ b/packages/physics-physx/src/PhysXCollider.ts
@@ -1,4 +1,4 @@
-import { ICollider } from "@galacean/engine-design";
+import { IRigidCollider } from "@galacean/engine-design";
 import { Quaternion, Vector3 } from "@galacean/engine";
 import { PhysXPhysics } from "./PhysXPhysics";
 import { PhysXColliderShape } from "./shape/PhysXColliderShape";
@@ -7,7 +7,7 @@ import { PhysXPhysicsScene } from "./PhysXPhysicsScene";
 /**
  * Abstract class of physical collider.
  */
-export abstract class PhysXCollider implements ICollider {
+export abstract class PhysXCollider implements IRigidCollider {
   private static _tempTransform: {
     translation: Vector3;
     rotation: Quaternion;
@@ -45,6 +45,17 @@ export abstract class PhysXCollider implements ICollider {
     const shapes = this._shapes;
     shapes.splice(shapes.indexOf(shape), 1);
     this._scene?._removeColliderShape(shape._id);
+  }
+
+  /**
+   * {@inheritDoc IRigidCollider.replaceShape }
+   */
+  replaceShape(previousShape: PhysXColliderShape, newShape: PhysXColliderShape): void {
+    if (!this._pxActor.attachShape(newShape._pxShape)) {
+      throw new Error("PhysXCollider: failed to attach shape to the native actor.");
+    }
+    this._shapes[this._shapes.indexOf(previousShape)] = newShape;
+    this._pxActor.detachShape(previousShape._pxShape, true);
   }
 
   /**

--- a/packages/physics-physx/src/PhysXPhysics.ts
+++ b/packages/physics-physx/src/PhysXPhysics.ts
@@ -54,16 +54,36 @@ export class PhysXPhysics implements IPhysics {
   private _initializePromise: Promise<void>;
   private _defaultErrorCallback: any;
   private _allocator: any;
-  private _tolerancesScale: any;
   private _wasmSIMDModeUrl: string;
   private _wasmModeUrl: string;
+  private readonly _tolerancesScaleLength: number;
+  private readonly _tolerancesScaleSpeed: number;
 
   /**
    * Create a PhysXPhysics instance.
    * @param runtimeMode - Runtime mode, `Auto` prefers WebAssembly SIMD if supported @see {@link PhysXRuntimeMode}
    * @param runtimeUrls - Manually specify the runtime URLs
+   * @param options - PhysX options.
    */
-  constructor(runtimeMode: PhysXRuntimeMode = PhysXRuntimeMode.Auto, runtimeUrls?: PhysXRuntimeUrls) {
+  constructor(runtimeMode?: PhysXRuntimeMode, runtimeUrls?: PhysXRuntimeUrls, options?: PhysXPhysicsOptions);
+  constructor(options?: PhysXPhysicsOptions);
+  constructor(
+    runtimeModeOrOptions: PhysXRuntimeMode | PhysXPhysicsOptions = PhysXRuntimeMode.Auto,
+    runtimeUrls?: PhysXRuntimeUrls,
+    options?: PhysXPhysicsOptions
+  ) {
+    const isOptionsObject = typeof runtimeModeOrOptions === "object";
+    const runtimeMode = isOptionsObject ? PhysXRuntimeMode.Auto : (runtimeModeOrOptions ?? PhysXRuntimeMode.Auto);
+    const resolvedOptions = isOptionsObject ? runtimeModeOrOptions : options;
+    const tolerancesScale = resolvedOptions?.tolerancesScale;
+    if (tolerancesScale !== undefined && (tolerancesScale === null || typeof tolerancesScale !== "object")) {
+      throw new Error("PhysXPhysics tolerancesScale must be an object.");
+    }
+    const length = tolerancesScale?.length === undefined ? 1 : tolerancesScale.length;
+    const speed = tolerancesScale?.speed === undefined ? 10 : tolerancesScale.speed;
+    this._assertPositiveFinite(length, "tolerancesScale.length");
+    this._assertPositiveFinite(speed, "tolerancesScale.speed");
+
     this._runTimeMode = runtimeMode;
     this._wasmSIMDModeUrl =
       runtimeUrls?.wasmSIMDModeUrl ??
@@ -71,6 +91,8 @@ export class PhysXPhysics implements IPhysics {
     this._wasmModeUrl =
       runtimeUrls?.wasmModeUrl ??
       "https://mdn.alipayobjects.com/rms/uri/file/as/apwallet/1787063975729/suyi/physx.release.js";
+    this._tolerancesScaleLength = length;
+    this._tolerancesScaleSpeed = speed;
   }
 
   /**
@@ -138,7 +160,6 @@ export class PhysXPhysics implements IPhysics {
     this._pxFoundation.release();
     this._defaultErrorCallback.delete();
     this._allocator.delete();
-    this._tolerancesScale.delete();
   }
 
   /**
@@ -154,6 +175,20 @@ export class PhysXPhysics implements IPhysics {
   createPhysicsScene(physicsManager: PhysXPhysicsManager): IPhysicsScene {
     const scene = new PhysXPhysicsScene(this, physicsManager);
     return scene;
+  }
+
+  /**
+   * {@inheritDoc IPhysics.getDefaultContactOffset }
+   */
+  getDefaultContactOffset(): number {
+    return 0.02 * this._tolerancesScaleLength;
+  }
+
+  /**
+   * {@inheritDoc IPhysics.getDefaultSleepThreshold }
+   */
+  getDefaultSleepThreshold(): number {
+    return 5e-5 * this._tolerancesScaleSpeed * this._tolerancesScaleSpeed;
   }
 
   /**
@@ -232,9 +267,19 @@ export class PhysXPhysics implements IPhysics {
     indices: Uint8Array | Uint16Array | Uint32Array | null,
     isConvex: boolean,
     material: PhysXPhysicsMaterial,
-    cookingFlags: number
+    cookingFlags: number,
+    worldScale: Vector3
   ): IMeshColliderShape | null {
-    const shape = new PhysXMeshColliderShape(this, uniqueID, positions, indices, isConvex, material, cookingFlags);
+    const shape = new PhysXMeshColliderShape(
+      this,
+      uniqueID,
+      positions,
+      indices,
+      isConvex,
+      material,
+      cookingFlags,
+      worldScale
+    );
     return shape._pxShape ? shape : null;
   }
 
@@ -279,12 +324,16 @@ export class PhysXPhysics implements IPhysics {
     const allocator = new physX.PxDefaultAllocator();
     const pxFoundation = physX.PxCreateFoundation(version, allocator, defaultErrorCallback);
     const tolerancesScale = new physX.PxTolerancesScale();
+    tolerancesScale.length = this._tolerancesScaleLength;
+    tolerancesScale.speed = this._tolerancesScaleSpeed;
     const pxPhysics = physX.PxCreatePhysics(version, pxFoundation, tolerancesScale, false, null);
 
     physX.PxInitExtensions(pxPhysics, null);
 
     // Initialize cooking for mesh colliders
     const cookingParams = new physX.PxCookingParams(tolerancesScale);
+    // PxPhysics and PxCookingParams copy the scale.
+    tolerancesScale.delete();
     physX.setCookingMeshPreprocessParams(cookingParams, 1); // eWELD_VERTICES
     cookingParams.meshWeldTolerance = 0.001;
     // BVH34 midphase requires SSE2; SIMD WASM provides SSE2 via WASM SIMD
@@ -300,7 +349,12 @@ export class PhysXPhysics implements IPhysics {
     this._pxCookingParams = cookingParams;
     this._defaultErrorCallback = defaultErrorCallback;
     this._allocator = allocator;
-    this._tolerancesScale = tolerancesScale;
+  }
+
+  private _assertPositiveFinite(value: number, name: string): void {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`PhysXPhysics ${name} must be a positive finite number.`);
+    }
   }
 }
 
@@ -315,4 +369,16 @@ interface PhysXRuntimeUrls {
   wasmModeUrl?: string;
   /*** The URL of `PhysXRuntimeMode.WebAssemblySIMD` mode. */
   wasmSIMDModeUrl?: string;
+}
+
+export interface PhysXTolerancesScale {
+  /** Approximate object length in the simulation unit. Must be positive and finite. PhysX default is 1. */
+  length?: number;
+  /** Typical object speed in the simulation unit. Must be positive and finite. PhysX default is 10. */
+  speed?: number;
+}
+
+export interface PhysXPhysicsOptions {
+  /** PhysX world unit scale, copied before PxPhysics, PxSceneDesc and PxCookingParams are created. */
+  tolerancesScale?: PhysXTolerancesScale;
 }

--- a/packages/physics-physx/src/PhysXPhysics.ts
+++ b/packages/physics-physx/src/PhysXPhysics.ts
@@ -62,14 +62,12 @@ export class PhysXPhysics implements IPhysics {
   /**
    * Create a PhysXPhysics instance.
    * @param runtimeMode - Runtime mode, `Auto` prefers WebAssembly SIMD if supported @see {@link PhysXRuntimeMode}
-   * @param runtimeUrls - Manually specify the runtime URLs
    * @param options - PhysX options.
    */
-  constructor(runtimeMode?: PhysXRuntimeMode, runtimeUrls?: PhysXRuntimeUrls, options?: PhysXPhysicsOptions);
+  constructor(runtimeMode?: PhysXRuntimeMode, options?: PhysXPhysicsOptions);
   constructor(options?: PhysXPhysicsOptions);
   constructor(
     runtimeModeOrOptions: PhysXRuntimeMode | PhysXPhysicsOptions = PhysXRuntimeMode.Auto,
-    runtimeUrls?: PhysXRuntimeUrls,
     options?: PhysXPhysicsOptions
   ) {
     const isOptionsObject = typeof runtimeModeOrOptions === "object";
@@ -86,10 +84,10 @@ export class PhysXPhysics implements IPhysics {
 
     this._runTimeMode = runtimeMode;
     this._wasmSIMDModeUrl =
-      runtimeUrls?.wasmSIMDModeUrl ??
+      resolvedOptions?.wasmSIMDModeUrl ??
       "https://mdn.alipayobjects.com/rms/uri/file/as/apwallet/1787063975729/suyi/physx.release.simd.js";
     this._wasmModeUrl =
-      runtimeUrls?.wasmModeUrl ??
+      resolvedOptions?.wasmModeUrl ??
       "https://mdn.alipayobjects.com/rms/uri/file/as/apwallet/1787063975729/suyi/physx.release.js";
     this._tolerancesScaleLength = length;
     this._tolerancesScaleSpeed = speed;
@@ -335,7 +333,7 @@ export class PhysXPhysics implements IPhysics {
     // PxPhysics and PxCookingParams copy the scale.
     tolerancesScale.delete();
     physX.setCookingMeshPreprocessParams(cookingParams, 1); // eWELD_VERTICES
-    cookingParams.meshWeldTolerance = 0.001;
+    cookingParams.meshWeldTolerance = 0.001 * this._tolerancesScaleLength;
     // BVH34 midphase requires SSE2; SIMD WASM provides SSE2 via WASM SIMD
     if (this._runTimeMode === PhysXRuntimeMode.WebAssemblySIMD) {
       physX.setCookingMidphaseType(cookingParams, 1); // eBVH34
@@ -364,13 +362,6 @@ enum InitializeState {
   Initialized
 }
 
-interface PhysXRuntimeUrls {
-  /*** The URL of `PhysXRuntimeMode.WebAssembly` mode. */
-  wasmModeUrl?: string;
-  /*** The URL of `PhysXRuntimeMode.WebAssemblySIMD` mode. */
-  wasmSIMDModeUrl?: string;
-}
-
 export interface PhysXTolerancesScale {
   /** Approximate object length in the simulation unit. Must be positive and finite. PhysX default is 1. */
   length?: number;
@@ -379,6 +370,10 @@ export interface PhysXTolerancesScale {
 }
 
 export interface PhysXPhysicsOptions {
+  /** The URL of `PhysXRuntimeMode.WebAssembly` mode. */
+  wasmModeUrl?: string;
+  /** The URL of `PhysXRuntimeMode.WebAssemblySIMD` mode. */
+  wasmSIMDModeUrl?: string;
   /** PhysX world unit scale, copied before PxPhysics, PxSceneDesc and PxCookingParams are created. */
   tolerancesScale?: PhysXTolerancesScale;
 }

--- a/packages/physics-physx/src/index.ts
+++ b/packages/physics-physx/src/index.ts
@@ -1,4 +1,5 @@
 export { PhysXPhysics } from "./PhysXPhysics";
+export type { PhysXPhysicsOptions, PhysXTolerancesScale } from "./PhysXPhysics";
 export { PhysXRuntimeMode } from "./enum/PhysXRuntimeMode";
 
 //@ts-ignore

--- a/packages/physics-physx/src/shape/PhysXColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXColliderShape.ts
@@ -107,8 +107,11 @@ export abstract class PhysXColliderShape implements IColliderShape {
    * @default 0.02f * PxTolerancesScale::length
    */
   setContactOffset(offset: number): void {
-    this._contactOffset = offset;
     const controllers = this._controllers;
+    if (controllers.length && (!Number.isFinite(offset) || offset <= 0)) {
+      throw new Error("CharacterController contactOffset must be a positive finite number.");
+    }
+    this._contactOffset = offset;
     if (controllers.length) {
       for (let i = 0, n = controllers.length; i < n; i++) {
         controllers.get(i)._pxController?.setContactOffset(offset);

--- a/packages/physics-physx/src/shape/PhysXColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXColliderShape.ts
@@ -31,7 +31,7 @@ export abstract class PhysXColliderShape implements IColliderShape {
   /** @internal */
   _controllers: DisorderedArray<PhysXCharacterController> = new DisorderedArray<PhysXCharacterController>();
   /** @internal */
-  _contractOffset: number = 0.02;
+  _contactOffset: number = 0.02;
 
   /** @internal */
   _worldScale: Vector3 = new Vector3(1, 1, 1);
@@ -56,6 +56,7 @@ export abstract class PhysXColliderShape implements IColliderShape {
 
   constructor(physXPhysics: PhysXPhysics) {
     this._physXPhysics = physXPhysics;
+    this._contactOffset = physXPhysics.getDefaultContactOffset();
   }
 
   /**
@@ -106,7 +107,7 @@ export abstract class PhysXColliderShape implements IColliderShape {
    * @default 0.02f * PxTolerancesScale::length
    */
   setContactOffset(offset: number): void {
-    this._contractOffset = offset;
+    this._contactOffset = offset;
     const controllers = this._controllers;
     if (controllers.length) {
       for (let i = 0, n = controllers.length; i < n; i++) {

--- a/packages/physics-physx/src/shape/PhysXMeshColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXMeshColliderShape.ts
@@ -34,23 +34,25 @@ export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshC
 
     const { _physX: physX, _pxPhysics: physics } = physXPhysics;
     const { x: scaleX, y: scaleY, z: scaleZ } = this._worldScale;
-    const shapeFlags = ShapeFlag.SCENE_QUERY_SHAPE | ShapeFlag.SIMULATION_SHAPE;
     const meshFlag = isConvex ? PhysXMeshColliderShape._tightBoundsFlag : 0;
-    const createShapeFn = isConvex ? physX.createConvexMeshShape : physX.createTriMeshShape;
+    const pxGeometry = isConvex
+      ? physX.createConvexMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag)
+      : physX.createTriMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag);
+    const shapeFlags = new physX.PxShapeFlags(ShapeFlag.SCENE_QUERY_SHAPE | ShapeFlag.SIMULATION_SHAPE);
+    const pxShape = physics.createShape(pxGeometry, material._pxMaterial, true, shapeFlags);
+    shapeFlags.delete();
 
-    const pxShape = createShapeFn(pxMesh, scaleX, scaleY, scaleZ, meshFlag, shapeFlags, material._pxMaterial, physics);
     if (!pxShape) {
+      pxGeometry.delete();
       pxMesh.release();
       return;
     }
 
-    this._pxShape = pxShape;
     this._id = uniqueID;
     this._pxMaterial = material._pxMaterial;
     this._pxMesh = pxMesh;
-    this._pxGeometry = isConvex
-      ? physX.createConvexMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag)
-      : physX.createTriMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag);
+    this._pxGeometry = pxGeometry;
+    this._pxShape = pxShape;
     this._pxShape.setUUID(uniqueID);
     this._setLocalPose();
   }

--- a/packages/physics-physx/src/shape/PhysXMeshColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXMeshColliderShape.ts
@@ -8,7 +8,7 @@ import { PhysXColliderShape, ShapeFlag } from "./PhysXColliderShape";
  * Mesh collider shape in PhysX.
  */
 export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshColliderShape {
-  private static _tightBoundsFlag = 1; // eTIGHT_BOUNDS = 1 (1<<0)
+  private static readonly _tightBoundsFlag = 1; // eTIGHT_BOUNDS = 1 (1<<0)
 
   private _pxMesh: any = null;
   private _isConvex: boolean;
@@ -20,12 +20,15 @@ export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshC
     indices: Uint8Array | Uint16Array | Uint32Array | null,
     isConvex: boolean,
     material: PhysXPhysicsMaterial,
-    cookingFlags: number
+    cookingFlags: number,
+    worldScale: Vector3
   ) {
     super(physXPhysics);
     this._isConvex = isConvex;
+    this._worldScale.set(Math.abs(worldScale.x), Math.abs(worldScale.y), Math.abs(worldScale.z));
 
-    if (!this._cookMesh(positions, indices, cookingFlags)) {
+    const pxMesh = this._cookMesh(positions, indices, isConvex, cookingFlags);
+    if (!pxMesh) {
       return;
     }
 
@@ -35,44 +38,21 @@ export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshC
     const meshFlag = isConvex ? PhysXMeshColliderShape._tightBoundsFlag : 0;
     const createShapeFn = isConvex ? physX.createConvexMeshShape : physX.createTriMeshShape;
 
-    this._pxShape = createShapeFn(
-      this._pxMesh,
-      scaleX,
-      scaleY,
-      scaleZ,
-      meshFlag,
-      shapeFlags,
-      material._pxMaterial,
-      physics
-    );
-
-    this._id = uniqueID;
-    this._pxMaterial = material._pxMaterial;
-    this._pxShape.setUUID(uniqueID);
-    this._setLocalPose();
-  }
-
-  /**
-   * {@inheritDoc IMeshColliderShape.setMeshData }
-   */
-  setMeshData(
-    positions: Vector3[],
-    indices: Uint8Array | Uint16Array | Uint32Array | null,
-    isConvex: boolean,
-    cookingFlags: number
-  ): boolean {
-    this._pxMesh?.release();
-    this._pxGeometry?.delete();
-    this._pxMesh = null;
-    this._pxGeometry = null;
-    this._isConvex = isConvex;
-
-    if (!this._cookMesh(positions, indices, cookingFlags)) {
-      return false;
+    const pxShape = createShapeFn(pxMesh, scaleX, scaleY, scaleZ, meshFlag, shapeFlags, material._pxMaterial, physics);
+    if (!pxShape) {
+      pxMesh.release();
+      return;
     }
 
-    this._pxShape.setGeometry(this._pxGeometry);
-    return true;
+    this._pxShape = pxShape;
+    this._id = uniqueID;
+    this._pxMaterial = material._pxMaterial;
+    this._pxMesh = pxMesh;
+    this._pxGeometry = isConvex
+      ? physX.createConvexMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag)
+      : physX.createTriMeshGeometry(pxMesh, scaleX, scaleY, scaleZ, meshFlag);
+    this._pxShape.setUUID(uniqueID);
+    this._setLocalPose();
   }
 
   /**
@@ -94,8 +74,9 @@ export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshC
   private _cookMesh(
     positions: Vector3[],
     indices: Uint8Array | Uint16Array | Uint32Array | null,
+    isConvex: boolean,
     cookingFlags: number
-  ): boolean {
+  ): any | null {
     const {
       _physX: physX,
       _pxPhysics: physics,
@@ -115,48 +96,36 @@ export class PhysXMeshColliderShape extends PhysXColliderShape implements IMeshC
     cooking.setParams(cookingParams);
 
     const verticesPtr = this._allocatePositions(positions);
+    let pxMesh: any;
 
-    if (this._isConvex) {
-      this._pxMesh = cooking.createConvexMesh(verticesPtr, positions.length, physics);
+    if (isConvex) {
+      pxMesh = cooking.createConvexMesh(verticesPtr, positions.length, physics);
       physX._free(verticesPtr);
 
-      if (!this._pxMesh) {
+      if (!pxMesh) {
         this._logConvexCookingError(physX);
-        return false;
+        return null;
       }
     } else {
       if (!indices) {
         physX._free(verticesPtr);
         console.error("PhysXMeshColliderShape: Triangle mesh requires indices.");
-        return false;
+        return null;
       }
 
       const isU32 = indices instanceof Uint32Array;
       const indicesPtr = this._allocateIndices(indices, isU32);
-      this._pxMesh = cooking.createTriMesh(
-        verticesPtr,
-        positions.length,
-        indicesPtr,
-        indices.length / 3,
-        !isU32,
-        physics
-      );
+      pxMesh = cooking.createTriMesh(verticesPtr, positions.length, indicesPtr, indices.length / 3, !isU32, physics);
       physX._free(verticesPtr);
       physX._free(indicesPtr);
 
-      if (!this._pxMesh) {
+      if (!pxMesh) {
         this._logTriMeshCookingError(physX);
-        return false;
+        return null;
       }
     }
 
-    const { x: scaleX, y: scaleY, z: scaleZ } = this._worldScale;
-    const meshFlag = this._isConvex ? PhysXMeshColliderShape._tightBoundsFlag : 0;
-    this._pxGeometry = this._isConvex
-      ? physX.createConvexMeshGeometry(this._pxMesh, scaleX, scaleY, scaleZ, meshFlag)
-      : physX.createTriMeshGeometry(this._pxMesh, scaleX, scaleY, scaleZ, meshFlag);
-
-    return true;
+    return pxMesh;
   }
 
   private _logConvexCookingError(physX: any): void {

--- a/tests/src/core/physics/CharacterController.test.ts
+++ b/tests/src/core/physics/CharacterController.test.ts
@@ -177,6 +177,27 @@ describe("CharacterController", function () {
     expect(formatValue(roleEntity.transform.position.y)).eq(1.5);
   });
 
+  it("preserves contactOffset when the native controller is recreated", () => {
+    const controller = roleEntity.getComponent(CharacterController);
+    controller.shapes[0].contactOffset = 0.3;
+
+    controller.enabled = false;
+    controller.enabled = true;
+    controller.move(new Vector3(0, 0, 0.1), 0.0001, 1);
+    controller.move(new Vector3(0, 0, 0.1), 0.0001, 1);
+    engine.update();
+
+    expect(formatValue(roleEntity.transform.position.y)).eq(0.8);
+  });
+
+  it("recreates the native controller when contactOffset is zero", () => {
+    const controller = roleEntity.getComponent(CharacterController);
+    controller.shapes[0].contactOffset = 0;
+    controller.enabled = false;
+
+    expect(() => (controller.enabled = true)).not.toThrow();
+  });
+
   it("slopeLimit notPass", () => {
     const { fixedTimeStep } = engine.sceneManager.activeScene.physics;
     const moveScript = roleEntity.getComponent(MoveScript);

--- a/tests/src/core/physics/CharacterController.test.ts
+++ b/tests/src/core/physics/CharacterController.test.ts
@@ -11,7 +11,8 @@ import {
   Script,
   ControllerCollisionFlag,
   Layer,
-  ColliderShapeUpAxis
+  ColliderShapeUpAxis,
+  MeshColliderShape
 } from "@galacean/engine-core";
 import { WebGLEngine } from "@galacean/engine";
 import { PhysXPhysics } from "@galacean/engine-physics-physx";
@@ -129,6 +130,19 @@ describe("CharacterController", function () {
     expect(controller.shapes.length).eq(1);
   });
 
+  it("rejects unsupported shapes before assigning an owner", () => {
+    const controller = roleEntity.getComponent(CharacterController);
+    controller.clearShapes();
+    const shape = new MeshColliderShape();
+
+    expect(() => controller.addShape(shape as unknown as BoxColliderShape)).toThrow();
+    expect(controller.shapes).toHaveLength(0);
+    expect(shape.collider).toBeFalsy();
+
+    shape._destroy();
+    shape.material.destroy();
+  });
+
   it("shape position", () => {
     const controller = roleEntity.getComponent(CharacterController);
     controller.clearShapes();
@@ -190,12 +204,26 @@ describe("CharacterController", function () {
     expect(formatValue(roleEntity.transform.position.y)).eq(0.8);
   });
 
-  it("recreates the native controller when contactOffset is zero", () => {
+  it("rejects zero contactOffset before attaching the shape", () => {
     const controller = roleEntity.getComponent(CharacterController);
-    controller.shapes[0].contactOffset = 0;
-    controller.enabled = false;
+    controller.clearShapes();
+    const shape = new BoxColliderShape();
+    shape.contactOffset = 0;
 
-    expect(() => (controller.enabled = true)).not.toThrow();
+    expect(() => controller.addShape(shape)).toThrow();
+    expect(controller.shapes).toHaveLength(0);
+    expect(shape.collider).toBeFalsy();
+
+    shape._destroy();
+    shape.material.destroy();
+  });
+
+  it("keeps contactOffset when an attached shape rejects zero", () => {
+    const shape = roleEntity.getComponent(CharacterController).shapes[0];
+    shape.contactOffset = 0.3;
+
+    expect(() => (shape.contactOffset = 0)).toThrow();
+    expect(shape.contactOffset).toBe(0.3);
   });
 
   it("slopeLimit notPass", () => {

--- a/tests/src/core/physics/MeshColliderShape.test.ts
+++ b/tests/src/core/physics/MeshColliderShape.test.ts
@@ -5,7 +5,6 @@ import {
   SphereColliderShape,
   BoxColliderShape,
   DynamicCollider,
-  Engine,
   HitResult,
   StaticCollider,
   PhysicsMaterial,
@@ -515,51 +514,28 @@ describe("MeshColliderShape PhysX", () => {
 
       const oldNativeShape = (meshShape as any)._nativeShape;
       const nativeCollider = (staticCollider as any)._nativeCollider;
-      const nativeScene = nativeCollider._scene;
-      const eventMap = nativeScene._physXManager._eventMap;
-      const eventSubMap = eventMap[meshShape.id];
-      const triggerEvent = eventSubMap[sphereShape.id];
-      const activeTriggers = nativeScene._activeTriggers;
-      const activeTriggerElements = activeTriggers._elements.slice(0, activeTriggers.length);
       const oldDestroySpy = vi.spyOn(oldNativeShape, "destroy");
       const actorAttachSpy = vi.spyOn(nativeCollider._pxActor, "attachShape").mockReturnValueOnce(false);
       const actorDetachSpy = vi.spyOn(nativeCollider._pxActor, "detachShape");
       const originalReplaceShape = nativeCollider.replaceShape.bind(nativeCollider);
       let candidateNativeShape: any;
       let candidateDestroySpy: any;
-      let attachError: unknown;
       const replaceShapeSpy = vi.spyOn(nativeCollider, "replaceShape").mockImplementation((previousShape, newShape) => {
         candidateNativeShape = newShape;
         candidateDestroySpy = vi.spyOn(newShape, "destroy");
-        try {
-          originalReplaceShape(previousShape, newShape);
-        } catch (error) {
-          attachError = error;
-          throw error;
-        }
+        originalReplaceShape(previousShape, newShape);
       });
 
       try {
         const replacementMesh = createModelMesh(engine, [0, 2, 0, -2, -2, -2, 2, -2, -2, 0, -2, 2]);
-        let thrownError: unknown;
-        try {
-          meshShape.mesh = replacementMesh;
-        } catch (error) {
-          thrownError = error;
-        }
 
-        expect(thrownError).toBe(attachError);
+        expect(() => (meshShape.mesh = replacementMesh)).toThrow();
         expect(meshShape.mesh).toBe(oldMesh);
         expect((meshShape as any)._nativeShape).toBe(oldNativeShape);
         expect(nativeCollider._shapes).toEqual([oldNativeShape]);
         expect(actorAttachSpy).toHaveBeenCalledTimes(1);
         expect(actorAttachSpy).toHaveBeenCalledWith(candidateNativeShape._pxShape);
         expect(actorDetachSpy).not.toHaveBeenCalled();
-        expect(eventMap[meshShape.id]).toBe(eventSubMap);
-        expect(eventSubMap[sphereShape.id]).toBe(triggerEvent);
-        expect(activeTriggers.length).toBe(activeTriggerElements.length);
-        expect(activeTriggers._elements.slice(0, activeTriggers.length)).toEqual(activeTriggerElements);
-        expect((Engine as any)._physicalObjectsMap[meshShape.id]).toBe(meshShape);
         expect(oldDestroySpy).not.toHaveBeenCalled();
         expect(candidateNativeShape).toBeDefined();
         expect(candidateDestroySpy).toHaveBeenCalledTimes(1);
@@ -855,15 +831,15 @@ describe("MeshColliderShape PhysX", () => {
   });
 
   describe("Set Mesh Null", () => {
-    it("should detach the native shape when setting mesh to null", () => {
+    it("should detach the native shape and accept a new mesh after setting mesh to null", () => {
       const entity = root.createChild("nullMesh");
       const staticCollider = entity.addComponent(StaticCollider);
 
       const meshShape = new MeshColliderShape();
       const defaultMaterial = meshShape.material;
 
-      const mesh = createModelMesh(engine, [0, 0, 0, 1, 0, 0, 0, 1, 0], [0, 1, 2]);
-      meshShape.mesh = mesh;
+      const mesh1 = createModelMesh(engine, [0, 0, 0, 1, 0, 0, 0, 1, 0], [0, 1, 2]);
+      meshShape.mesh = mesh1;
       staticCollider.addShape(meshShape);
 
       // @ts-ignore
@@ -877,34 +853,11 @@ describe("MeshColliderShape PhysX", () => {
       expect(meshShape.mesh).toBeNull();
       expect((staticCollider as any)._nativeCollider._shapes).toHaveLength(0);
 
-      entity.destroy();
-      defaultMaterial?.destroy();
-    });
-
-    it("should still work after setting mesh to null and then setting a new mesh", () => {
-      const entity = root.createChild("nullThenNewMesh");
-      const staticCollider = entity.addComponent(StaticCollider);
-
-      const meshShape = new MeshColliderShape();
-      const defaultMaterial = meshShape.material;
-
-      const mesh1 = createModelMesh(engine, [0, 0, 0, 1, 0, 0, 0, 1, 0], [0, 1, 2]);
-      meshShape.mesh = mesh1;
-      staticCollider.addShape(meshShape);
-
-      // @ts-ignore
-      expect(meshShape._nativeShape).not.toBeNull();
-
-      // Disable
-      meshShape.mesh = null;
-      // @ts-ignore
-      expect(meshShape._nativeShape).toBeNull();
-
-      // Re-enable with new mesh
       const mesh2 = createModelMesh(engine, [0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0], [0, 1, 2, 3, 4, 5]);
       meshShape.mesh = mesh2;
       // @ts-ignore
       expect(meshShape._nativeShape).not.toBeNull();
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([(meshShape as any)._nativeShape]);
 
       entity.destroy();
       defaultMaterial?.destroy();
@@ -1058,8 +1011,6 @@ describe("MeshColliderShape PhysX", () => {
 
         expect(clonedShape.mesh).toBeNull();
         expect((clonedShape as any)._nativeShape).toBeNull();
-        expect((clonedShape as any)._positions).toBeNull();
-        expect((clonedShape as any)._indices).toBeNull();
         expect((clonedCollider as any)._nativeCollider._shapes).toHaveLength(0);
         expect(mesh.refCount).toBe(sourceRefCount);
         expect(shape.mesh).toBe(mesh);

--- a/tests/src/core/physics/MeshColliderShape.test.ts
+++ b/tests/src/core/physics/MeshColliderShape.test.ts
@@ -5,6 +5,7 @@ import {
   SphereColliderShape,
   BoxColliderShape,
   DynamicCollider,
+  Engine,
   HitResult,
   StaticCollider,
   PhysicsMaterial,
@@ -206,6 +207,36 @@ describe("MeshColliderShape PhysX", () => {
       defaultMaterial?.destroy();
     });
 
+    it("keeps the convex shape when non-convex mode is unsupported", () => {
+      const entity = root.createChild("unsupportedDynamicMesh");
+      const dynamicCollider = entity.addComponent(DynamicCollider);
+
+      const meshShape = new MeshColliderShape();
+      const meshMaterial = meshShape.material;
+      const convexMesh = createModelMesh(
+        engine,
+        [0, 1, 0, -1, 0, -1, 1, 0, -1, 0, 0, 1],
+        [0, 1, 2, 0, 2, 3, 0, 3, 1, 1, 3, 2]
+      );
+      meshShape.isConvex = true;
+      meshShape.mesh = convexMesh;
+      dynamicCollider.addShape(meshShape);
+      const nativeShape = (meshShape as any)._nativeShape;
+
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        meshShape.isConvex = false;
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(meshShape.isConvex).toBe(true);
+        expect((meshShape as any)._nativeShape).toBe(nativeShape);
+        expect((dynamicCollider as any)._nativeCollider._shapes).toEqual([nativeShape]);
+      } finally {
+        consoleErrorSpy.mockRestore();
+        entity.destroy();
+        meshMaterial?.destroy();
+      }
+    });
+
     it("should allow convex mesh on dynamic collider", async () => {
       // Create ground
       const groundEntity = root.createChild("ground2");
@@ -398,7 +429,7 @@ describe("MeshColliderShape PhysX", () => {
   });
 
   describe("Mesh Data Update", () => {
-    it("should update mesh data", () => {
+    it("should replace mesh data with one native shape", () => {
       const entity = root.createChild("updateMesh");
       const staticCollider = entity.addComponent(StaticCollider);
 
@@ -409,15 +440,145 @@ describe("MeshColliderShape PhysX", () => {
       const mesh1 = createModelMesh(engine, [0, 0, 0, 1, 0, 0, 0, 1, 0], [0, 1, 2]);
       meshShape.mesh = mesh1;
       staticCollider.addShape(meshShape);
+      const firstNativeShape = (meshShape as any)._nativeShape;
 
       // Update mesh
       const mesh2 = createModelMesh(engine, [0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0], [0, 1, 2, 3, 4, 5]);
       meshShape.mesh = mesh2;
 
       expect(staticCollider.shapes.length).toBe(1);
+      expect((meshShape as any)._nativeShape).not.toBe(firstNativeShape);
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([(meshShape as any)._nativeShape]);
 
       entity.destroy();
       defaultMaterial?.destroy();
+    });
+
+    it("keeps the existing native mesh when runtime mesh recooking fails", () => {
+      const groundEntity = root.createChild("transactionalMeshUpdateGround");
+      const staticCollider = groundEntity.addComponent(StaticCollider);
+      const meshShape = new MeshColliderShape();
+      const meshMaterial = meshShape.material;
+      const groundMesh = createModelMesh(engine, [-10, 0, -10, 10, 0, -10, -10, 0, 10, 10, 0, 10], [0, 2, 1, 1, 2, 3]);
+      meshShape.mesh = groundMesh;
+      staticCollider.addShape(meshShape);
+
+      const nativeShape = (meshShape as any)._nativeShape;
+      const destroySpy = vi.spyOn(nativeShape, "destroy");
+      const cooking = nativeShape._physXPhysics._pxCooking;
+      const originalCreateTriMesh = cooking.createTriMesh;
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        cooking.createTriMesh = () => null;
+        const replacementMesh = createModelMesh(engine, [-2, 0, -2, 2, 0, -2, -2, 0, 2, 2, 0, 2], [0, 2, 1, 1, 2, 3]);
+        meshShape.mesh = replacementMesh;
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to create triangle mesh"));
+        expect(meshShape.mesh).toBe(groundMesh);
+        expect((meshShape as any)._nativeShape).toBe(nativeShape);
+        expect((staticCollider as any)._nativeCollider._shapes).toEqual([nativeShape]);
+        expect(destroySpy).not.toHaveBeenCalled();
+      } finally {
+        cooking.createTriMesh = originalCreateTriMesh;
+        consoleErrorSpy.mockRestore();
+        destroySpy.mockRestore();
+        groundEntity.destroy();
+        meshMaterial?.destroy();
+      }
+    });
+
+    it("keeps the attached mesh and active trigger when replacement attachment fails", () => {
+      const entity = root.createChild("failedMeshReplacementAttachment");
+      const staticCollider = entity.addComponent(StaticCollider);
+      const meshShape = new MeshColliderShape();
+      const meshMaterial = meshShape.material;
+      meshShape.isConvex = true;
+      meshShape.isTrigger = true;
+      const oldMesh = createModelMesh(
+        engine,
+        [-1, -1, -1, 1, -1, -1, 1, 1, -1, -1, 1, -1, -1, -1, 1, 1, -1, 1, 1, 1, 1, -1, 1, 1]
+      );
+      meshShape.mesh = oldMesh;
+      staticCollider.addShape(meshShape);
+
+      const sphereEntity = root.createChild("replacementTriggerOverlap");
+      const dynamicCollider = sphereEntity.addComponent(DynamicCollider);
+      dynamicCollider.isKinematic = true;
+      const sphereShape = new SphereColliderShape();
+      const sphereMaterial = sphereShape.material;
+      sphereShape.radius = 0.25;
+      dynamicCollider.addShape(sphereShape);
+      const triggerScript = sphereEntity.addComponent(CollisionScript);
+      physicsScene._update(1 / 60);
+      expect(triggerScript.onTriggerEnter).toHaveBeenCalledTimes(1);
+
+      const oldNativeShape = (meshShape as any)._nativeShape;
+      const nativeCollider = (staticCollider as any)._nativeCollider;
+      const nativeScene = nativeCollider._scene;
+      const eventMap = nativeScene._physXManager._eventMap;
+      const eventSubMap = eventMap[meshShape.id];
+      const triggerEvent = eventSubMap[sphereShape.id];
+      const activeTriggers = nativeScene._activeTriggers;
+      const activeTriggerElements = activeTriggers._elements.slice(0, activeTriggers.length);
+      const oldDestroySpy = vi.spyOn(oldNativeShape, "destroy");
+      const actorAttachSpy = vi.spyOn(nativeCollider._pxActor, "attachShape").mockReturnValueOnce(false);
+      const actorDetachSpy = vi.spyOn(nativeCollider._pxActor, "detachShape");
+      const originalReplaceShape = nativeCollider.replaceShape.bind(nativeCollider);
+      let candidateNativeShape: any;
+      let candidateDestroySpy: any;
+      let attachError: unknown;
+      const replaceShapeSpy = vi.spyOn(nativeCollider, "replaceShape").mockImplementation((previousShape, newShape) => {
+        candidateNativeShape = newShape;
+        candidateDestroySpy = vi.spyOn(newShape, "destroy");
+        try {
+          originalReplaceShape(previousShape, newShape);
+        } catch (error) {
+          attachError = error;
+          throw error;
+        }
+      });
+
+      try {
+        const replacementMesh = createModelMesh(engine, [0, 2, 0, -2, -2, -2, 2, -2, -2, 0, -2, 2]);
+        let thrownError: unknown;
+        try {
+          meshShape.mesh = replacementMesh;
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBe(attachError);
+        expect(meshShape.mesh).toBe(oldMesh);
+        expect((meshShape as any)._nativeShape).toBe(oldNativeShape);
+        expect(nativeCollider._shapes).toEqual([oldNativeShape]);
+        expect(actorAttachSpy).toHaveBeenCalledTimes(1);
+        expect(actorAttachSpy).toHaveBeenCalledWith(candidateNativeShape._pxShape);
+        expect(actorDetachSpy).not.toHaveBeenCalled();
+        expect(eventMap[meshShape.id]).toBe(eventSubMap);
+        expect(eventSubMap[sphereShape.id]).toBe(triggerEvent);
+        expect(activeTriggers.length).toBe(activeTriggerElements.length);
+        expect(activeTriggers._elements.slice(0, activeTriggers.length)).toEqual(activeTriggerElements);
+        expect((Engine as any)._physicalObjectsMap[meshShape.id]).toBe(meshShape);
+        expect(oldDestroySpy).not.toHaveBeenCalled();
+        expect(candidateNativeShape).toBeDefined();
+        expect(candidateDestroySpy).toHaveBeenCalledTimes(1);
+
+        physicsScene._update(1 / 60);
+        expect(triggerScript.onTriggerEnter).toHaveBeenCalledTimes(1);
+        expect(triggerScript.onTriggerExit).not.toHaveBeenCalled();
+        expect(triggerScript.onTriggerStay).toHaveBeenCalled();
+      } finally {
+        replaceShapeSpy.mockRestore();
+        actorAttachSpy.mockRestore();
+        actorDetachSpy.mockRestore();
+        oldDestroySpy.mockRestore();
+        candidateDestroySpy?.mockRestore();
+        entity.destroy();
+        sphereEntity.destroy();
+        meshMaterial?.destroy();
+        sphereMaterial?.destroy();
+      }
     });
   });
 
@@ -558,7 +719,6 @@ describe("MeshColliderShape PhysX", () => {
         expect(collider.shapes).toHaveLength(0);
         expect(nativeCollider._shapes).toHaveLength(0);
         expect(shape.collider).toBeFalsy();
-        expect((shape as any)._isShapeAttached).toBe(false);
       } finally {
         attachSpy.mockRestore();
         entity.destroy();
@@ -659,7 +819,7 @@ describe("MeshColliderShape PhysX", () => {
       defaultMaterial?.destroy();
     });
 
-    it("should disable shape when switching to non-convex and mesh has no indices", () => {
+    it("should keep the convex shape when switching requires missing indices", () => {
       const warnSpy = vi.spyOn(console, "warn");
 
       const entity = root.createChild("switchConvexNoIndices");
@@ -677,15 +837,16 @@ describe("MeshColliderShape PhysX", () => {
       meshShape.mesh = mesh;
       staticCollider.addShape(meshShape);
 
-      // @ts-ignore
-      expect(meshShape._nativeShape).not.toBeNull();
+      const nativeShape = (meshShape as any)._nativeShape;
+      expect(nativeShape).not.toBeNull();
 
       // Switch to non-convex - should fail because no indices
       meshShape.isConvex = false;
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Non-convex mesh requires indices"));
-      // @ts-ignore - shape should be destroyed (failure = disable)
-      expect(meshShape._nativeShape).toBeNull();
+      expect(meshShape.isConvex).toBe(true);
+      expect((meshShape as any)._nativeShape).toBe(nativeShape);
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([nativeShape]);
 
       warnSpy.mockRestore();
       entity.destroy();
@@ -694,7 +855,7 @@ describe("MeshColliderShape PhysX", () => {
   });
 
   describe("Set Mesh Null", () => {
-    it("should destroy native shape when setting mesh to null", () => {
+    it("should detach the native shape when setting mesh to null", () => {
       const entity = root.createChild("nullMesh");
       const staticCollider = entity.addComponent(StaticCollider);
 
@@ -714,6 +875,7 @@ describe("MeshColliderShape PhysX", () => {
       // @ts-ignore
       expect(meshShape._nativeShape).toBeNull();
       expect(meshShape.mesh).toBeNull();
+      expect((staticCollider as any)._nativeCollider._shapes).toHaveLength(0);
 
       entity.destroy();
       defaultMaterial?.destroy();
@@ -750,7 +912,30 @@ describe("MeshColliderShape PhysX", () => {
   });
 
   describe("CookingFlags", () => {
-    it("should reuse existing native shape when changing cookingFlags", () => {
+    it("should switch to convex using cached data after mesh upload data is released", () => {
+      const entity = root.createChild("releasedMeshData");
+      const staticCollider = entity.addComponent(StaticCollider);
+      const meshShape = new MeshColliderShape();
+      const defaultMaterial = meshShape.material;
+      const mesh = createModelMesh(
+        engine,
+        [0, 1, 0, -1, 0, -1, 1, 0, -1, 0, 0, 1],
+        [0, 1, 2, 0, 2, 3, 0, 3, 1, 1, 3, 2]
+      );
+      meshShape.mesh = mesh;
+      staticCollider.addShape(meshShape);
+      mesh.uploadData(true);
+
+      meshShape.isConvex = true;
+
+      expect(meshShape.isConvex).toBe(true);
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([(meshShape as any)._nativeShape]);
+
+      entity.destroy();
+      defaultMaterial?.destroy();
+    });
+
+    it("should replace the native shape when changing cookingFlags", () => {
       const entity = root.createChild("cookingFlags");
       const staticCollider = entity.addComponent(StaticCollider);
 
@@ -765,11 +950,11 @@ describe("MeshColliderShape PhysX", () => {
       const nativeShapeBefore = meshShape._nativeShape;
       expect(nativeShapeBefore).not.toBeNull();
 
-      // Change cooking flags - should reuse existing shape via setMeshData
       meshShape.cookingFlags = MeshColliderShapeCookingFlag.Cleaning;
 
-      // @ts-ignore - same native shape instance (reused, not recreated)
-      expect(meshShape._nativeShape).toBe(nativeShapeBefore);
+      const nativeShapeAfter = (meshShape as any)._nativeShape;
+      expect(nativeShapeAfter).not.toBe(nativeShapeBefore);
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([nativeShapeAfter]);
 
       entity.destroy();
       defaultMaterial?.destroy();
@@ -847,6 +1032,45 @@ describe("MeshColliderShape PhysX", () => {
 
       entity.destroy();
       expect(meshA.refCount).toBe(0);
+    });
+
+    it("keeps a failed mesh clone empty without acquiring source ownership", () => {
+      const entity = root.createChild("failedMeshCloneSource");
+      const collider = entity.addComponent(StaticCollider);
+      const shape = new MeshColliderShape();
+      const material = shape.material;
+      const mesh = createModelMesh(engine, [-1, 0, -1, 1, 0, -1, 0, 0, 1], [0, 1, 2]);
+      shape.mesh = mesh;
+      collider.addShape(shape);
+
+      const nativeShape = (shape as any)._nativeShape;
+      const cooking = nativeShape._physXPhysics._pxCooking;
+      const originalCreateTriMesh = cooking.createTriMesh;
+      const sourceRefCount = mesh.refCount;
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let clone: Entity | null = null;
+
+      try {
+        cooking.createTriMesh = () => null;
+        clone = entity.clone();
+        const clonedCollider = clone.getComponent(StaticCollider);
+        const clonedShape = clonedCollider.shapes[0] as MeshColliderShape;
+
+        expect(clonedShape.mesh).toBeNull();
+        expect((clonedShape as any)._nativeShape).toBeNull();
+        expect((clonedShape as any)._positions).toBeNull();
+        expect((clonedShape as any)._indices).toBeNull();
+        expect((clonedCollider as any)._nativeCollider._shapes).toHaveLength(0);
+        expect(mesh.refCount).toBe(sourceRefCount);
+        expect(shape.mesh).toBe(mesh);
+        expect((shape as any)._nativeShape).toBe(nativeShape);
+      } finally {
+        cooking.createTriMesh = originalCreateTriMesh;
+        consoleErrorSpy.mockRestore();
+        clone?.destroy();
+        entity.destroy();
+        material?.destroy();
+      }
     });
   });
 });

--- a/tests/src/core/physics/MeshColliderShape.test.ts
+++ b/tests/src/core/physics/MeshColliderShape.test.ts
@@ -795,6 +795,32 @@ describe("MeshColliderShape PhysX", () => {
       defaultMaterial?.destroy();
     });
 
+    it("should switch to non-convex using cached indices after mesh data is released", () => {
+      const entity = root.createChild("releasedConvexMeshData");
+      const staticCollider = entity.addComponent(StaticCollider);
+      const meshShape = new MeshColliderShape();
+      const defaultMaterial = meshShape.material;
+      const mesh = createModelMesh(
+        engine,
+        [0, 1, 0, -1, 0, -1, 1, 0, -1, 0, 0, 1],
+        [0, 1, 2, 0, 2, 3, 0, 3, 1, 1, 3, 2]
+      );
+      meshShape.isConvex = true;
+      meshShape.mesh = mesh;
+      staticCollider.addShape(meshShape);
+      mesh.uploadData(true);
+      const nativeShape = (meshShape as any)._nativeShape;
+
+      meshShape.isConvex = false;
+
+      expect(meshShape.isConvex).toBe(false);
+      expect((meshShape as any)._nativeShape).not.toBe(nativeShape);
+      expect((staticCollider as any)._nativeCollider._shapes).toEqual([(meshShape as any)._nativeShape]);
+
+      entity.destroy();
+      defaultMaterial?.destroy();
+    });
+
     it("should keep the convex shape when switching requires missing indices", () => {
       const warnSpy = vi.spyOn(console, "warn");
 

--- a/tests/src/core/physics/PhysXPhysics.test.ts
+++ b/tests/src/core/physics/PhysXPhysics.test.ts
@@ -1,0 +1,44 @@
+import { BoxColliderShape, DynamicCollider, Engine } from "@galacean/engine-core";
+import { PhysXPhysics } from "@galacean/engine-physics-physx";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+describe("PhysXPhysics", () => {
+  let engine: Engine;
+  let physics: PhysXPhysics;
+
+  beforeAll(async () => {
+    physics = new PhysXPhysics({ tolerancesScale: { length: 2, speed: 20 } });
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas"), physics });
+  });
+
+  afterAll(() => {
+    engine.destroy();
+    physics.destroy();
+  });
+
+  it("validates and snapshots tolerancesScale at construction", () => {
+    expect(() => new PhysXPhysics({ tolerancesScale: { length: 0 } })).toThrow();
+    expect(() => new PhysXPhysics({ tolerancesScale: { length: null as unknown as number } })).toThrow();
+
+    const tolerancesScale = { length: 2, speed: 20 };
+    const uninitializedPhysics = new PhysXPhysics({ tolerancesScale });
+    tolerancesScale.length = 3;
+
+    expect(uninitializedPhysics.getDefaultContactOffset()).toBeCloseTo(0.04);
+  });
+
+  it("applies tolerancesScale to native physics and core defaults", () => {
+    const nativeScale = physics._pxPhysics.getTolerancesScale();
+    expect(nativeScale.length).toBeCloseTo(2);
+    expect(nativeScale.speed).toBeCloseTo(20);
+
+    const entity = engine.sceneManager.activeScene.createRootEntity("scaledDefaults");
+    const collider = entity.addComponent(DynamicCollider);
+    const shape = new BoxColliderShape();
+    collider.addShape(shape);
+
+    expect(shape.contactOffset).toBeCloseTo(0.04);
+    expect(collider.sleepThreshold).toBeCloseTo(0.02);
+  });
+});

--- a/tests/src/core/physics/PhysXPhysics.test.ts
+++ b/tests/src/core/physics/PhysXPhysics.test.ts
@@ -32,6 +32,7 @@ describe("PhysXPhysics", () => {
     const nativeScale = physics._pxPhysics.getTolerancesScale();
     expect(nativeScale.length).toBeCloseTo(2);
     expect(nativeScale.speed).toBeCloseTo(20);
+    expect(physics._pxCookingParams.meshWeldTolerance).toBeCloseTo(0.002);
 
     const entity = engine.sceneManager.activeScene.createRootEntity("scaledDefaults");
     const collider = entity.addComponent(DynamicCollider);
@@ -40,5 +41,22 @@ describe("PhysXPhysics", () => {
 
     expect(shape.contactOffset).toBeCloseTo(0.04);
     expect(collider.sleepThreshold).toBeCloseTo(0.02);
+  });
+
+  it("rejects non-finite contactOffset without changing the public value", () => {
+    const entity = engine.sceneManager.activeScene.createRootEntity("finiteContactOffset");
+    const collider = entity.addComponent(DynamicCollider);
+    const shape = new BoxColliderShape();
+    const material = shape.material;
+    collider.addShape(shape);
+    shape.contactOffset = 0.3;
+
+    for (const value of [NaN, Infinity, -Infinity]) {
+      expect(() => (shape.contactOffset = value)).toThrow();
+      expect(shape.contactOffset).toBe(0.3);
+    }
+
+    entity.destroy();
+    material.destroy();
   });
 });

--- a/tests/src/core/physics/PhysicsMaterial.test.ts
+++ b/tests/src/core/physics/PhysicsMaterial.test.ts
@@ -11,7 +11,7 @@ import {
 import { WebGLEngine } from "@galacean/engine";
 import { PhysXPhysics } from "@galacean/engine-physics-physx";
 import { Vector3 } from "@galacean/engine-math";
-import { describe, beforeAll, beforeEach, expect, it } from "vitest";
+import { describe, beforeAll, beforeEach, expect, it, vi } from "vitest";
 
 describe("PhysicsMaterial", () => {
   let rootEntity: Entity;
@@ -77,6 +77,24 @@ describe("PhysicsMaterial", () => {
     engine.sceneManager.activeScene.physics._update(2);
     expect(boxEntity.transform.position.y).greaterThan(0);
     expect(formatValue(boxEntity2.transform.position.y)).eq(0);
+  });
+
+  it("cloned collider shape shares material and releases its constructor material", () => {
+    const sourceEntity = addBox(new Vector3(1, 1, 1), StaticCollider, new Vector3());
+    const sourceMaterial = sourceEntity.getComponent(StaticCollider).shapes[0].material;
+    const destroySpy = vi.spyOn(PhysicsMaterial.prototype, "destroy");
+    const cloneEntity = sourceEntity.clone();
+    try {
+      const cloneMaterial = cloneEntity.getComponent(StaticCollider).shapes[0].material;
+      expect(cloneMaterial).toBe(sourceMaterial);
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+      expect(destroySpy.mock.instances[0]).not.toBe(sourceMaterial);
+    } finally {
+      destroySpy.mockRestore();
+      cloneEntity.destroy();
+      sourceEntity.destroy();
+      sourceMaterial.destroy();
+    }
   });
 
   it("bounceCombine Average", () => {


### PR DESCRIPTION
## Problem

Updating a `MeshColliderShape` could change the Core state before PhysX had successfully created and attached the replacement shape. If cooking or attachment failed, the public mesh, native attachment, trigger state, and resource ownership could disagree.

`PxShape::setGeometry()` cannot provide the transaction boundary we need: it does not report failure and cannot switch between convex and triangle geometry. Mesh candidates were also created at unit scale, and several related PhysX defaults and ownership paths were inconsistent.

## What changed

- Build a complete native mesh-shape candidate from cached mesh data, final world scale, material, pose, trigger/contact state, and cooking options.
- Attach and replace the candidate first, then commit the Core mesh/configuration state. A failure destroys only the candidate and leaves the previous shape untouched.
- Route convex/triangle changes and `mesh = null` through the same replacement owner; cached CPU data remains usable after `uploadData(true)`.
- Snapshot validated PhysX tolerance scales and derive scaled contact-offset and sleep-threshold defaults.
- Keep clone material ownership and material combine arguments consistent.
- Restrict `CharacterController` to supported box/capsule shapes, validate contact offset before attachment, and preserve it when the native controller is recreated.

## Scope

Engine Core, physics design contracts, and the PhysX adapter only. No `physX.js`, WASM, or CDN artifact changes.

## Verification

- `pnpm b:module`
- `pnpm b:types` (12 package projects)
- `HEADLESS=true pnpm vitest run tests/src/core/physics` (12 files, 221 tests)
- Mesh collider browser suite (32 tests)
- Visual E2E: `PhysX Mesh Collider` and `PhysX Mesh Collider Data`
- Prettier, ESLint (0 errors), and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added atomic collider shape replacement, preserving existing attachments when replacement fails.
  * Added configurable physics runtime URLs and publicly available physics tolerance options.
  * Physics defaults now apply automatically for contact offsets and sleep thresholds.

* **Bug Fixes**
  * Improved validation for collider shapes and contact offsets, rejecting unsupported or invalid values.
  * Fixed physics material combination settings and mesh collider scale handling.
  * Improved mesh replacement, cloning, cleanup, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->