### PR TITLE
fix(loader): preserve physical URLs for virtual assets

### DIFF
--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -11,6 +11,14 @@ export type LoadItem = {
    */
   type?: string;
   /**
+   * Physical URL resolved by ResourceManager for a virtual resource.
+   *
+   * Loader implementations can use this URL for file-format detection and
+   * resolving files addressed relative to the loaded asset. Callers provide
+   * `url`; ResourceManager owns this resolved value.
+   */
+  resolvedUrl?: string;
+  /**
    * Number of retries after failed loading.
    */
   retryCount?: number;

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -367,6 +367,7 @@ export class ResourceManager {
         ? Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL)
         : assetBaseURL;
     const remoteAssetBaseURL = virtualResourceEntry?.path ?? item.url;
+    item.resolvedUrl = remoteAssetBaseURL;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];

--- a/packages/loader/src/ShaderLoader.ts
+++ b/packages/loader/src/ShaderLoader.ts
@@ -11,7 +11,9 @@ import {
 @resourceLoader(AssetType.Shader, ["shader", "shaderc"])
 class ShaderLoader extends Loader<Shader> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Shader> {
-    const url = item.url!;
+    // Virtual paths preserve source identity (for example `.shader`), while
+    // the physical path determines how this file is encoded (`.shaderc`).
+    const url = item.resolvedUrl ?? item.url!;
 
     if (url.endsWith(".shaderc")) {
       // @ts-ignore

--- a/packages/loader/src/SpriteAtlasLoader.ts
+++ b/packages/loader/src/SpriteAtlasLoader.ts
@@ -21,6 +21,9 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
   private _tempVec4: Vector4 = new Vector4();
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<SpriteAtlas> {
     return new AssetPromise<SpriteAtlas>((resolve, reject, _, __, onCancel) => {
+      // Atlas pages are runtime files addressed relative to the encoded atlas,
+      // not to the editor-facing virtual resource identity.
+      const atlasUrl = item.resolvedUrl ?? item.url!;
       const chainPromises = [];
       onCancel(() => {
         for (let i = 0; i < chainPromises.length; i++) {
@@ -28,7 +31,7 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
         }
       });
       // @ts-ignore
-      const configPromise = resourceManager._request<AtlasConfig>(item.url, {
+      const configPromise = resourceManager._request<AtlasConfig>(atlasUrl, {
         ...item,
         type: "json"
       });
@@ -50,7 +53,7 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
               chainPromises.push(
                 resourceManager
                   .load<Texture2D>({
-                    url: Utils.resolveAbsoluteUrl(item.url, atlasItem.img),
+                    url: Utils.resolveAbsoluteUrl(atlasUrl, atlasItem.img),
                     type: atlasItem.type ?? AssetType.Texture,
                     params: { format, mipmap }
                   })

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -128,6 +128,25 @@ describe("ResourceManager", () => {
       loaderSpy.mockRestore();
     });
 
+    it("provides loaders the physical URL while preserving the virtual resource identity", () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Assets/precompiled-shader";
+      const physicalPath = "/Assets/precompiled-shader.shaderc";
+      resourceManager.initVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Shader }]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Shader], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      resourceManager.load({ url: virtualPath });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      const [loadItem] = loaderSpy.mock.calls[0];
+      expect(loadItem.url).equal(virtualPath);
+      expect(loadItem.resolvedUrl).equal(physicalPath);
+      loaderSpy.mockRestore();
+    });
+
     it("fills params from virtualPathResourceMap when params is omitted", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.initVirtualResources([

--- a/tests/src/loader/ShaderLoader.test.ts
+++ b/tests/src/loader/ShaderLoader.test.ts
@@ -1,0 +1,33 @@
+import { AssetPromise, AssetType, ResourceManager, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("ShaderLoader", () => {
+  it("loads a precompiled Shader from its physical .shaderc path", () => {
+    const virtualPath = "Shader/Migrated/outline.shader";
+    const physicalPath = "/Shader/Migrated/outline.shaderc";
+    const requestSpy = vi.spyOn(engine.resourceManager as any, "_request").mockReturnValue(new AssetPromise(() => {}));
+
+    try {
+      // @ts-ignore - loaders are registered in ResourceManager's internal registry.
+      ResourceManager._loaders[AssetType.Shader].load(
+        { url: virtualPath, resolvedUrl: physicalPath },
+        engine.resourceManager
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(physicalPath, expect.objectContaining({ type: "json" }));
+    } finally {
+      requestSpy.mockRestore();
+    }
+  });
+});

--- a/tests/src/loader/SpriteAtlasLoader.test.ts
+++ b/tests/src/loader/SpriteAtlasLoader.test.ts
@@ -1,0 +1,44 @@
+import { AssetPromise, AssetType, ResourceManager, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("SpriteAtlasLoader", () => {
+  it("resolves prepacked SpriteAtlas pages from the physical atlas directory", async () => {
+    const virtualPath = "SpriteAtlas/Migrated/ui.atlas";
+    const physicalPath = "/SpriteAtlas/Migrated/ui.atlas";
+    const requestSpy = vi.spyOn(engine.resourceManager as any, "_request").mockReturnValue(
+      new AssetPromise((resolve) => {
+        resolve({ atlasItems: [{ img: "./ui_image_0.tex", sprites: [] }] });
+      })
+    );
+    const loadSpy = vi
+      .spyOn(engine.resourceManager, "load")
+      .mockReturnValue(new AssetPromise((resolve) => resolve({} as any)) as any);
+
+    try {
+      // @ts-ignore - loaders are registered in ResourceManager's internal registry.
+      await ResourceManager._loaders[AssetType.SpriteAtlas].load(
+        { url: virtualPath, resolvedUrl: physicalPath },
+        engine.resourceManager
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(physicalPath, expect.objectContaining({ type: "json" }));
+      expect(loadSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "/SpriteAtlas/Migrated/ui_image_0.tex", type: AssetType.Texture })
+      );
+    } finally {
+      requestSpy.mockRestore();
+      loadSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## What

Preserves the physical file URL alongside an editor-facing virtual resource URL, then uses the physical URL for shader format detection and SpriteAtlas page resolution.

## Why

Virtual resource identity may be extensionless or point to a logical path, while the emitted runtime file is a `.shaderc` file or has atlas pages relative to its physical directory. Loaders previously used the virtual URL for both concerns.

## Validation

- `pnpm vitest run tests/src/core/resource/ResourceManager.test.ts tests/src/loader/ShaderLoader.test.ts tests/src/loader/SpriteAtlasLoader.test.ts`
- 3 files passed, 19 tests passed.

## Branch hygiene

The prior direct change was reverted from `feat/migrate-2.0` in `4dab08da5`; this PR reintroduces it through the normal review path.