### PR TITLE
fix(core): harden render pipeline resource lifecycle

### DIFF
--- a/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
+++ b/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
@@ -49,6 +49,7 @@ export class BasicRenderPipeline {
   private _copyBackgroundTexture: Texture2D;
   private _canUseBlitFrameBuffer = false;
   private _shouldCopyBackgroundColor = false;
+  private _destroyed = false;
 
   /**
    * Create a basic render pipeline.
@@ -69,7 +70,14 @@ export class BasicRenderPipeline {
    * Destroy internal resources.
    */
   destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
     this._cullingResults.destroy();
+    this._cascadedShadowCasterPass.release();
+    this._depthOnlyPass.release();
+    this._saoPass.destroy();
+    this._opaqueTexturePass.release();
+    this._finalPass.destroy();
 
     const pool = this._camera.engine._renderTargetPool;
 

--- a/packages/core/src/RenderPipeline/InstanceBuffer.ts
+++ b/packages/core/src/RenderPipeline/InstanceBuffer.ts
@@ -39,6 +39,9 @@ export class InstanceBuffer {
       this._intView = new Int32Array(this._data);
       this.buffer?.destroy();
       this.buffer = new Buffer(this._engine, BufferBindFlag.ConstantBuffer, totalBytes, BufferUsage.Dynamic);
+      // This buffer is owned by BatcherManager rather than a component reference.
+      // ResourceManager.gc() must not reclaim it while the render pipeline is active.
+      this.buffer.isGCIgnored = true;
     }
   }
 

--- a/packages/core/src/RenderPipeline/InstanceBuffer.ts
+++ b/packages/core/src/RenderPipeline/InstanceBuffer.ts
@@ -39,8 +39,6 @@ export class InstanceBuffer {
       this._intView = new Int32Array(this._data);
       this.buffer?.destroy();
       this.buffer = new Buffer(this._engine, BufferBindFlag.ConstantBuffer, totalBytes, BufferUsage.Dynamic);
-      // This buffer is owned by BatcherManager rather than a component reference.
-      // ResourceManager.gc() must not reclaim it while the render pipeline is active.
       this.buffer.isGCIgnored = true;
     }
   }

--- a/packages/core/src/RenderPipeline/OpaqueTexturePass.ts
+++ b/packages/core/src/RenderPipeline/OpaqueTexturePass.ts
@@ -51,4 +51,12 @@ export class OpaqueTexturePass extends PipelinePass {
     Blitter.blitTexture(this.engine, <Texture2D>this._cameraColorTexture, this._renderTarget);
     context.camera.shaderData.setTexture(Camera._cameraOpaqueTextureProperty, this._renderTarget.getColorTexture(0));
   }
+
+  release(): void {
+    if (this._renderTarget) {
+      this.engine._renderTargetPool.freeRenderTarget(this._renderTarget);
+      this._renderTarget = null;
+    }
+    this._cameraColorTexture = null;
+  }
 }

--- a/packages/core/src/RenderPipeline/RenderTargetPool.ts
+++ b/packages/core/src/RenderPipeline/RenderTargetPool.ts
@@ -121,11 +121,13 @@ export class RenderTargetPool {
 
   freeRenderTarget(renderTarget: RenderTarget): void {
     if (!renderTarget || renderTarget.destroyed) return;
+    if (this._freeRenderTargets.includes(renderTarget)) return;
     this._freeRenderTargets.push(renderTarget);
   }
 
   freeTexture(texture: Texture2D): void {
     if (!texture || texture.destroyed) return;
+    if (this._freeTextures.includes(texture)) return;
     this._freeTextures.push(texture);
   }
 

--- a/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
+++ b/packages/core/src/lighting/ambientOcclusion/ScalableAmbientObscurancePass.ts
@@ -44,6 +44,7 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
   private _offsetX = new Vector4();
   private _offsetY = new Vector4();
   private _quality: AmbientOcclusionQuality;
+  private _destroyed = false;
 
   constructor(engine: Engine) {
     super(engine);
@@ -167,6 +168,14 @@ export class ScalableAmbientObscurancePass extends PipelinePass {
       this._blurRenderTarget = null;
     }
     this._depthRenderTarget = null;
+  }
+
+  destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this.release();
+    this._material._addReferCount(-1);
+    this._material.destroy();
   }
 
   private _updateBlurKernel(blurShaderData: ShaderData, quality: AmbientOcclusionQuality): void {

--- a/packages/core/src/postProcess/FinalPass.ts
+++ b/packages/core/src/postProcess/FinalPass.ts
@@ -18,6 +18,7 @@ export class FinalPass extends PipelinePass {
   private _srgbRenderTarget: RenderTarget;
   private _antiAliasingMaterial: Material;
   private _sRGBmaterial: Material;
+  private _destroyed = false;
 
   constructor(engine: Engine) {
     super(engine);
@@ -79,5 +80,15 @@ export class FinalPass extends PipelinePass {
       this._srgbRenderTarget = null;
     }
     this._inputRenderTarget = null;
+  }
+
+  destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this.release();
+    this._sRGBmaterial._addReferCount(-1);
+    this._sRGBmaterial.destroy();
+    this._antiAliasingMaterial._addReferCount(-1);
+    this._antiAliasingMaterial.destroy();
   }
 }

--- a/packages/core/src/shadow/CascadedShadowCasterPass.ts
+++ b/packages/core/src/shadow/CascadedShadowCasterPass.ts
@@ -80,6 +80,18 @@ export class CascadedShadowCasterPass extends PipelinePass {
     this._updateReceiversShaderData(light);
   }
 
+  release(): void {
+    const renderTarget = this._renderTarget;
+    if (!renderTarget) return;
+    const sceneShaderData = this._camera.scene.shaderData;
+    if (sceneShaderData.getTexture(CascadedShadowCasterPass._shadowMapsProperty) === this._depthTexture) {
+      sceneShaderData.setTexture(CascadedShadowCasterPass._shadowMapsProperty, null);
+    }
+    this.engine._renderTargetPool.freeRenderTarget(renderTarget);
+    this._renderTarget = null;
+    this._depthTexture = null;
+  }
+
   private _renderDirectShadowMap(context: RenderContext, light: DirectLight): void {
     const {
       engine,
@@ -264,7 +276,7 @@ export class CascadedShadowCasterPass extends PipelinePass {
     }
 
     // set zero matrix to project the index out of max cascade
-    for (var i = shadowCascades * 16, n = shadowMatrices.length; i < n; i++) {
+    for (let i = shadowCascades * 16, n = shadowMatrices.length; i < n; i++) {
       shadowMatrices[i] = 0.0;
     }
 
@@ -352,8 +364,6 @@ export class CascadedShadowCasterPass extends PipelinePass {
           shadowCascades == ShadowCascadesMode.TwoCascades ? shadowTileResolution : shadowTileResolution * 2;
         this._shadowMapSize.set(1.0 / width, 1.0 / height, width, height);
       }
-
-      this._renderTarget = null;
 
       const viewportOffset = this._viewportOffsets;
       const shadowTileResolution = this._shadowTileResolution;

--- a/tests/src/core/Camera.test.ts
+++ b/tests/src/core/Camera.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@galacean/engine-core";
 import { Matrix, Ray, Vector2, Vector3, Vector4 } from "@galacean/engine-math";
 import { WebGLEngine } from "@galacean/engine";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 describe("camera test", function () {
   const canvasDOM = new OffscreenCanvas(256, 256);
@@ -124,6 +124,33 @@ describe("camera test", function () {
     expect(camera.enableHDR).to.eq(true);
     // @ts-ignore
     expect(camera._isIndependentCanvasEnabled()).to.eq(true);
+  });
+
+  it("releases every owned render pass and material when destroyed", () => {
+    const entity = engine.sceneManager.scenes[0].createRootEntity("pipeline-lifecycle-camera");
+    const lifecycleCamera = entity.addComponent(Camera);
+    const pipeline = lifecycleCamera["_renderPipeline"];
+    const cascadedShadowPass = pipeline["_cascadedShadowCasterPass"];
+    const depthOnlyPass = pipeline["_depthOnlyPass"];
+    const saoPass = pipeline["_saoPass"];
+    const opaqueTexturePass = pipeline["_opaqueTexturePass"];
+    const finalPass = pipeline["_finalPass"];
+    const releaseSpies = [
+      vi.spyOn(cascadedShadowPass, "release"),
+      vi.spyOn(depthOnlyPass, "release"),
+      vi.spyOn(opaqueTexturePass, "release")
+    ];
+    const saoMaterial = saoPass["_material"];
+    const finalSrgbMaterial = finalPass["_sRGBmaterial"];
+    const finalAntiAliasingMaterial = finalPass["_antiAliasingMaterial"];
+
+    lifecycleCamera.destroy();
+
+    for (const releaseSpy of releaseSpies) expect(releaseSpy).toHaveBeenCalledOnce();
+    expect(saoMaterial.destroyed).to.eq(true);
+    expect(finalSrgbMaterial.destroyed).to.eq(true);
+    expect(finalAntiAliasingMaterial.destroyed).to.eq(true);
+    entity.destroy();
   });
 
   it("view matrix", () => {

--- a/tests/src/core/RenderPipeline/InstanceBuffer.test.ts
+++ b/tests/src/core/RenderPipeline/InstanceBuffer.test.ts
@@ -1,0 +1,25 @@
+import { WebGLEngine } from "@galacean/engine";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("InstanceBuffer", () => {
+  let engine: WebGLEngine | undefined;
+
+  afterEach(() => {
+    engine?.destroy();
+    engine = undefined;
+  });
+
+  it("keeps its engine-owned buffer alive across resource-manager garbage collection", async () => {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+    const instanceBuffer = engine._batcherManager.instanceBuffer;
+    instanceBuffer.setLayout({ instanceFields: [], instanceMaxCount: 1, structSize: 16 });
+    const buffer = instanceBuffer.buffer;
+
+    engine.resourceManager.gc();
+
+    expect(buffer.destroyed).toBe(false);
+
+    engine._batcherManager.destroy();
+    expect(buffer.destroyed).toBe(true);
+  });
+});

--- a/tests/src/core/RenderPipeline/RenderTargetPool.test.ts
+++ b/tests/src/core/RenderPipeline/RenderTargetPool.test.ts
@@ -96,6 +96,17 @@ describe("RenderTargetPool", () => {
       const c = alloc(pool, 1024, 768);
       expect(c).to.equal(a);
     });
+
+    it("ignores duplicate render-target returns instead of leasing one target twice", () => {
+      const a = alloc(pool, 320, 180);
+      pool.freeRenderTarget(a);
+      pool.freeRenderTarget(a);
+
+      const first = alloc(pool, 320, 180);
+      const second = alloc(pool, 320, 180);
+      expect(first).to.equal(a);
+      expect(second).not.to.equal(a);
+    });
   });
 
   describe("texture free-list", () => {
@@ -108,6 +119,17 @@ describe("RenderTargetPool", () => {
       pool.freeTexture(b);
       const c = allocTex(pool, 64, 64);
       expect(c).to.not.equal(a);
+    });
+
+    it("ignores duplicate texture returns instead of leasing one texture twice", () => {
+      const a = allocTex(pool, 96, 96);
+      pool.freeTexture(a);
+      pool.freeTexture(a);
+
+      const first = allocTex(pool, 96, 96);
+      const second = allocTex(pool, 96, 96);
+      expect(first).to.equal(a);
+      expect(second).not.to.equal(a);
     });
   });
 


### PR DESCRIPTION
## Summary

- keep the render pipeline's engine-owned instance buffer alive during ordinary resource-manager garbage collection
- release camera-owned render passes, pooled render targets, pooled textures, and internal materials when `BasicRenderPipeline` is destroyed
- return the previous cascaded-shadow render target to the pool when shadow settings change
- reject duplicate render-target and texture returns so the pool cannot lease one resource to two consumers
- add focused Chromium regression coverage for GC retention, camera teardown, and pool deduplication

## Root causes

### Instance buffer lifetime

`InstanceBuffer` retained its GPU `Buffer` through a plain engine-owned field, so it had no component reference count. Because the buffer was not excluded from ordinary resource GC, `ResourceManager.gc()` could destroy it while the render pipeline still held and reused the wrapper. The next upload then reached a destroyed `GLBuffer`, causing repeated `bindBuffer` failures and WebGL context loss.

### Camera pipeline teardown

`BasicRenderPipeline.destroy()` previously released only its culling results and two top-level pooled resources. Camera-owned shadow, depth, SAO, opaque-texture, and final passes could therefore retain render targets or internal materials after camera destruction. In addition, the shadow pass discarded its current render-target reference before `PipelineUtils.recreateRenderTargetIfNeeded()` could return an incompatible target to the pool, and the pool accepted duplicate returns of the same object.

## Ownership boundaries

- `ResourceManager.gc()` must not reclaim engine-owned buffers that remain active in the render pipeline.
- `Camera` owns its `BasicRenderPipeline`; destroying the camera releases every resource owned by that pipeline exactly once.
- `RenderTargetPool` owns reuse after a resource is returned and ignores duplicate returns; it remains responsible for destroying pooled resources during pool GC or engine teardown.
- Explicit `BatcherManager.destroy()` and engine teardown still destroy the instance buffer.

## Validation

- `pnpm run b:module`
- `HEADLESS=true pnpm exec vitest run tests/src/core/RenderPipeline/InstanceBuffer.test.ts tests/src/core/RenderPipeline/RenderTargetPool.test.ts tests/src/core/Camera.test.ts` (3 files, 32 tests)
- `pnpm run b:types`
- `git diff --check origin/dev/2.0...HEAD`
- `git merge-tree --write-tree origin/dev/2.0 HEAD` (clean virtual merge)

Fixes #3064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented actively used rendering instance buffers from being reclaimed during cleanup.
  * Improved render-pipeline pass teardown to be idempotent and ensure render targets and materials are properly released/destroyed.
  * Updated render-target pool to avoid duplicate entries when resources are freed multiple times.
* **Tests**
  * Added and expanded test coverage to confirm instance buffers remain alive after garbage collection and are destroyed during pipeline teardown.
  * Added tests for render-target pool behavior when freeing the same items repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->