### PR TITLE
feat(particle): add collection clear APIs

### DIFF
--- a/packages/core/src/particle/modules/CustomDataModule.ts
+++ b/packages/core/src/particle/modules/CustomDataModule.ts
@@ -187,6 +187,18 @@ export class CustomDataModule extends ParticleGeneratorModule {
   }
 
   /**
+   * Remove all custom data streams.
+   */
+  clear(): void {
+    for (const name of this._curves.keys()) {
+      this.removeCurve(name);
+    }
+    for (const name of this._gradients.keys()) {
+      this.removeGradient(name);
+    }
+  }
+
+  /**
    * @internal
    */
   _cloneTo(target: CustomDataModule): void {

--- a/packages/core/src/particle/modules/CustomDataModule.ts
+++ b/packages/core/src/particle/modules/CustomDataModule.ts
@@ -190,12 +190,19 @@ export class CustomDataModule extends ParticleGeneratorModule {
    * Remove all custom data streams.
    */
   clear(): void {
-    for (const name of this._curves.keys()) {
-      this.removeCurve(name);
+    const shaderData = this._generator._renderer.shaderData;
+    const curveStreams = this._curveStreams;
+    for (let i = 0, n = curveStreams.length; i < n; i++) {
+      this._zeroCurveUniforms(shaderData, curveStreams[i]);
     }
-    for (const name of this._gradients.keys()) {
-      this.removeGradient(name);
+    const gradientStreams = this._gradientStreams;
+    for (let i = 0, n = gradientStreams.length; i < n; i++) {
+      this._zeroGradientUniforms(shaderData, gradientStreams[i]);
     }
+    this._curves.clear();
+    this._gradients.clear();
+    curveStreams.length = 0;
+    gradientStreams.length = 0;
   }
 
   /**

--- a/packages/core/src/particle/modules/SubEmittersModule.ts
+++ b/packages/core/src/particle/modules/SubEmittersModule.ts
@@ -95,6 +95,17 @@ export class SubEmittersModule extends ParticleGeneratorModule {
     this._generator._setTransformFeedback();
   }
 
+  /**
+   * Remove all sub-emitter slots.
+   */
+  clear(): void {
+    if (this._subEmitters.length === 0) {
+      return;
+    }
+    this._subEmitters.length = 0;
+    this._generator._setTransformFeedback();
+  }
+
   override get enabled(): boolean {
     return this._enabled && this._generator._renderer.engine._hardwareRenderer.isWebGL2;
   }

--- a/tests/src/core/particle/CustomData.test.ts
+++ b/tests/src/core/particle/CustomData.test.ts
@@ -165,13 +165,27 @@ describe("CustomDataModule", function () {
 
   it("clear removes every stream", function () {
     const customData = particleRenderer.generator.customData;
-    customData.addCurve("A", new ParticleCompositeCurve(1));
-    customData.addGradient("B", new ParticleCompositeGradient(new Color()));
+    const shaderData = particleRenderer.shaderData;
+    customData.enabled = true;
+    customData.addCurve("ClearCurveA", new ParticleCompositeCurve(1));
+    customData.addCurve("ClearCurveB", new ParticleCompositeCurve(2));
+    customData.addGradient("ClearGradientA", new ParticleCompositeGradient(new Color(1, 0, 0, 1)));
+    customData.addGradient("ClearGradientB", new ParticleCompositeGradient(new Color(0, 1, 0, 1)));
+    //@ts-ignore - drive the upload directly
+    customData._updateShaderData(shaderData);
 
     customData.clear();
 
     expect(customData.curves.size).to.eq(0);
     expect(customData.gradients.size).to.eq(0);
+    //@ts-ignore - removed streams must not upload again
+    customData._updateShaderData(shaderData);
+    expect(shaderData.getFloat("renderer_ClearCurveAMaxConst")).to.eq(0);
+    expect(shaderData.getFloat("renderer_ClearCurveBMaxConst")).to.eq(0);
+    expect(shaderData.getColor("renderer_ClearGradientAMaxConst")).to.deep.eq(new Color(0, 0, 0, 0));
+    expect(shaderData.getColor("renderer_ClearGradientBMaxConst")).to.deep.eq(new Color(0, 0, 0, 0));
+
+    customData.clear();
   });
 
   it("removeCurve / removeGradient zero out shaderData uniforms", function () {

--- a/tests/src/core/particle/CustomData.test.ts
+++ b/tests/src/core/particle/CustomData.test.ts
@@ -163,6 +163,17 @@ describe("CustomDataModule", function () {
     expect(customData.gradients.size).to.eq(0);
   });
 
+  it("clear removes every stream", function () {
+    const customData = particleRenderer.generator.customData;
+    customData.addCurve("A", new ParticleCompositeCurve(1));
+    customData.addGradient("B", new ParticleCompositeGradient(new Color()));
+
+    customData.clear();
+
+    expect(customData.curves.size).to.eq(0);
+    expect(customData.gradients.size).to.eq(0);
+  });
+
   it("removeCurve / removeGradient zero out shaderData uniforms", function () {
     const customData = particleRenderer.generator.customData;
     const shaderData = particleRenderer.shaderData;

--- a/tests/src/core/particle/SubEmitter.test.ts
+++ b/tests/src/core/particle/SubEmitter.test.ts
@@ -90,6 +90,23 @@ describe("SubEmitter", () => {
     child.entity.destroy();
   });
 
+  it("clear removes every sub-emitter slot", () => {
+    const parent = createParticleRenderer(engine, "Parent_Clear");
+    const child = createParticleRenderer(engine, "Child_Clear");
+
+    parent.generator.subEmitters.enabled = true;
+    parent.generator.subEmitters.addSubEmitter(child, ParticleSubEmitterType.Death);
+    expect((parent.generator as any)._useTransformFeedback).to.equal(true);
+
+    parent.generator.subEmitters.clear();
+
+    expect(parent.generator.subEmitters.subEmitters).to.have.length(0);
+    expect((parent.generator as any)._useTransformFeedback).to.equal(false);
+
+    parent.entity.destroy();
+    child.entity.destroy();
+  });
+
   it("Sub system's own EmissionModule does not double-fire when sub-emit drives it", () => {
     // The target renderer has its own t=0 burst AND is auto-playing on enable.
     // The slot must NOT read that burst and re-fire — sub system's own emission


### PR DESCRIPTION
## Summary

- add `clear()` to `SubEmittersModule`
- add `clear()` to `CustomDataModule`
- preserve each module cleanup semantics while removing all entries

## Why `clear` is required

Runtime-v2 Prefab `componentProps` overrides are applied after the referenced Prefab has been instantiated, so the target component may already contain inherited collection entries.

Source-v2 collection semantics distinguish three states:

- field absent: preserve the inherited collection
- field present with `[]`: replace it with an empty collection
- field present with entries: replace it with exactly those entries

Builder can encode fixed method calls, but it cannot iterate an inherited runtime collection. Add-only output therefore cannot represent an authored empty collection and turns non-empty overrides into append operations. Correct replacement requires `clear` followed by the authored `add` calls.

The collection-owning Engine modules must perform the clear because removal has module-specific side effects: sub-emitters must refresh transform-feedback state, while custom data must clear shader uniforms and its parallel stream bookkeeping. Builder-side private mutation or reconstruction of inherited state would bypass those invariants.

Removing a reference from source Prefab data does not remove references already held by an instantiated runtime component. GC only reclaims objects after the runtime collection releases them; it does not reconcile source overrides with live component state or update transform-feedback and shader state. `clear()` performs that runtime mutation without destroying referenced emitter entities, which remain owned by the scene hierarchy.

## Verification

- `pnpm build`
- `pnpm exec vitest run tests/src/core/particle/SubEmitter.test.ts tests/src/core/particle/CustomData.test.ts` — 42 tests passed
- linked this Engine build with the current Editor resource package compiler and rendered/replayed `energy-core-burst.package` with no browser warnings or errors

## Consumer

Required by galacean/editor#3805 for source-v2 particle collection overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to clear all custom particle data streams at once.
  * Added the ability to remove all configured sub-emitters at once.
  * Clearing sub-emitters now refreshes particle rendering state automatically.

* **Tests**
  * Added coverage verifying custom data and sub-emitter cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

