### PR TITLE
Fix ParticleCompositeCurve zero max overload selection

### DIFF
--- a/packages/core/src/particle/modules/ParticleCompositeCurve.ts
+++ b/packages/core/src/particle/modules/ParticleCompositeCurve.ts
@@ -143,7 +143,7 @@ export class ParticleCompositeCurve extends DataObject {
     super();
     this._updateDispatch = this._updateManager.dispatch.bind(this._updateManager);
     if (typeof constantOrCurve === "number") {
-      if (constantMaxOrCurveMax) {
+      if (constantMaxOrCurveMax !== undefined) {
         this.constantMin = constantOrCurve;
         this.constantMax = <number>constantMaxOrCurveMax;
         this.mode = ParticleCurveMode.TwoConstants;
@@ -152,7 +152,7 @@ export class ParticleCompositeCurve extends DataObject {
         this.mode = ParticleCurveMode.Constant;
       }
     } else {
-      if (constantMaxOrCurveMax) {
+      if (constantMaxOrCurveMax !== undefined) {
         this.curveMin = constantOrCurve;
         this.curveMax = <ParticleCurve>constantMaxOrCurveMax;
         this.mode = ParticleCurveMode.TwoCurves;

--- a/tests/src/core/particle/ParticleCurve.test.ts
+++ b/tests/src/core/particle/ParticleCurve.test.ts
@@ -16,6 +16,15 @@ describe("ParticleCurve tests", () => {
     expect(gradient.evaluate(undefined, 1.0)).to.equal(0.2);
   });
 
+  it("Constructor with zero as the max constant", () => {
+    const gradient = new ParticleCompositeCurve(5, 0);
+    expect(gradient.mode).to.equal(ParticleCurveMode.TwoConstants);
+    expect(gradient.constantMin).to.equal(5);
+    expect(gradient.constantMax).to.equal(0);
+    expect(gradient.evaluate(undefined, 0)).to.equal(5);
+    expect(gradient.evaluate(undefined, 1)).to.equal(0);
+  });
+
   it("Constructor with curve params", () => {
     const gradient0 = new ParticleCompositeCurve(new ParticleCurve(new CurveKey(0, 0.333)));
     expect(gradient0.mode).to.equal(ParticleCurveMode.Curve);


### PR DESCRIPTION
## Summary

- select `ParticleCompositeCurve` two-argument overloads by argument presence instead of truthiness
- preserve `0` as a valid maximum constant
- add a regression that verifies the hydrated Engine object mode, endpoints, and evaluation

## Verification

- `HEADLESS=true pnpm vitest run tests/src/core/particle/ParticleCurve.test.ts` (8 tests passed)
- `pnpm -F @galacean/engine-core b:types`
- `pnpm eslint packages/core/src/particle/modules/ParticleCompositeCurve.ts` (no errors; 6 pre-existing warnings elsewhere in the file)
- `pnpm prettier --check packages/core/src/particle/modules/ParticleCompositeCurve.ts tests/src/core/particle/ParticleCurve.test.ts`

Closes #3082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed composite curves with a maximum value of `0` being interpreted incorrectly.
  * Ensured two-value curve configurations evaluate correctly across their range.

* **Tests**
  * Added coverage for composite curves using a maximum value of `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Downstream

- Implements [#3082](https://github.com/galacean/engine/issues/3082) for [galacean/editor#3813](https://github.com/galacean/editor/pull/3813), which emits canonical `ParticleCompositeCurve(min, max)` runtime-v2 constructor data.
- After this fix is merged and published in a new `2.0.0-alpha.*`, Editor will bump its pinned Engine dependencies and restore the API → source-v2 → Builder → Loader → Engine object regression.
