### PR TITLE
fix(loader): preserve virtual resource identity in Editor Preview

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-e2e",
   "private": true,
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "license": "MIT",
   "scripts": {
     "case": "vite serve .dev --config .dev/vite.config.js",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-examples",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "private": true,
   "license": "MIT",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-root",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "packageManager": "pnpm@9.3.0",
   "private": true,
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-core",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -82,10 +82,16 @@ export class Utils {
       return relativeUrl ? new URL(relativeUrl, baseUrl).href : baseUrl;
     }
 
-    const head = "file://";
-    const encodedBaseUrl = head + this._encodePathComponents(baseUrl);
+    // A relative virtual asset path (for example `SpriteAtlas/...`) must be
+    // treated as a path, not as the host portion of a file URL. The latter
+    // lowercases the first segment and breaks case-sensitive virtual-resource
+    // lookup in Editor previews
+    const resolvedHasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
+    const head = "file:///";
+    const encodedBaseUrl = head + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));
     const encodedRelativeUrl = this._encodePathComponents(relativeUrl);
-    return decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).href.slice(head.length));
+    const resolvedPath = decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).href.slice(head.length));
+    return resolvedHasLeadingSlash ? `/${resolvedPath}` : resolvedPath;
   }
 
   /**
@@ -134,7 +140,7 @@ export class Utils {
    * @param path - The path of the property to get.
    * @returns Returns the resolved value.
    */
-  static _reflectGet(target: Object, path: string) {
+  static _reflectGet(target: object, path: string) {
     const pathArr = this._stringToPath(path);
 
     let object = target;

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,7 +28,8 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Loading url.
+   * Requested resource identity. Virtual resources keep their virtual path so
+   * loaders can resolve dependent resources through ResourceManager.
    */
   url: string;
   /**

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -346,12 +346,15 @@ export class ResourceManager {
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // Not absolute and base url is set
-    item.url =
-      !Utils.isAbsoluteUrl(assetBaseURL) && this.baseUrl
-        ? Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL)
-        : assetBaseURL;
-    const remoteAssetBaseURL = virtualResourceEntry?.path ?? item.url;
+    // Keep a virtual resource's logical identity so loaders can resolve its
+    // sibling resources through the virtual-resource map. `baseUrl` only
+    // resolves ordinary relative transport URLs
+    const loadItemUrl =
+      virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
+        ? assetBaseURL
+        : Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL);
+    item.url = loadItemUrl;
+    const remoteAssetBaseURL = virtualResourceEntry?.path ?? loadItemUrl;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-design",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/galacean/package.json
+++ b/packages/galacean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-loader",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/loader/src/TextureLoader.ts
+++ b/packages/loader/src/TextureLoader.ts
@@ -72,39 +72,29 @@ class TextureLoader extends Loader<Texture> {
   }
 
   private _decodeImage(buffer: ArrayBuffer, item: LoadItem, resourceManager: ResourceManager): AssetPromise<Texture2D> {
-    return new AssetPromise((resolve, reject) => {
-      const blob = new Blob([buffer]);
-      const img = new Image();
-      img.onload = () => {
-        URL.revokeObjectURL(img.src);
-        const {
-          format = TextureFormat.R8G8B8A8,
-          isSRGBColorSpace = true,
-          mipmap = true
-        } = (item.params as Partial<TextureParams>) ?? {};
+    return decodeImage(buffer, item.url!).then((img) => {
+      const {
+        format = TextureFormat.R8G8B8A8,
+        isSRGBColorSpace = true,
+        mipmap = true
+      } = (item.params as Partial<TextureParams>) ?? {};
 
-        const engine = resourceManager.engine;
-        const { width, height } = img;
-        const generateMipmap = TextureUtils.supportGenerateMipmapsWithCorrection(
-          engine,
-          width,
-          height,
-          format,
-          mipmap,
-          isSRGBColorSpace
-        );
+      const engine = resourceManager.engine;
+      const { width, height } = img;
+      const generateMipmap = TextureUtils.supportGenerateMipmapsWithCorrection(
+        engine,
+        width,
+        height,
+        format,
+        mipmap,
+        isSRGBColorSpace
+      );
 
-        const texture = new Texture2D(engine, width, height, format, generateMipmap, isSRGBColorSpace);
-        texture.setImageSource(img);
-        generateMipmap && texture.generateMipmaps();
-        this._applyParams(texture, item);
-        resolve(texture);
-      };
-      img.onerror = (e) => {
-        URL.revokeObjectURL(img.src);
-        reject(e);
-      };
-      img.src = URL.createObjectURL(blob);
+      const texture = new Texture2D(engine, width, height, format, generateMipmap, isSRGBColorSpace);
+      texture.setImageSource(img);
+      generateMipmap && texture.generateMipmaps();
+      this._applyParams(texture, item);
+      return texture;
     });
   }
 
@@ -151,24 +141,31 @@ class TextureContentRestorer extends ContentRestorer<Texture> {
             return texture;
           }
 
-          return new AssetPromise<Texture>((resolve, reject) => {
-            const blob = new Blob([buffer]);
-            const img = new Image();
-            img.onload = () => {
-              URL.revokeObjectURL(img.src);
-              texture.setImageSource(img);
-              texture.mipmapCount > 1 && texture.generateMipmaps();
-              resolve(texture);
-            };
-            img.onerror = (e) => {
-              URL.revokeObjectURL(img.src);
-              reject(e);
-            };
-            img.src = URL.createObjectURL(blob);
+          return decodeImage(buffer, this.url).then((img) => {
+            texture.setImageSource(img);
+            texture.mipmapCount > 1 && texture.generateMipmaps();
+            return texture;
           });
         })
     );
   }
+}
+
+function decodeImage(buffer: ArrayBuffer, url: string): AssetPromise<HTMLImageElement> {
+  return new AssetPromise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(new Blob([buffer]));
+    const image = new Image();
+    const releaseObjectUrl = () => URL.revokeObjectURL(objectUrl);
+    image.onload = () => {
+      releaseObjectUrl();
+      resolve(image);
+    };
+    image.onerror = () => {
+      releaseObjectUrl();
+      reject(new Error(`TextureLoader: failed to decode texture "${url}" (${buffer.byteLength} bytes).`));
+    };
+    image.src = objectUrl;
+  });
 }
 
 /**

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-math",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-physics-physx",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/rhi-webgl/package.json
+++ b/packages/rhi-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-rhi-webgl",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "repository": {
     "url": "https://github.com/galacean/engine.git"
   },

--- a/packages/shader-compiler/package.json
+++ b/packages/shader-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-shader-compiler",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/shader/package.json
+++ b/packages/shader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-shader",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/spine-core-3.8/package.json
+++ b/packages/spine-core-3.8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-spine-core-3.8",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/spine-core-4.2/package.json
+++ b/packages/spine-core-4.2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-spine-core-4.2",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/spine/package.json
+++ b/packages/spine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-spine",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-ui",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr-webxr/package.json
+++ b/packages/xr-webxr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr-webxr",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr",
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-tests",
   "private": true,
-  "version": "0.0.0-experimental-2.0-migrate.4",
+  "version": "0.0.0-experimental-2.0-migrate.6",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/tests/src/core/Utils.test.ts
+++ b/tests/src/core/Utils.test.ts
@@ -28,20 +28,22 @@ describe("Utils test", function () {
       "https://www.galacean.com/texture.png"
     );
 
-    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "file.html")).to.equal(
-      "/path/to/file.html"
-    );
+    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "file.html")).to.equal("/path/to/file.html");
 
-    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "../file.html")).to.equal(
-      "/path/file.html"
-    );
+    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "../file.html")).to.equal("/path/file.html");
 
-    expect(Utils.resolveAbsoluteUrl("/a/b", "./空 格")).to.equal(
-      "/a/空 格"
-    );
+    expect(Utils.resolveAbsoluteUrl("/a/b", "./空 格")).to.equal("/a/空 格");
 
     expect(Utils.resolveAbsoluteUrl("/a c%/中%20文/test1/test2", "../空 格/测%试.json")).to.equal(
       "/a c%/中%20文/空 格/测%试.json"
+    );
+
+    expect(Utils.resolveAbsoluteUrl("SpriteAtlas/Art/UI/auto-atlas.atlas", "./auto-atlas_image_0.tex")).to.equal(
+      "SpriteAtlas/Art/UI/auto-atlas_image_0.tex"
+    );
+
+    expect(Utils.resolveAbsoluteUrl("SpriteAtlas/Art/UI/auto-atlas.atlas", "/Shared/page.tex")).to.equal(
+      "/Shared/page.tex"
     );
 
     const base64Url = "data:application/octet-stream;base64,AAAAAImICD2JiIg9zczMPYmICD6rqio";

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -183,6 +183,28 @@ describe("ResourceManager", () => {
       }
     });
 
+    it("preserves the virtual resource identity for loaders", () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Assets/precompiled-shader";
+      const physicalPath = "/Assets/precompiled-shader.shaderc";
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Shader }]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Shader], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      try {
+        resourceManager.load({ url: virtualPath });
+
+        expect(loaderSpy).toHaveBeenCalled();
+        const [loadItem] = loaderSpy.mock.calls[0];
+        expect(loadItem.url).equal(virtualPath);
+        expect(loadItem).not.toHaveProperty("resolvedUrl");
+      } finally {
+        loaderSpy.mockRestore();
+      }
+    });
+
     it("fills params from virtualPathResourceMap when params is omitted", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.registerVirtualResources([
@@ -335,9 +357,9 @@ describe("ResourceManager", () => {
 
     it("resolves virtualPath via map even when baseUrl is set", () => {
       const resourceManager = engine.resourceManager;
-      resourceManager.registerVirtualResources([
-        { virtualPath: "Assets/withBaseUrl", path: "https://cdn.ali.com/real.json", type: AssetType.Texture }
-      ]);
+      const virtualPath = "Assets/withBaseUrl";
+      const physicalPath = "https://cdn.ali.com/real.json";
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Texture }]);
       // @ts-ignore
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
@@ -345,9 +367,13 @@ describe("ResourceManager", () => {
       resourceManager.baseUrl = "https://base.com/app/";
 
       try {
-        resourceManager.load({ url: "Assets/withBaseUrl" });
+        resourceManager.load({ url: virtualPath });
         expect(loaderSpy).toHaveBeenCalled();
-        expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
+        expect(loaderSpy.mock.calls[0][0]).toMatchObject({
+          type: AssetType.Texture,
+          url: virtualPath
+        });
+        expect(loaderSpy.mock.calls[0][0]).not.toHaveProperty("resolvedUrl");
       } finally {
         resourceManager.baseUrl = null;
         loaderSpy.mockRestore();

--- a/tests/src/loader/SpriteAtlasLoader.test.ts
+++ b/tests/src/loader/SpriteAtlasLoader.test.ts
@@ -1,0 +1,65 @@
+import { AssetPromise, AssetType, ResourceManager, Texture2D, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("SpriteAtlasLoader", () => {
+  it("keeps virtual atlas page paths resolvable when a base URL is configured", async () => {
+    const resourceManager = engine.resourceManager;
+    const atlasVirtualPath = "SpriteAtlas/Migrated/BaseUrl/ui.atlas";
+    const pageVirtualPath = "SpriteAtlas/Migrated/BaseUrl/ui_image_0.tex";
+    const atlasPhysicalPath = "blob:https://local.alipay.net/atlas";
+    const pagePhysicalPath = "blob:https://local.alipay.net/atlas-page";
+    resourceManager.registerVirtualResources([
+      { virtualPath: atlasVirtualPath, path: atlasPhysicalPath, type: AssetType.SpriteAtlas },
+      { virtualPath: pageVirtualPath, path: pagePhysicalPath, type: AssetType.Texture }
+    ]);
+    resourceManager.baseUrl = "https://base.example.com/project/";
+
+    const requestSpy = vi.spyOn(resourceManager as any, "_requestByRemoteUrl").mockImplementation((url: string) => {
+      return new AssetPromise((resolve, reject) => {
+        if (url === atlasPhysicalPath) {
+          resolve({ atlasItems: [{ img: "./ui_image_0.tex", sprites: [] }] });
+        } else if (url === pagePhysicalPath) {
+          resolve(new ArrayBuffer(0));
+        } else {
+          reject(new Error(`Unexpected transport URL: ${url}`));
+        }
+      });
+    });
+    // @ts-ignore - loaders are registered in ResourceManager's internal registry
+    const textureLoaderSpy = vi
+      .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+      .mockImplementation((item, manager) => {
+        // @ts-ignore - exercise ResourceManager's virtual-to-transport mapping boundary
+        return manager._request(item.url, { ...item, type: "arraybuffer" }).then(() => new Texture2D(engine, 1, 1));
+      });
+
+    try {
+      await resourceManager.load({ url: atlasVirtualPath });
+
+      expect(requestSpy).toHaveBeenCalledWith(atlasPhysicalPath, expect.objectContaining({ type: "json" }));
+      expect(requestSpy).toHaveBeenCalledWith(pagePhysicalPath, expect.objectContaining({ type: "arraybuffer" }));
+      expect(textureLoaderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: pageVirtualPath,
+          type: AssetType.Texture
+        }),
+        resourceManager
+      );
+    } finally {
+      resourceManager.baseUrl = null;
+      requestSpy.mockRestore();
+      textureLoaderSpy.mockRestore();
+    }
+  });
+});

--- a/tests/src/loader/TextureLoader.test.ts
+++ b/tests/src/loader/TextureLoader.test.ts
@@ -1,0 +1,49 @@
+import { AssetPromise, AssetType, Texture2D, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("TextureLoader", () => {
+  it("keeps the resource identity when image decoding fails during content restoration", async () => {
+    const resourceManager = engine.resourceManager;
+    const virtualPath = "Texture/Migrated/page.tex";
+    const physicalPath = "blob:https://local.alipay.net/page";
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const pngBlob = await new Promise<Blob>((resolve) => canvas.toBlob((blob) => resolve(blob!), "image/png"));
+    const pngBytes = await pngBlob.arrayBuffer();
+    const invalidBytes = new Uint8Array([1, 2, 3]).buffer;
+    resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Texture }]);
+    const requestSpy = vi
+      .spyOn(resourceManager as any, "_requestByRemoteUrl")
+      .mockReturnValue(AssetPromise.resolve(pngBytes));
+
+    try {
+      const texture = await resourceManager.load<Texture2D>({ url: virtualPath });
+      const restorers = Object.values((resourceManager as any)._contentRestorerPool) as Array<{
+        resource: Texture2D;
+        restoreContent(): AssetPromise<Texture2D>;
+      }>;
+      const restorer = restorers.find((candidate) => candidate.resource === texture);
+      expect(restorer).toBeDefined();
+
+      requestSpy.mockReturnValue(AssetPromise.resolve(invalidBytes));
+
+      await expect(restorer!.restoreContent()).rejects.toThrow(
+        `TextureLoader: failed to decode texture "${virtualPath}" (${invalidBytes.byteLength} bytes).`
+      );
+    } finally {
+      requestSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## 分支关系

本 PR 已直接重建在最新 `feat/migrate-2.0@f6da19d79`，不再依赖 #3078，也不包含任何 clone 改动。

最新基线已经包含 #3074 的 Shader payload 判型：一次 text 请求后由 payload 决定预编译 JSON 或 ShaderLab 源码，并以逻辑路径作为相对 `#include` 基准。因此本 PR 不再重复修改 ShaderLoader，也不复制 Shader fixture。

## 为什么要改

Editor Preview 中一个资源有两个正交事实：

- `virtualPath` 是稳定逻辑身份，用于引用、报错定位和推导同目录依赖
- `path` 是 Blob/CDN/构建产物等物理传输地址，只负责实际读取字节

此前 `ResourceManager.baseUrl` 会把已经命中 VFS 的逻辑路径改写成普通 HTTP 地址。SpriteAtlas 再根据该地址推导页面路径时无法命中 VFS。相对逻辑路径还通过 `file://<path>` 计算，URL parser 把首段当成 hostname 并小写，导致 `SpriteAtlas/...` 变成不同的 `spriteatlas/...` key。

初版方案曾公开增加 `LoadItem.resolvedUrl`。全链路审查后已删除：物理地址已经由虚拟资源表与 ResourceManager 拥有，不应再复制到 Loader 输入形成第二份状态。

## 修复后的契约

- 注册过的虚拟资源在 `LoadItem.url` 中始终保留逻辑 `virtualPath`
- `baseUrl` 只解析未命中 VFS 的普通相对 URL
- `ResourceManager` 唯一拥有 `virtualPath -> path` 映射、cache/loading key 与 I/O 请求边界
- Loader 通过逻辑 URL 请求；ResourceManager 在 I/O 边界映射到物理地址
- 相对虚拟路径在 `file:///` 下按 path segment 解析，保留大小写与 leading-root 语义
- SpriteAtlas 继续从既有逻辑 `item.url` 推导页面；不增加 loader-specific transport 分支
- Shader 行为原样继承 #3074，payload 拥有表示格式，逻辑 URL 拥有 include 基准
- Texture 首次加载与设备恢复共用一个 ArrayBuffer-to-Image decoder，由它统一拥有 object URL 生命周期和带资源身份的错误

## 实际链路

```text
Editor manifest { virtualPath, path, type }
  -> ResourceManager { logical identity, physical request owner }
  -> loader receives logical LoadItem.url
  -> dependent logical path
  -> ResourceManager maps it to the physical request URL
```

例如 Atlas 内容中的 `./auto-atlas_image_0.tex` 会先由逻辑 Atlas 路径推导出 `SpriteAtlas/Art/UI/auto-atlas_image_0.tex`，再查 VFS 映射到对应 Blob/CDN URL；不会从 Blob URL 猜目录。

## 实际改动

- ResourceManager 在 VFS 命中时保留 loader 输入的逻辑身份
- `Utils.resolveAbsoluteUrl` 修复相对路径首段被 hostname 规则小写的问题
- `LoadItem.url` 文档明确逻辑身份契约；没有新增 `resolvedUrl` 字段
- Texture 两套 Image/Object URL 状态机收敛为一个 helper
- 新增完整 ResourceManager -> SpriteAtlas -> page 映射测试与 Texture restoration 错误测试
- 删除重基后已由基线覆盖的 Shader 改动和测试，以及无行为差异的 SpriteAtlas production 改动

## TDD 与验证

- 旧实现下，边界用例分别证明了 VFS key 首段被小写、`baseUrl` 覆盖逻辑身份、Texture restoration 仅返回原始浏览器 Event
- 聚焦浏览器测试：5 files passed，28 tests passed
- 全量浏览器测试：137 files passed，1758 tests passed
- `pnpm run b:module`：通过
- `pnpm run b:types`：15 个 package project 全部通过
- `pnpm lint`：0 error；仓库既有 1978 warnings 保持不变


## 发布边界

`0.0.0-experimental-2.0-migrate.5` 已从更早的分支状态发布，不包含本次重基后的独立 loader 提交；包含该修复的发布必须使用新版本。
