### PR TITLE
fix(loader): preserve virtual resource identity in Editor Preview

### DIFF
--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -82,8 +82,10 @@ export class Utils {
       return relativeUrl ? new URL(relativeUrl, baseUrl).href : baseUrl;
     }
 
-    // 相对虚拟资源路径必须放在 file URL 的路径段中，不能放在 host 位置
-    // host 会被 URL 规范化为小写，导致大小写敏感的 VFS key 无法命中
+    // A relative virtual asset path (for example `SpriteAtlas/...`) must be
+    // treated as a path, not as the host portion of a file URL. The latter
+    // lowercases the first segment and breaks case-sensitive virtual-resource
+    // lookup in Editor previews
     const resolvedHasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
     const head = "file:///";
     const encodedBaseUrl = head + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));

--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -44,7 +44,7 @@ export class Utils {
    * @returns Whether the url is absolute url.
    */
   static isAbsoluteUrl(url: string): boolean {
-    return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url);
+    return /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(url);
   }
 
   /**
@@ -71,10 +71,6 @@ export class Utils {
    */
   static resolveAbsoluteUrl(baseUrl: string, relativeUrl: string): string {
     if (Utils.isAbsoluteUrl(relativeUrl)) {
-      return relativeUrl;
-    }
-
-    if (Utils.isBase64Url(relativeUrl)) {
       return relativeUrl;
     }
 

--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -82,10 +82,16 @@ export class Utils {
       return relativeUrl ? new URL(relativeUrl, baseUrl).href : baseUrl;
     }
 
-    const head = "file://";
-    const encodedBaseUrl = head + this._encodePathComponents(baseUrl);
+    // A relative virtual asset path (for example `SpriteAtlas/...`) must be
+    // treated as a path, not as the host portion of a file URL. The latter
+    // lowercases the first segment and breaks case-sensitive virtual-resource
+    // lookup in Editor previews
+    const resolvedHasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
+    const head = "file:///";
+    const encodedBaseUrl = head + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));
     const encodedRelativeUrl = this._encodePathComponents(relativeUrl);
-    return decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).href.slice(head.length));
+    const resolvedPath = decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).href.slice(head.length));
+    return resolvedHasLeadingSlash ? `/${resolvedPath}` : resolvedPath;
   }
 
   /**
@@ -134,7 +140,7 @@ export class Utils {
    * @param path - The path of the property to get.
    * @returns Returns the resolved value.
    */
-  static _reflectGet(target: Object, path: string) {
+  static _reflectGet(target: object, path: string) {
     const pathArr = this._stringToPath(path);
 
     let object = target;

--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -82,16 +82,12 @@ export class Utils {
       return relativeUrl ? new URL(relativeUrl, baseUrl).href : baseUrl;
     }
 
-    // A relative virtual asset path (for example `SpriteAtlas/...`) must be
-    // treated as a path, not as the host portion of a file URL. The latter
-    // lowercases the first segment and breaks case-sensitive virtual-resource
-    // lookup in Editor previews
-    const resolvedHasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
-    const head = "file:///";
-    const encodedBaseUrl = head + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));
+    // Use an empty file URL host to preserve path casing
+    const hasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
+    const encodedBaseUrl = "file:///" + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));
     const encodedRelativeUrl = this._encodePathComponents(relativeUrl);
-    const resolvedPath = decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).href.slice(head.length));
-    return resolvedHasLeadingSlash ? `/${resolvedPath}` : resolvedPath;
+    const resolvedPath = decodeURIComponent(new URL(encodedRelativeUrl, encodedBaseUrl).pathname);
+    return hasLeadingSlash ? resolvedPath : resolvedPath.slice(1);
   }
 
   /**

--- a/packages/core/src/Utils.ts
+++ b/packages/core/src/Utils.ts
@@ -82,10 +82,8 @@ export class Utils {
       return relativeUrl ? new URL(relativeUrl, baseUrl).href : baseUrl;
     }
 
-    // A relative virtual asset path (for example `SpriteAtlas/...`) must be
-    // treated as a path, not as the host portion of a file URL. The latter
-    // lowercases the first segment and breaks case-sensitive virtual-resource
-    // lookup in Editor previews
+    // 相对虚拟资源路径必须放在 file URL 的路径段中，不能放在 host 位置
+    // host 会被 URL 规范化为小写，导致大小写敏感的 VFS key 无法命中
     const resolvedHasLeadingSlash = baseUrl.startsWith("/") || relativeUrl.startsWith("/");
     const head = "file:///";
     const encodedBaseUrl = head + this._encodePathComponents(baseUrl.replace(/^\/+/, ""));

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,8 +28,7 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Requested resource identity. Virtual resources keep their virtual path so
-   * loaders can resolve dependent resources through ResourceManager.
+   * Resource URL.
    */
   url: string;
   /**

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,7 +28,7 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Logical resource URL passed to loaders. ResourceManager resolves it to a physical URL at the request boundary.
+   * URL of the resource to load.
    */
   url: string;
   /**

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,8 +28,8 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Requested resource identity. Virtual resources keep their virtual path so
-   * loaders can resolve dependent resources through ResourceManager.
+   * 请求资源的逻辑标识。虚拟资源必须保留 virtualPath，
+   * 使 Loader 派生出的同目录依赖仍可由 ResourceManager 映射到物理地址。
    */
   url: string;
   /**

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,7 +28,8 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Loading url.
+   * Requested resource identity. Virtual resources keep their virtual path so
+   * loaders can resolve dependent resources through ResourceManager.
    */
   url: string;
   /**

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,7 +28,7 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * Resource URL.
+   * Logical resource URL passed to loaders. ResourceManager resolves it to a physical URL at the request boundary.
    */
   url: string;
   /**

--- a/packages/core/src/asset/LoadItem.ts
+++ b/packages/core/src/asset/LoadItem.ts
@@ -28,8 +28,8 @@ export type LoadItem = {
   params?: Record<string, any>;
 } & PickOnlyOne<{
   /**
-   * 请求资源的逻辑标识。虚拟资源必须保留 virtualPath，
-   * 使 Loader 派生出的同目录依赖仍可由 ResourceManager 映射到物理地址。
+   * Requested resource identity. Virtual resources keep their virtual path so
+   * loaders can resolve dependent resources through ResourceManager.
    */
   url: string;
   /**

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -100,7 +100,7 @@ export class ResourceManager {
 
   /**
    * Get the resource from cache by asset url, return the resource object if it loaded, otherwise return null.
-   * @param url - Resource URL or registered virtual path
+   * @param url - Resource URL
    * @returns Resource object
    */
   getFromCache<T>(url: string): T {
@@ -140,13 +140,13 @@ export class ResourceManager {
 
   /**
    * Cancel assets whose url has not finished loading.
-   * @param url - Resource URL or registered virtual path
+   * @param url - Resource URL
    */
   cancelNotLoaded(url: string): void;
 
   /**
    * Cancel the incompletely loaded assets in urls.
-   * @param urls - Resource URLs or registered virtual paths
+   * @param urls - Resource URLs
    */
   cancelNotLoaded(urls: string[]): void;
 

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -346,8 +346,9 @@ export class ResourceManager {
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // 命中虚拟资源时必须保留逻辑路径，Loader 需要用它推导同目录依赖
-    // baseUrl 只解析未注册到 VFS 的普通相对地址，避免绕过虚拟资源映射
+    // Keep a virtual resource's logical identity so loaders can resolve its
+    // sibling resources through the virtual-resource map. `baseUrl` only
+    // resolves ordinary relative transport URLs
     const loadItemUrl =
       virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
         ? assetBaseURL

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -156,10 +156,10 @@ export class ResourceManager {
         promise.cancel();
       });
     } else if (typeof url === "string") {
-      this._loadingPromises[this._getRemoteUrl(url)]?.cancel();
+      this._loadingPromises[this._getLoadingKey(url)]?.cancel();
     } else {
       for (let i = 0, n = url.length; i < n; i++) {
-        this._loadingPromises[this._getRemoteUrl(url[i])]?.cancel();
+        this._loadingPromises[this._getLoadingKey(url[i])]?.cancel();
       }
     }
   }
@@ -186,7 +186,9 @@ export class ResourceManager {
    * @internal
    */
   _getRemoteUrl(url: string): string {
-    return this._virtualPathResourceMap[url]?.path ?? url;
+    return (
+      this._virtualPathResourceMap[url]?.path ?? (this.baseUrl ? Utils.resolveAbsoluteUrl(this.baseUrl, url) : url)
+    );
   }
 
   /**
@@ -340,17 +342,12 @@ export class ResourceManager {
     const { assetBaseURL, queryPath } = this._parseURL(item.url);
     const paths = queryPath ? this._parseQueryPath(queryPath) : [];
 
-    // Get remote asset base url
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // Only resolve unmapped relative URLs against baseUrl
-    const loadItemUrl =
-      virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
-        ? assetBaseURL
-        : Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL);
-    item.url = loadItemUrl;
-    const remoteAssetBaseURL = this._getRemoteUrl(loadItemUrl);
+    const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
+    // Preserve virtual paths for loaders
+    item.url = virtualResourceEntry ? assetBaseURL : remoteAssetBaseURL;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];
@@ -360,15 +357,7 @@ export class ResourceManager {
       });
     }
 
-    // Get asset url
-    let remoteAssetURL = remoteAssetBaseURL;
-    if (queryPath) {
-      remoteAssetURL += "?q=" + paths.shift();
-      let index: string;
-      while ((index = paths.shift())) {
-        remoteAssetURL += `[${index}]`;
-      }
-    }
+    const remoteAssetURL = this._getRemoteAssetURL(remoteAssetBaseURL, paths);
 
     // Check is loading
     const loadingPromises = this._loadingPromises;
@@ -507,6 +496,25 @@ export class ResourceManager {
       }
     }
     return subResource;
+  }
+
+  private _getLoadingKey(url: string): string {
+    const { assetBaseURL, queryPath } = this._parseURL(url);
+    const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
+    return queryPath
+      ? this._getRemoteAssetURL(remoteAssetBaseURL, this._parseQueryPath(queryPath))
+      : remoteAssetBaseURL;
+  }
+
+  private _getRemoteAssetURL(remoteAssetBaseURL: string, paths: string[]): string {
+    let remoteAssetURL = remoteAssetBaseURL;
+    if (paths.length > 0) {
+      remoteAssetURL += `?q=${paths[0]}`;
+      for (let i = 1, n = paths.length; i < n; i++) {
+        remoteAssetURL += `[${paths[i]}]`;
+      }
+    }
+    return remoteAssetURL;
   }
 
   private _parseURL(path: string): { assetBaseURL: string; queryPath: string } {

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -100,11 +100,11 @@ export class ResourceManager {
 
   /**
    * Get the resource from cache by asset url, return the resource object if it loaded, otherwise return null.
-   * @param url - Resource url
+   * @param url - Resource URL or registered virtual path
    * @returns Resource object
    */
   getFromCache<T>(url: string): T {
-    return (this._assetUrlPool[url] as T) ?? null;
+    return (this._assetUrlPool[this._getRemoteUrl(url)] as T) ?? null;
   }
 
   /**
@@ -140,13 +140,13 @@ export class ResourceManager {
 
   /**
    * Cancel assets whose url has not finished loading.
-   * @param url - Resource url
+   * @param url - Resource URL or registered virtual path
    */
   cancelNotLoaded(url: string): void;
 
   /**
    * Cancel the incompletely loaded assets in urls.
-   * @param urls - Resource urls
+   * @param urls - Resource URLs or registered virtual paths
    */
   cancelNotLoaded(urls: string[]): void;
 
@@ -155,11 +155,10 @@ export class ResourceManager {
       Utils.objectValues(this._loadingPromises).forEach((promise) => {
         promise.cancel();
       });
-    } else if (typeof url === "string") {
-      this._loadingPromises[url]?.cancel();
     } else {
-      url.forEach((p) => {
-        this._loadingPromises[p]?.cancel();
+      const urls = typeof url === "string" ? [url] : url;
+      urls.forEach((url) => {
+        this._loadingPromises[this._getRemoteUrl(url)]?.cancel();
       });
     }
   }
@@ -208,7 +207,7 @@ export class ResourceManager {
    * @internal
    */
   _onSubAssetSuccess<T>(assetBaseURL: string, assetSubPath: string, value: T): void {
-    const remoteAssetBaseURL = this._virtualPathResourceMap[assetBaseURL]?.path ?? assetBaseURL;
+    const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
 
     const subPromiseCallback = this._subAssetPromiseCallbacks[remoteAssetBaseURL]?.[assetSubPath];
     if (subPromiseCallback) {
@@ -354,7 +353,7 @@ export class ResourceManager {
         ? assetBaseURL
         : Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL);
     item.url = loadItemUrl;
-    const remoteAssetBaseURL = virtualResourceEntry?.path ?? loadItemUrl;
+    const remoteAssetBaseURL = this._getRemoteUrl(loadItemUrl);
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -155,11 +155,12 @@ export class ResourceManager {
       Utils.objectValues(this._loadingPromises).forEach((promise) => {
         promise.cancel();
       });
+    } else if (typeof url === "string") {
+      this._loadingPromises[this._getRemoteUrl(url)]?.cancel();
     } else {
-      const urls = typeof url === "string" ? [url] : url;
-      urls.forEach((url) => {
-        this._loadingPromises[this._getRemoteUrl(url)]?.cancel();
-      });
+      for (let i = 0, n = url.length; i < n; i++) {
+        this._loadingPromises[this._getRemoteUrl(url[i])]?.cancel();
+      }
     }
   }
 

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -346,9 +346,8 @@ export class ResourceManager {
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // Keep a virtual resource's logical identity so loaders can resolve its
-    // sibling resources through the virtual-resource map. `baseUrl` only
-    // resolves ordinary relative transport URLs
+    // 命中虚拟资源时必须保留逻辑路径，Loader 需要用它推导同目录依赖
+    // baseUrl 只解析未注册到 VFS 的普通相对地址，避免绕过虚拟资源映射
     const loadItemUrl =
       virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
         ? assetBaseURL

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -209,8 +209,8 @@ export class ResourceManager {
   /**
    * @internal
    */
-  _onSubAssetSuccess<T>(assetBaseURL: string, assetSubPath: string, value: T): void {
-    const subAssetPromiseCallbacks = (this._subAssetPromiseCallbacks[this._getRemoteUrl(assetBaseURL)] ||= {});
+  _onSubAssetSuccess<T>(remoteAssetBaseURL: string, assetSubPath: string, value: T): void {
+    const subAssetPromiseCallbacks = (this._subAssetPromiseCallbacks[remoteAssetBaseURL] ||= {});
     const subPromiseCallback = subAssetPromiseCallbacks[assetSubPath];
     if (subPromiseCallback) {
       subPromiseCallback.resolve(value);

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -346,8 +346,7 @@ export class ResourceManager {
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
     const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
-    // Preserve virtual paths for loaders
-    item.url = virtualResourceEntry ? assetBaseURL : remoteAssetBaseURL;
+    item.url = assetBaseURL;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -208,14 +208,12 @@ export class ResourceManager {
    * @internal
    */
   _onSubAssetSuccess<T>(assetBaseURL: string, assetSubPath: string, value: T): void {
-    const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
-
-    const subPromiseCallback = this._subAssetPromiseCallbacks[remoteAssetBaseURL]?.[assetSubPath];
+    const subAssetPromiseCallbacks = (this._subAssetPromiseCallbacks[this._getRemoteUrl(assetBaseURL)] ||= {});
+    const subPromiseCallback = subAssetPromiseCallbacks[assetSubPath];
     if (subPromiseCallback) {
       subPromiseCallback.resolve(value);
     } else {
-      // Pending
-      (this._subAssetPromiseCallbacks[remoteAssetBaseURL] ||= {})[assetSubPath] = {
+      subAssetPromiseCallbacks[assetSubPath] = {
         resolvedValue: value
       };
     }
@@ -346,9 +344,7 @@ export class ResourceManager {
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // Keep a virtual resource's logical identity so loaders can resolve its
-    // sibling resources through the virtual-resource map. `baseUrl` only
-    // resolves ordinary relative transport URLs
+    // Only resolve unmapped relative URLs against baseUrl
     const loadItemUrl =
       virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
         ? assetBaseURL

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -346,12 +346,15 @@ export class ResourceManager {
     const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
     this._resolveLoadItemOptions(item, virtualResourceEntry);
 
-    // Not absolute and base url is set
-    item.url =
-      !Utils.isAbsoluteUrl(assetBaseURL) && this.baseUrl
-        ? Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL)
-        : assetBaseURL;
-    const remoteAssetBaseURL = virtualResourceEntry?.path ?? item.url;
+    // Keep a virtual resource's logical identity so loaders can resolve its
+    // sibling resources through the virtual-resource map. `baseUrl` only
+    // resolves ordinary relative transport URLs
+    const loadItemUrl =
+      virtualResourceEntry !== undefined || Utils.isAbsoluteUrl(assetBaseURL) || !this.baseUrl
+        ? assetBaseURL
+        : Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL);
+    item.url = loadItemUrl;
+    const remoteAssetBaseURL = virtualResourceEntry?.path ?? loadItemUrl;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];

--- a/packages/loader/src/AmbientLightLoader.ts
+++ b/packages/loader/src/AmbientLightLoader.ts
@@ -70,13 +70,14 @@ class AmbientLightLoader extends Loader<AmbientLight> {
   }
 
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<AmbientLight> {
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteUrl = resourceManager._getRemoteUrl(item.url);
     return new AssetPromise((resolve, reject) => {
       const requestConfig = { ...item, type: "arraybuffer" } as RequestConfig;
       const engine = resourceManager.engine;
-      const url = item.url;
       resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(url, requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(remoteUrl, requestConfig)
         .then((buffer) => {
           const header = FileHeader.decode(buffer);
           const dataOffset = header.headerLength;
@@ -91,7 +92,7 @@ class AmbientLightLoader extends Loader<AmbientLight> {
             header.dataLength - AmbientLightLoader._shByteLength
           ).then((specularTexture) => {
             engine.resourceManager.addContentRestorer(
-              new AmbientLightContentRestorer(specularTexture, url, requestConfig)
+              new AmbientLightContentRestorer(specularTexture, remoteUrl, requestConfig)
             );
             const ambientLight = new AmbientLight(engine);
             ambientLight.diffuseMode = DiffuseMode.SphericalHarmonics;
@@ -111,7 +112,7 @@ class AmbientLightLoader extends Loader<AmbientLight> {
 class AmbientLightContentRestorer extends ContentRestorer<TextureCube> {
   constructor(
     resource: TextureCube,
-    public url: string,
+    public remoteUrl: string,
     public requestConfig: RequestConfig
   ) {
     super(resource);
@@ -123,7 +124,7 @@ class AmbientLightContentRestorer extends ContentRestorer<TextureCube> {
       const engine = resource.engine;
       engine.resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(this.url, this.requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(this.remoteUrl, this.requestConfig)
         .then((buffer) => {
           const header = FileHeader.decode(buffer);
           const dataOffset = header.headerLength;

--- a/packages/loader/src/FontLoader.ts
+++ b/packages/loader/src/FontLoader.ts
@@ -5,7 +5,8 @@ import {
   Loader,
   LoadItem,
   resourceLoader,
-  ResourceManager
+  ResourceManager,
+  Utils
 } from "@galacean/engine-core";
 
 @resourceLoader(AssetType.Font, ["font"])
@@ -19,7 +20,10 @@ class FontLoader extends Loader<Font> {
           const { fontName, fontUrl } = data;
 
           if (fontUrl) {
-            this._registerFont(fontName, fontUrl)
+            const absoluteUrl = Utils.resolveAbsoluteUrl(item.url, fontUrl);
+            // @ts-ignore
+            const remoteUrl = resourceManager._getRemoteUrl(absoluteUrl);
+            this._registerFont(fontName, remoteUrl)
               .then(() => {
                 const font = new Font(resourceManager.engine, fontName);
                 resolve(font);

--- a/packages/loader/src/KTXLoader.ts
+++ b/packages/loader/src/KTXLoader.ts
@@ -14,6 +14,8 @@ import { parseSingleKTX } from "./compressed-texture";
 @resourceLoader(AssetType.KTX, ["ktx"])
 export class KTXLoader extends Loader<Texture2D> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Texture2D> {
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteUrl = resourceManager._getRemoteUrl(item.url);
     const requestConfig = <RequestConfig>{
       ...item,
       type: "arraybuffer"
@@ -21,7 +23,7 @@ export class KTXLoader extends Loader<Texture2D> {
     return new AssetPromise((resolve, reject) => {
       resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(item.url, requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(remoteUrl, requestConfig)
         .then((bin) => {
           const parsedData = parseSingleKTX(bin);
           const { width, height, mipmaps, engineFormat } = parsedData;
@@ -32,7 +34,7 @@ export class KTXLoader extends Loader<Texture2D> {
             const { width, height, data } = mipmaps[miplevel];
             texture.setPixelBuffer(data, miplevel, 0, 0, width, height);
           }
-          resourceManager.addContentRestorer(new KTXContentRestorer(texture, item.url, requestConfig));
+          resourceManager.addContentRestorer(new KTXContentRestorer(texture, remoteUrl, requestConfig));
           resolve(texture);
         })
         .catch((e) => {
@@ -45,7 +47,7 @@ export class KTXLoader extends Loader<Texture2D> {
 class KTXContentRestorer extends ContentRestorer<Texture2D> {
   constructor(
     resource: Texture2D,
-    public url: string,
+    public remoteUrl: string,
     public requestConfig: RequestConfig
   ) {
     super(resource);
@@ -57,7 +59,7 @@ class KTXContentRestorer extends ContentRestorer<Texture2D> {
     return new AssetPromise((resolve, reject) => {
       engine.resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(this.url, this.requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(this.remoteUrl, this.requestConfig)
         .then((bin) => {
           const mipmaps = parseSingleKTX(bin).mipmaps;
           for (let miplevel = 0; miplevel < mipmaps.length; miplevel++) {

--- a/packages/loader/src/MeshLoader.ts
+++ b/packages/loader/src/MeshLoader.ts
@@ -18,16 +18,17 @@ class MeshLoader extends Loader<ModelMesh> {
       ...item,
       type: "arraybuffer"
     };
-    const url = item.url;
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteUrl = resourceManager._getRemoteUrl(item.url);
     return new AssetPromise((resolve, reject) => {
       resourceManager
         // @ts-ignore
-        ._request(url, requestConfig)
+        ._requestByRemoteUrl(remoteUrl, requestConfig)
         .then((data) => {
           return decode<ModelMesh>(data, resourceManager.engine);
         })
         .then((mesh: ModelMesh) => {
-          resourceManager.addContentRestorer(new MeshContentRestorer(mesh, url, requestConfig));
+          resourceManager.addContentRestorer(new MeshContentRestorer(mesh, remoteUrl, requestConfig));
           resolve(mesh);
         })
         .catch(reject);
@@ -38,7 +39,7 @@ class MeshLoader extends Loader<ModelMesh> {
 class MeshContentRestorer extends ContentRestorer<ModelMesh> {
   constructor(
     resource: ModelMesh,
-    public url: string,
+    public remoteUrl: string,
     public requestConfig: RequestConfig
   ) {
     super(resource);
@@ -50,7 +51,7 @@ class MeshContentRestorer extends ContentRestorer<ModelMesh> {
     return new AssetPromise((resolve, reject) => {
       engine.resourceManager
         // @ts-ignore
-        ._request<any>(this.url, this.requestConfig)
+        ._requestByRemoteUrl<any>(this.remoteUrl, this.requestConfig)
         .then((data) => {
           return decode<ModelMesh>(data, engine, resource);
         })

--- a/packages/loader/src/RenderTargetLoader.ts
+++ b/packages/loader/src/RenderTargetLoader.ts
@@ -16,10 +16,12 @@ import {
 class RenderTargetLoader extends Loader<RenderTarget> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<RenderTarget> {
     const { engine } = resourceManager;
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteAssetBaseURL = resourceManager._getRemoteUrl(item.url);
     return (
       resourceManager
         // @ts-ignore
-        ._request<IRenderTargetData>(item.url, {
+        ._requestByRemoteUrl<IRenderTargetData>(remoteAssetBaseURL, {
           ...item,
           type: "json"
         })
@@ -48,7 +50,7 @@ class RenderTargetLoader extends Loader<RenderTarget> {
           // Notify pending sub-asset requests for colorTextures
           for (let i = 0, n = colorTextures.length; i < n; i++) {
             // @ts-ignore
-            resourceManager._onSubAssetSuccess(item.url, `colorTextures[${i}]`, colorTextures[i]);
+            resourceManager._onSubAssetSuccess(remoteAssetBaseURL, `colorTextures[${i}]`, colorTextures[i]);
           }
 
           return rt;

--- a/packages/loader/src/TextureLoader.ts
+++ b/packages/loader/src/TextureLoader.ts
@@ -72,39 +72,29 @@ class TextureLoader extends Loader<Texture> {
   }
 
   private _decodeImage(buffer: ArrayBuffer, item: LoadItem, resourceManager: ResourceManager): AssetPromise<Texture2D> {
-    return new AssetPromise((resolve, reject) => {
-      const blob = new Blob([buffer]);
-      const img = new Image();
-      img.onload = () => {
-        URL.revokeObjectURL(img.src);
-        const {
-          format = TextureFormat.R8G8B8A8,
-          isSRGBColorSpace = true,
-          mipmap = true
-        } = (item.params as Partial<TextureParams>) ?? {};
+    return decodeImage(buffer, item.url!).then((img) => {
+      const {
+        format = TextureFormat.R8G8B8A8,
+        isSRGBColorSpace = true,
+        mipmap = true
+      } = (item.params as Partial<TextureParams>) ?? {};
 
-        const engine = resourceManager.engine;
-        const { width, height } = img;
-        const generateMipmap = TextureUtils.supportGenerateMipmapsWithCorrection(
-          engine,
-          width,
-          height,
-          format,
-          mipmap,
-          isSRGBColorSpace
-        );
+      const engine = resourceManager.engine;
+      const { width, height } = img;
+      const generateMipmap = TextureUtils.supportGenerateMipmapsWithCorrection(
+        engine,
+        width,
+        height,
+        format,
+        mipmap,
+        isSRGBColorSpace
+      );
 
-        const texture = new Texture2D(engine, width, height, format, generateMipmap, isSRGBColorSpace);
-        texture.setImageSource(img);
-        generateMipmap && texture.generateMipmaps();
-        this._applyParams(texture, item);
-        resolve(texture);
-      };
-      img.onerror = (e) => {
-        URL.revokeObjectURL(img.src);
-        reject(e);
-      };
-      img.src = URL.createObjectURL(blob);
+      const texture = new Texture2D(engine, width, height, format, generateMipmap, isSRGBColorSpace);
+      texture.setImageSource(img);
+      generateMipmap && texture.generateMipmaps();
+      this._applyParams(texture, item);
+      return texture;
     });
   }
 
@@ -151,24 +141,31 @@ class TextureContentRestorer extends ContentRestorer<Texture> {
             return texture;
           }
 
-          return new AssetPromise<Texture>((resolve, reject) => {
-            const blob = new Blob([buffer]);
-            const img = new Image();
-            img.onload = () => {
-              URL.revokeObjectURL(img.src);
-              texture.setImageSource(img);
-              texture.mipmapCount > 1 && texture.generateMipmaps();
-              resolve(texture);
-            };
-            img.onerror = (e) => {
-              URL.revokeObjectURL(img.src);
-              reject(e);
-            };
-            img.src = URL.createObjectURL(blob);
+          return decodeImage(buffer, this.url).then((img) => {
+            texture.setImageSource(img);
+            texture.mipmapCount > 1 && texture.generateMipmaps();
+            return texture;
           });
         })
     );
   }
+}
+
+function decodeImage(buffer: ArrayBuffer, url: string): AssetPromise<HTMLImageElement> {
+  return new AssetPromise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(new Blob([buffer]));
+    const image = new Image();
+    const releaseObjectUrl = () => URL.revokeObjectURL(objectUrl);
+    image.onload = () => {
+      releaseObjectUrl();
+      resolve(image);
+    };
+    image.onerror = () => {
+      releaseObjectUrl();
+      reject(new Error(`TextureLoader: failed to decode texture "${url}" (${buffer.byteLength} bytes).`));
+    };
+    image.src = objectUrl;
+  });
 }
 
 /**

--- a/packages/loader/src/TextureLoader.ts
+++ b/packages/loader/src/TextureLoader.ts
@@ -23,15 +23,17 @@ import { HDRDecoder } from "./HDRDecoder";
 class TextureLoader extends Loader<Texture> {
   override load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Texture> {
     const url = item.url;
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteUrl = resourceManager._getRemoteUrl(url);
     const requestConfig = <RequestConfig>{ ...item, type: "arraybuffer" };
     return new AssetPromise((resolve, reject, setTaskCompleteProgress, setTaskDetailProgress) => {
       resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(url, requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(remoteUrl, requestConfig)
         .onProgress(setTaskCompleteProgress, setTaskDetailProgress)
         .then((buffer) => {
           this._decode(buffer, item, resourceManager).then((texture) => {
-            resourceManager.addContentRestorer(new TextureContentRestorer(texture, url, requestConfig));
+            resourceManager.addContentRestorer(new TextureContentRestorer(texture, url, remoteUrl, requestConfig));
             resolve(texture);
           }, reject);
         })
@@ -116,6 +118,7 @@ class TextureContentRestorer extends ContentRestorer<Texture> {
   constructor(
     resource: Texture,
     public url: string,
+    public remoteUrl: string,
     public requestConfig: RequestConfig
   ) {
     super(resource);
@@ -125,7 +128,7 @@ class TextureContentRestorer extends ContentRestorer<Texture> {
     return (
       this.resource.engine.resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(this.url, this.requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(this.remoteUrl, this.requestConfig)
         .then((buffer) => {
           if (FileHeader.checkMagic(buffer)) {
             return decode<Texture>(buffer, this.resource.engine, this.resource);

--- a/packages/loader/src/gltf/parser/GLTFBufferParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFBufferParser.ts
@@ -17,16 +17,16 @@ export class GLTFBufferParser extends GLTFParser {
   private _parseSingleBuffer(context: GLTFParserContext, bufferInfo: IBuffer): AssetPromise<ArrayBuffer> {
     const { glTFResource, contentRestorer, resourceManager } = context;
     const url = glTFResource.url;
+    const absoluteUrl = Utils.resolveAbsoluteUrl(url, bufferInfo.uri);
     // @ts-ignore
-    const remoteUrl = resourceManager._getRemoteUrl(url);
+    const remoteUrl = resourceManager._getRemoteUrl(absoluteUrl);
     const restoreBufferRequests = contentRestorer.bufferRequests;
     const requestConfig = <RequestConfig>{ type: "arraybuffer" };
-    const absoluteUrl = Utils.resolveAbsoluteUrl(remoteUrl, bufferInfo.uri);
 
-    restoreBufferRequests.push(new BufferRequestInfo(absoluteUrl, requestConfig));
+    restoreBufferRequests.push(new BufferRequestInfo(remoteUrl, requestConfig));
     const promise = resourceManager
       // @ts-ignore
-      ._requestByRemoteUrl<ArrayBuffer>(absoluteUrl, requestConfig)
+      ._requestByRemoteUrl<ArrayBuffer>(remoteUrl, requestConfig)
       .onProgress(undefined, context._onTaskDetail);
 
     context._addTaskCompletePromise(promise);

--- a/packages/loader/src/gltf/parser/GLTFParserContext.ts
+++ b/packages/loader/src/gltf/parser/GLTFParserContext.ts
@@ -39,6 +39,7 @@ export class GLTFParserContext {
   _getPromises: AssetPromise<unknown>[] = [];
 
   private _resourceCache = new Map<string, any>();
+  private readonly _remoteAssetBaseURL: string;
   private _progress = {
     taskDetail: {},
     taskComplete: { loaded: 0, total: 0 }
@@ -54,6 +55,8 @@ export class GLTFParserContext {
     public resourceManager: ResourceManager,
     public params: GLTFParams
   ) {
+    // @ts-expect-error -- internal method is omitted from public declarations
+    this._remoteAssetBaseURL = resourceManager._getRemoteUrl(glTFResource.url);
     this.contentRestorer = new GLTFContentRestorer(glTFResource);
   }
 
@@ -177,7 +180,7 @@ export class GLTFParserContext {
     if (type === GLTFParserType.Entity) {
       (this.glTFResource[glTFResourceKey] ||= [])[index] = <Entity>resource;
     } else {
-      const url = this.glTFResource.url;
+      const remoteAssetBaseURL = this._remoteAssetBaseURL;
 
       (<AssetPromise<T>>resource)
         .then((item: T) => {
@@ -191,19 +194,23 @@ export class GLTFParserContext {
             for (let i = 0, length = (<ModelMesh[]>item).length; i < length; i++) {
               const mesh = item[i] as ModelMesh;
               // @ts-ignore
-              this.resourceManager._onSubAssetSuccess<ModelMesh>(url, `${glTFResourceKey}[${index}][${i}]`, mesh);
+              this.resourceManager._onSubAssetSuccess<ModelMesh>(
+                remoteAssetBaseURL,
+                `${glTFResourceKey}[${index}][${i}]`,
+                mesh
+              );
             }
           } else {
             // @ts-ignore
             this.resourceManager._onSubAssetSuccess<T>(
-              url,
+              remoteAssetBaseURL,
               `${glTFResourceKey}${index === undefined ? "" : `[${index}]`}`,
               item
             );
 
             if (type === GLTFParserType.Scene && (this.glTF.scene ?? 0) === index) {
               // @ts-ignore
-              this.resourceManager._onSubAssetSuccess<Entity>(url, `defaultSceneRoot`, item as Entity);
+              this.resourceManager._onSubAssetSuccess<Entity>(remoteAssetBaseURL, `defaultSceneRoot`, item as Entity);
             }
           }
         })

--- a/packages/loader/src/ktx2/KTX2Loader.ts
+++ b/packages/loader/src/ktx2/KTX2Loader.ts
@@ -241,15 +241,16 @@ export class KTX2Loader extends Loader<Texture2D | TextureCube> {
     item: LoadItem & { params?: KTX2Params },
     resourceManager: ResourceManager
   ): AssetPromise<Texture2D | TextureCube> {
+    // @ts-expect-error -- internal method is omitted from public declarations
+    const remoteUrl = resourceManager._getRemoteUrl(item.url);
     return new AssetPromise((resolve, reject, setTaskCompleteProgress, setTaskDetailProgress) => {
       const requestConfig = <RequestConfig>{
         ...item,
         type: "arraybuffer"
       };
-      const url = item.url;
       resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(url, requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(remoteUrl, requestConfig)
         .onProgress(setTaskCompleteProgress, setTaskDetailProgress)
         .then((buffer) =>
           KTX2Loader._parseBuffer(new Uint8Array(buffer), resourceManager.engine, item.params)
@@ -257,7 +258,7 @@ export class KTX2Loader extends Loader<Texture2D | TextureCube> {
               KTX2Loader._createTextureByBuffer(engine, ktx2Container.isSRGB, result, targetFormat, params)
             )
             .then((texture) => {
-              resourceManager.addContentRestorer(new KTX2ContentRestorer(texture, url, requestConfig));
+              resourceManager.addContentRestorer(new KTX2ContentRestorer(texture, remoteUrl, requestConfig));
               resolve(texture);
             })
         )
@@ -269,7 +270,7 @@ export class KTX2Loader extends Loader<Texture2D | TextureCube> {
 class KTX2ContentRestorer extends ContentRestorer<Texture2D | TextureCube> {
   constructor(
     resource: Texture2D | TextureCube,
-    public url: string,
+    public remoteUrl: string,
     public requestConfig: RequestConfig & { params?: KTX2Params }
   ) {
     super(resource);
@@ -281,7 +282,7 @@ class KTX2ContentRestorer extends ContentRestorer<Texture2D | TextureCube> {
     return new AssetPromise((resolve, reject) => {
       engine.resourceManager
         // @ts-ignore
-        ._request<ArrayBuffer>(this.url, requestConfig)
+        ._requestByRemoteUrl<ArrayBuffer>(this.remoteUrl, requestConfig)
         .then((buffer) =>
           KTX2Loader._parseBuffer(new Uint8Array(buffer), engine, requestConfig.params).then(
             ({ ktx2Container, engine, result, targetFormat, params }) =>

--- a/tests/src/core/Utils.test.ts
+++ b/tests/src/core/Utils.test.ts
@@ -5,6 +5,17 @@ describe("Utils test", function () {
   it("is absolute", () => {
     expect(Utils.isAbsoluteUrl("/test.png")).to.false;
     expect(Utils.isAbsoluteUrl("https://www.galacean.com/test.png")).to.true;
+
+    const absoluteUrls = [
+      "blob:https://www.galacean.com/font",
+      "data:font/woff2;base64,AAAA",
+      "file:///Assets/Fonts/Hero.woff",
+      "galacean-asset:Hero.woff"
+    ];
+    for (const url of absoluteUrls) {
+      expect(Utils.isAbsoluteUrl(url)).to.true;
+      expect(Utils.resolveAbsoluteUrl("Assets/Fonts/Hero.font", url)).to.equal(url);
+    }
   });
 
   it("resolve base url", () => {

--- a/tests/src/core/Utils.test.ts
+++ b/tests/src/core/Utils.test.ts
@@ -28,20 +28,22 @@ describe("Utils test", function () {
       "https://www.galacean.com/texture.png"
     );
 
-    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "file.html")).to.equal(
-      "/path/to/file.html"
-    );
+    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "file.html")).to.equal("/path/to/file.html");
 
-    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "../file.html")).to.equal(
-      "/path/file.html"
-    );
+    expect(Utils.resolveAbsoluteUrl("/path/to/dir", "../file.html")).to.equal("/path/file.html");
 
-    expect(Utils.resolveAbsoluteUrl("/a/b", "./空 格")).to.equal(
-      "/a/空 格"
-    );
+    expect(Utils.resolveAbsoluteUrl("/a/b", "./空 格")).to.equal("/a/空 格");
 
     expect(Utils.resolveAbsoluteUrl("/a c%/中%20文/test1/test2", "../空 格/测%试.json")).to.equal(
       "/a c%/中%20文/空 格/测%试.json"
+    );
+
+    expect(Utils.resolveAbsoluteUrl("SpriteAtlas/Art/UI/auto-atlas.atlas", "./auto-atlas_image_0.tex")).to.equal(
+      "SpriteAtlas/Art/UI/auto-atlas_image_0.tex"
+    );
+
+    expect(Utils.resolveAbsoluteUrl("SpriteAtlas/Art/UI/auto-atlas.atlas", "/Shared/page.tex")).to.equal(
+      "/Shared/page.tex"
     );
 
     const base64Url = "data:application/octet-stream;base64,AAAAAImICD2JiIg9zczMPYmICD6rqio";

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -94,7 +94,7 @@ describe("ResourceManager", () => {
       resourceManager.registerVirtualResources([
         { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: AssetType.Texture }
       ]);
-      // @ts-ignore
+      // @ts-ignore -- 需要观察内部 Loader 入参，验证虚拟资源不会被改写为物理地址
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
         .mockReturnValue(new AssetPromise(() => {}));

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -118,6 +118,24 @@ describe("ResourceManager", () => {
   });
 
   describe("load asset", () => {
+    it("resolves a relative baseUrl once at the request boundary", async () => {
+      const resourceManager = engine.resourceManager;
+      const requestSpy = vi
+        .spyOn(resourceManager, "_requestByRemoteUrl")
+        .mockReturnValue(AssetPromise.resolve("content") as any);
+      resourceManager.baseUrl = "assets/";
+
+      try {
+        const asset = await resourceManager.load({ type: AssetType.Text, url: "text/file.txt" });
+
+        expect(requestSpy).toHaveBeenCalledWith("assets/text/file.txt", expect.objectContaining({ type: "text" }));
+        asset.destroy();
+      } finally {
+        resourceManager.baseUrl = null;
+        requestSpy.mockRestore();
+      }
+    });
+
     it("not found", async () => {
       try {
         await engine.resourceManager.load("/model.glb");

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -28,6 +28,26 @@ describe("ResourceManager", () => {
       getResource = engine.resourceManager.getFromCache(wrongUrl);
       expect(getResource).equal(null);
     });
+
+    it("returns a virtual resource from the cache by its logical path", async () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Prefab/Cache/Character.prefab";
+      const physicalPath = "blob:https://local.alipay.net/cache-character";
+      const resource = { instanceId: 987654324 };
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Prefab }]);
+      // @ts-ignore -- replace the internal loader to isolate cache-key behavior
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Prefab], "load")
+        .mockReturnValue(AssetPromise.resolve(resource) as any);
+
+      try {
+        expect(await resourceManager.load(virtualPath)).equal(resource);
+        expect(resourceManager.getFromCache(virtualPath)).equal(resource);
+        expect(resourceManager.getFromCache(physicalPath)).equal(resource);
+      } finally {
+        loaderSpy.mockRestore();
+      }
+    });
   });
 
   describe("findResourcesByType", () => {
@@ -179,6 +199,31 @@ describe("ResourceManager", () => {
         expect(loadItem.url).equal(virtualPath);
         expect(loadItem).not.toHaveProperty("resolvedUrl");
       } finally {
+        loaderSpy.mockRestore();
+      }
+    });
+
+    it("cancels a pending virtual resource by its logical path", () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Prefab/Pending/Character.prefab";
+      const physicalPath = "blob:https://local.alipay.net/pending-character";
+      const onCancelSpy = vi.fn();
+      const pendingPromise = new AssetPromise((_resolve, _reject, _setComplete, _setDetail, onCancel) => {
+        onCancel(onCancelSpy);
+      });
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Prefab }]);
+      // @ts-ignore -- replace the internal loader to keep the request pending
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Prefab], "load")
+        .mockReturnValue(pendingPromise as any);
+
+      try {
+        resourceManager.load(virtualPath).catch(() => {});
+        resourceManager.cancelNotLoaded(virtualPath);
+
+        expect(onCancelSpy).toHaveBeenCalledOnce();
+      } finally {
+        resourceManager.cancelNotLoaded(physicalPath);
         loaderSpy.mockRestore();
       }
     });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -94,7 +94,7 @@ describe("ResourceManager", () => {
       resourceManager.registerVirtualResources([
         { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: AssetType.Texture }
       ]);
-      // @ts-ignore -- 需要读取内部 Loader 注册表，验证 VFS 中记录的 type 决定 Loader 选择
+      // @ts-ignore -- inspect the internal loader registry to verify VFS-driven type selection
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
         .mockReturnValue(new AssetPromise(() => {}));
@@ -166,7 +166,7 @@ describe("ResourceManager", () => {
       const virtualPath = "Assets/precompiled-shader";
       const physicalPath = "/Assets/precompiled-shader.shaderc";
       resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Shader }]);
-      // @ts-ignore -- 需要观察内部 Loader 入参，验证虚拟资源不会被改写为物理地址
+      // @ts-ignore -- inspect the internal loader input to verify that virtual resource identity is preserved
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Shader], "load")
         .mockReturnValue(new AssetPromise(() => {}));

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -94,7 +94,7 @@ describe("ResourceManager", () => {
       resourceManager.registerVirtualResources([
         { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: AssetType.Texture }
       ]);
-      // @ts-ignore -- 需要观察内部 Loader 入参，验证虚拟资源不会被改写为物理地址
+      // @ts-ignore -- 需要读取内部 Loader 注册表，验证 VFS 中记录的 type 决定 Loader 选择
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
         .mockReturnValue(new AssetPromise(() => {}));
@@ -166,7 +166,7 @@ describe("ResourceManager", () => {
       const virtualPath = "Assets/precompiled-shader";
       const physicalPath = "/Assets/precompiled-shader.shaderc";
       resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Shader }]);
-      // @ts-ignore
+      // @ts-ignore -- 需要观察内部 Loader 入参，验证虚拟资源不会被改写为物理地址
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Shader], "load")
         .mockReturnValue(new AssetPromise(() => {}));

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -48,6 +48,25 @@ describe("ResourceManager", () => {
         loaderSpy.mockRestore();
       }
     });
+
+    it("resolves relative cache keys against baseUrl", async () => {
+      const resourceManager = engine.resourceManager;
+      const relativePath = "Prefab/Cache/Relative.prefab";
+      const resource = { instanceId: 987654325 };
+      resourceManager.baseUrl = "https://base.example.com/project/";
+      // @ts-ignore -- replace the internal loader to isolate cache-key behavior
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Prefab], "load")
+        .mockReturnValue(AssetPromise.resolve(resource) as any);
+
+      try {
+        expect(await resourceManager.load(relativePath)).equal(resource);
+        expect(resourceManager.getFromCache(relativePath)).equal(resource);
+      } finally {
+        resourceManager.baseUrl = null;
+        loaderSpy.mockRestore();
+      }
+    });
   });
 
   describe("findResourcesByType", () => {
@@ -192,13 +211,14 @@ describe("ResourceManager", () => {
         .mockReturnValue(new AssetPromise(() => {}));
 
       try {
-        resourceManager.load({ url: virtualPath });
+        resourceManager.load({ url: virtualPath }).catch(() => {});
 
         expect(loaderSpy).toHaveBeenCalled();
         const [loadItem] = loaderSpy.mock.calls[0];
         expect(loadItem.url).equal(virtualPath);
         expect(loadItem).not.toHaveProperty("resolvedUrl");
       } finally {
+        resourceManager.cancelNotLoaded(virtualPath);
         loaderSpy.mockRestore();
       }
     });
@@ -224,6 +244,54 @@ describe("ResourceManager", () => {
         expect(onCancelSpy).toHaveBeenCalledOnce();
       } finally {
         resourceManager.cancelNotLoaded(physicalPath);
+        loaderSpy.mockRestore();
+      }
+    });
+
+    it("cancels a pending relative resource with baseUrl", () => {
+      const resourceManager = engine.resourceManager;
+      const relativePath = "Prefab/Pending/Relative.prefab";
+      const onCancelSpy = vi.fn();
+      const pendingPromise = new AssetPromise((_resolve, _reject, _setComplete, _setDetail, onCancel) => {
+        onCancel(onCancelSpy);
+      });
+      resourceManager.baseUrl = "https://base.example.com/project/";
+      // @ts-ignore -- replace the internal loader to keep the request pending
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Prefab], "load")
+        .mockReturnValue(pendingPromise as any);
+
+      try {
+        resourceManager.load(relativePath).catch(() => {});
+        resourceManager.cancelNotLoaded(relativePath);
+
+        expect(onCancelSpy).toHaveBeenCalledOnce();
+      } finally {
+        resourceManager.cancelNotLoaded(relativePath);
+        resourceManager.baseUrl = null;
+        loaderSpy.mockRestore();
+      }
+    });
+
+    it("cancels a pending virtual sub-asset by its logical path", async () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Assets/Pending/model.glb";
+      const subAssetPath = `${virtualPath}?q=materials[0]`;
+      resourceManager.registerVirtualResources([
+        { virtualPath, path: "blob:https://local.alipay.net/pending-model", type: AssetType.GLTF }
+      ]);
+      // @ts-ignore -- replace the internal loader to keep the main asset pending
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.GLTF], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      try {
+        const subAssetPromise = resourceManager.load(subAssetPath);
+        resourceManager.cancelNotLoaded(subAssetPath);
+
+        await expect(subAssetPromise).rejects.toBe("canceled");
+      } finally {
+        resourceManager.cancelNotLoaded(virtualPath);
         loaderSpy.mockRestore();
       }
     });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -161,6 +161,28 @@ describe("ResourceManager", () => {
       }
     });
 
+    it("preserves the virtual resource identity for loaders", () => {
+      const resourceManager = engine.resourceManager;
+      const virtualPath = "Assets/precompiled-shader";
+      const physicalPath = "/Assets/precompiled-shader.shaderc";
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Shader }]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Shader], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      try {
+        resourceManager.load({ url: virtualPath });
+
+        expect(loaderSpy).toHaveBeenCalled();
+        const [loadItem] = loaderSpy.mock.calls[0];
+        expect(loadItem.url).equal(virtualPath);
+        expect(loadItem).not.toHaveProperty("resolvedUrl");
+      } finally {
+        loaderSpy.mockRestore();
+      }
+    });
+
     it("fills params from virtualPathResourceMap when params is omitted", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.registerVirtualResources([
@@ -313,9 +335,9 @@ describe("ResourceManager", () => {
 
     it("resolves virtualPath via map even when baseUrl is set", () => {
       const resourceManager = engine.resourceManager;
-      resourceManager.registerVirtualResources([
-        { virtualPath: "Assets/withBaseUrl", path: "https://cdn.ali.com/real.json", type: AssetType.Texture }
-      ]);
+      const virtualPath = "Assets/withBaseUrl";
+      const physicalPath = "https://cdn.ali.com/real.json";
+      resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Texture }]);
       // @ts-ignore
       const loaderSpy = vi
         .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
@@ -323,9 +345,13 @@ describe("ResourceManager", () => {
       resourceManager.baseUrl = "https://base.com/app/";
 
       try {
-        resourceManager.load({ url: "Assets/withBaseUrl" });
+        resourceManager.load({ url: virtualPath });
         expect(loaderSpy).toHaveBeenCalled();
-        expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
+        expect(loaderSpy.mock.calls[0][0]).toMatchObject({
+          type: AssetType.Texture,
+          url: virtualPath
+        });
+        expect(loaderSpy.mock.calls[0][0]).not.toHaveProperty("resolvedUrl");
       } finally {
         resourceManager.baseUrl = null;
         loaderSpy.mockRestore();

--- a/tests/src/loader/FontLoader.test.ts
+++ b/tests/src/loader/FontLoader.test.ts
@@ -1,0 +1,76 @@
+import { AssetPromise, AssetType, Font, ResourceManager, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("FontLoader", () => {
+  it("preserves an absolute blob font URL", async () => {
+    const resourceManager = engine.resourceManager;
+    const configVirtualPath = "Assets/Fonts/Blob.font";
+    const configPhysicalPath = "blob:https://local.alipay.net/blob-font-config";
+    const fontUrl = "blob:https://local.alipay.net/blob-font";
+    resourceManager.registerVirtualResources([
+      { virtualPath: configVirtualPath, path: configPhysicalPath, type: AssetType.Font }
+    ]);
+    const requestSpy = vi
+      .spyOn(resourceManager, "_requestByRemoteUrl")
+      .mockReturnValue(AssetPromise.resolve({ fontName: "BlobFont", fontUrl }) as any);
+    const registerSpy = vi
+      .spyOn(ResourceManager._loaders[AssetType.Font] as any, "_registerFont")
+      .mockResolvedValue(undefined);
+    let font: Font;
+
+    try {
+      font = await resourceManager.load(configVirtualPath);
+
+      expect(requestSpy).toHaveBeenCalledWith(configPhysicalPath, expect.objectContaining({ type: "json" }));
+      expect(registerSpy).toHaveBeenCalledWith("BlobFont", fontUrl);
+    } finally {
+      font?.destroy();
+      delete (resourceManager as any)._virtualPathResourceMap[configVirtualPath];
+      requestSpy.mockRestore();
+      registerSpy.mockRestore();
+    }
+  });
+
+  it("resolves relative font URLs in logical space before virtual mapping", async () => {
+    const resourceManager = engine.resourceManager;
+    const configVirtualPath = "Assets/Fonts/Hero.font";
+    const fontVirtualPath = "Assets/Fonts/Hero.woff";
+    const configPhysicalPath = "blob:https://local.alipay.net/hero-font-config";
+    const fontPhysicalPath = "blob:https://local.alipay.net/hero-font";
+    resourceManager.registerVirtualResources([
+      { virtualPath: configVirtualPath, path: configPhysicalPath, type: AssetType.Font },
+      { virtualPath: fontVirtualPath, path: fontPhysicalPath, type: AssetType.SourceFont }
+    ]);
+    const requestSpy = vi
+      .spyOn(resourceManager, "_requestByRemoteUrl")
+      .mockReturnValue(AssetPromise.resolve({ fontName: "Hero", fontUrl: "./Hero.woff" }) as any);
+    const registerSpy = vi
+      .spyOn(ResourceManager._loaders[AssetType.Font] as any, "_registerFont")
+      .mockResolvedValue(undefined);
+    let font: Font;
+
+    try {
+      font = await resourceManager.load(configVirtualPath);
+
+      expect(requestSpy).toHaveBeenCalledWith(configPhysicalPath, expect.objectContaining({ type: "json" }));
+      expect(registerSpy).toHaveBeenCalledWith("Hero", fontPhysicalPath);
+    } finally {
+      font?.destroy();
+      delete (resourceManager as any)._virtualPathResourceMap[configVirtualPath];
+      delete (resourceManager as any)._virtualPathResourceMap[fontVirtualPath];
+      requestSpy.mockRestore();
+      registerSpy.mockRestore();
+    }
+  });
+});

--- a/tests/src/loader/GLTFLoader.test.ts
+++ b/tests/src/loader/GLTFLoader.test.ts
@@ -1,4 +1,5 @@
 import {
+  AssetPromise,
   AssetType,
   BlinnPhongMaterial,
   Entity,
@@ -27,7 +28,7 @@ import {
 } from "@galacean/engine-loader";
 import { Color } from "@galacean/engine-math";
 import { WebGLEngine } from "@galacean/engine";
-import { describe, beforeAll, afterAll, expect, it } from "vitest";
+import { describe, beforeAll, afterAll, expect, it, vi } from "vitest";
 
 let engine: WebGLEngine;
 beforeAll(async function () {
@@ -39,6 +40,10 @@ beforeAll(async function () {
   @registerGLTFParser(GLTFParserType.Schema)
   class GLTFCustomJSONParser extends GLTFParser {
     parse(context: GLTFParserContext) {
+      if (context.glTFResource.url === "Assets/Models/Hero.gltf") {
+        return new GLTFSchemaParser().parse(context);
+      }
+
       if (context.glTFResource.url.endsWith("testSkinRoot.gltf")) {
         context.buffers = [new ArrayBuffer(128)];
         return Promise.resolve({
@@ -602,6 +607,51 @@ afterAll(() => {
 });
 
 describe("glTF Loader test", function () {
+  it("resolves external buffers in logical space before virtual mapping", async () => {
+    const resourceManager = engine.resourceManager;
+    const glTFVirtualPath = "Assets/Models/Hero.gltf";
+    const bufferVirtualPath = "Assets/Buffers/Hero.bin";
+    const glTFPhysicalPath = "blob:https://local.alipay.net/hero-gltf";
+    const bufferPhysicalPath = "blob:https://local.alipay.net/hero-buffer";
+    const buffer = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]).buffer;
+    const glTF = {
+      asset: { version: "2.0" },
+      scene: 0,
+      scenes: [{ nodes: [0] }],
+      nodes: [{ mesh: 0 }],
+      meshes: [{ primitives: [{ attributes: { POSITION: 0 }, mode: 4 }] }],
+      accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: "VEC3" }],
+      bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: buffer.byteLength }],
+      buffers: [{ byteLength: buffer.byteLength, uri: "../Buffers/Hero.bin" }]
+    };
+    const glTFBuffer = new TextEncoder().encode(JSON.stringify(glTF)).buffer;
+    resourceManager.registerVirtualResources([
+      { virtualPath: glTFVirtualPath, path: glTFPhysicalPath, type: AssetType.GLTF },
+      { virtualPath: bufferVirtualPath, path: bufferPhysicalPath, type: AssetType.Buffer }
+    ]);
+    const requestSpy = vi.spyOn(resourceManager, "_requestByRemoteUrl").mockImplementation((url) => {
+      if (url === glTFPhysicalPath) return AssetPromise.resolve(glTFBuffer) as any;
+      if (url === bufferPhysicalPath) return AssetPromise.resolve(buffer) as any;
+      return new AssetPromise((_resolve, reject) => reject(new Error(`Unexpected transport URL: ${url}`)));
+    });
+    let resource: GLTFResource;
+
+    try {
+      resource = await resourceManager.load(glTFVirtualPath);
+
+      expect(requestSpy.mock.calls.map(([url]) => url)).toEqual([glTFPhysicalPath, bufferPhysicalPath]);
+      const restorer = Object.values((resourceManager as any)._contentRestorerPool).find(
+        (candidate: any) => candidate.resource === resource
+      ) as any;
+      expect(restorer.bufferRequests[0].url).toBe(bufferPhysicalPath);
+    } finally {
+      resource?.destroy();
+      delete (resourceManager as any)._virtualPathResourceMap[glTFVirtualPath];
+      delete (resourceManager as any)._virtualPathResourceMap[bufferVirtualPath];
+      requestSpy.mockRestore();
+    }
+  });
+
   it("Pipeline Parser", async () => {
     const glTFResource: GLTFResource = await engine.resourceManager.load({
       type: AssetType.GLTF,

--- a/tests/src/loader/RenderTargetLoader.test.ts
+++ b/tests/src/loader/RenderTargetLoader.test.ts
@@ -1,7 +1,7 @@
-import { AssetType, RenderTarget, Texture2D, TextureFormat } from "@galacean/engine-core";
+import { AssetPromise, AssetType, RenderTarget, Texture2D, TextureFormat } from "@galacean/engine-core";
 import "@galacean/engine-loader";
 import { WebGLEngine } from "@galacean/engine";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 let engine: WebGLEngine;
 
@@ -19,6 +19,55 @@ function createRenderTargetBlob(data: Record<string, any>): string {
 }
 
 describe("RenderTargetLoader", () => {
+  it("keeps concurrent relative sub-assets bound to their request base URL", async () => {
+    const resourceManager = engine.resourceManager;
+    const logicalUrl = "render-targets/concurrent.renderTarget";
+    const baseUrlA = "https://a.example.com/";
+    const baseUrlB = "https://b.example.com/";
+    const remoteUrlA = `${baseUrlA}${logicalUrl}`;
+    const remoteUrlB = `${baseUrlB}${logicalUrl}`;
+    const requests = new Map<string, (data: unknown) => void>();
+    const requestSpy = vi.spyOn(resourceManager, "_requestByRemoteUrl").mockImplementation((url) => {
+      return new AssetPromise((resolve) => requests.set(url, resolve));
+    });
+    const data = {
+      width: 1,
+      height: 1,
+      colorFormats: [TextureFormat.R8G8B8A8],
+      depthFormat: -1,
+      antiAliasing: 1
+    };
+
+    try {
+      resourceManager.baseUrl = baseUrlA;
+      const textureA = resourceManager.load<Texture2D>({
+        url: `${logicalUrl}?q=colorTextures[0]`,
+        type: AssetType.RenderTarget
+      });
+      resourceManager.baseUrl = baseUrlB;
+      const textureB = resourceManager.load<Texture2D>({
+        url: `${logicalUrl}?q=colorTextures[0]`,
+        type: AssetType.RenderTarget
+      });
+      let textureBSettled = false;
+      textureB.then(() => (textureBSettled = true));
+
+      requests.get(remoteUrlA)!(data);
+      const loadedTextureA = await textureA;
+
+      expect(textureBSettled).toBe(false);
+
+      requests.get(remoteUrlB)!(data);
+      const loadedTextureB = await textureB;
+      expect(loadedTextureB).not.toBe(loadedTextureA);
+    } finally {
+      resourceManager.baseUrl = null;
+      requests.get(remoteUrlA)?.(data);
+      requests.get(remoteUrlB)?.(data);
+      requestSpy.mockRestore();
+    }
+  });
+
   it("load returns RenderTarget with correct properties", async () => {
     const url = createRenderTargetBlob({
       width: 256,

--- a/tests/src/loader/SpriteAtlasLoader.test.ts
+++ b/tests/src/loader/SpriteAtlasLoader.test.ts
@@ -36,11 +36,11 @@ describe("SpriteAtlasLoader", () => {
         }
       });
     });
-    // @ts-ignore -- 需要替换内部 Texture Loader，隔离图片解码并观察页面资源请求
+    // @ts-ignore -- loaders are registered in ResourceManager's internal registry
     const textureLoaderSpy = vi
       .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
       .mockImplementation((item, manager) => {
-        // @ts-ignore -- 通过内部请求入口验证逻辑路径只在 I/O 边界映射为物理地址
+        // @ts-ignore -- exercise ResourceManager's virtual-to-transport mapping boundary
         return manager._request(item.url, { ...item, type: "arraybuffer" }).then(() => new Texture2D(engine, 1, 1));
       });
 

--- a/tests/src/loader/SpriteAtlasLoader.test.ts
+++ b/tests/src/loader/SpriteAtlasLoader.test.ts
@@ -1,0 +1,65 @@
+import { AssetPromise, AssetType, ResourceManager, Texture2D, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("SpriteAtlasLoader", () => {
+  it("keeps virtual atlas page paths resolvable when a base URL is configured", async () => {
+    const resourceManager = engine.resourceManager;
+    const atlasVirtualPath = "SpriteAtlas/Migrated/BaseUrl/ui.atlas";
+    const pageVirtualPath = "SpriteAtlas/Migrated/BaseUrl/ui_image_0.tex";
+    const atlasPhysicalPath = "blob:https://local.alipay.net/atlas";
+    const pagePhysicalPath = "blob:https://local.alipay.net/atlas-page";
+    resourceManager.registerVirtualResources([
+      { virtualPath: atlasVirtualPath, path: atlasPhysicalPath, type: AssetType.SpriteAtlas },
+      { virtualPath: pageVirtualPath, path: pagePhysicalPath, type: AssetType.Texture }
+    ]);
+    resourceManager.baseUrl = "https://base.example.com/project/";
+
+    const requestSpy = vi.spyOn(resourceManager as any, "_requestByRemoteUrl").mockImplementation((url: string) => {
+      return new AssetPromise((resolve, reject) => {
+        if (url === atlasPhysicalPath) {
+          resolve({ atlasItems: [{ img: "./ui_image_0.tex", sprites: [] }] });
+        } else if (url === pagePhysicalPath) {
+          resolve(new ArrayBuffer(0));
+        } else {
+          reject(new Error(`Unexpected transport URL: ${url}`));
+        }
+      });
+    });
+    // @ts-ignore - loaders are registered in ResourceManager's internal registry
+    const textureLoaderSpy = vi
+      .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+      .mockImplementation((item, manager) => {
+        // @ts-ignore - exercise ResourceManager's virtual-to-transport mapping boundary
+        return manager._request(item.url, { ...item, type: "arraybuffer" }).then(() => new Texture2D(engine, 1, 1));
+      });
+
+    try {
+      await resourceManager.load({ url: atlasVirtualPath });
+
+      expect(requestSpy).toHaveBeenCalledWith(atlasPhysicalPath, expect.objectContaining({ type: "json" }));
+      expect(requestSpy).toHaveBeenCalledWith(pagePhysicalPath, expect.objectContaining({ type: "arraybuffer" }));
+      expect(textureLoaderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: pageVirtualPath,
+          type: AssetType.Texture
+        }),
+        resourceManager
+      );
+    } finally {
+      resourceManager.baseUrl = null;
+      requestSpy.mockRestore();
+      textureLoaderSpy.mockRestore();
+    }
+  });
+});

--- a/tests/src/loader/SpriteAtlasLoader.test.ts
+++ b/tests/src/loader/SpriteAtlasLoader.test.ts
@@ -36,11 +36,11 @@ describe("SpriteAtlasLoader", () => {
         }
       });
     });
-    // @ts-ignore - loaders are registered in ResourceManager's internal registry
+    // @ts-ignore -- 需要替换内部 Texture Loader，隔离图片解码并观察页面资源请求
     const textureLoaderSpy = vi
       .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
       .mockImplementation((item, manager) => {
-        // @ts-ignore - exercise ResourceManager's virtual-to-transport mapping boundary
+        // @ts-ignore -- 通过内部请求入口验证逻辑路径只在 I/O 边界映射为物理地址
         return manager._request(item.url, { ...item, type: "arraybuffer" }).then(() => new Texture2D(engine, 1, 1));
       });
 

--- a/tests/src/loader/TextureLoader.test.ts
+++ b/tests/src/loader/TextureLoader.test.ts
@@ -1,0 +1,49 @@
+import { AssetPromise, AssetType, Texture2D, WebGLEngine } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("TextureLoader", () => {
+  it("keeps the resource identity when image decoding fails during content restoration", async () => {
+    const resourceManager = engine.resourceManager;
+    const virtualPath = "Texture/Migrated/page.tex";
+    const physicalPath = "blob:https://local.alipay.net/page";
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const pngBlob = await new Promise<Blob>((resolve) => canvas.toBlob((blob) => resolve(blob!), "image/png"));
+    const pngBytes = await pngBlob.arrayBuffer();
+    const invalidBytes = new Uint8Array([1, 2, 3]).buffer;
+    resourceManager.registerVirtualResources([{ virtualPath, path: physicalPath, type: AssetType.Texture }]);
+    const requestSpy = vi
+      .spyOn(resourceManager as any, "_requestByRemoteUrl")
+      .mockReturnValue(AssetPromise.resolve(pngBytes));
+
+    try {
+      const texture = await resourceManager.load<Texture2D>({ url: virtualPath });
+      const restorers = Object.values((resourceManager as any)._contentRestorerPool) as Array<{
+        resource: Texture2D;
+        restoreContent(): AssetPromise<Texture2D>;
+      }>;
+      const restorer = restorers.find((candidate) => candidate.resource === texture);
+      expect(restorer).toBeDefined();
+
+      requestSpy.mockReturnValue(AssetPromise.resolve(invalidBytes));
+
+      await expect(restorer!.restoreContent()).rejects.toThrow(
+        `TextureLoader: failed to decode texture "${virtualPath}" (${invalidBytes.byteLength} bytes).`
+      );
+    } finally {
+      requestSpy.mockRestore();
+    }
+  });
+});

--- a/tests/src/loader/TextureLoader.test.ts
+++ b/tests/src/loader/TextureLoader.test.ts
@@ -13,6 +13,35 @@ afterAll(() => {
 });
 
 describe("TextureLoader", () => {
+  it("restores a relative texture from its original request base URL", async () => {
+    const resourceManager = engine.resourceManager;
+    const logicalUrl = "textures/relative.png";
+    const baseUrlA = "https://a.example.com/";
+    const baseUrlB = "https://b.example.com/";
+    const remoteUrlA = `${baseUrlA}${logicalUrl}`;
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const pngBlob = await new Promise<Blob>((resolve) => canvas.toBlob((blob) => resolve(blob!), "image/png"));
+    const pngBytes = await pngBlob.arrayBuffer();
+    const requestSpy = vi.spyOn(resourceManager, "_requestByRemoteUrl").mockReturnValue(AssetPromise.resolve(pngBytes));
+
+    try {
+      resourceManager.baseUrl = baseUrlA;
+      const texture = await resourceManager.load<Texture2D>({ url: logicalUrl, type: AssetType.Texture });
+      const restorer = Object.values((resourceManager as any)._contentRestorerPool).find(
+        (candidate: any) => candidate.resource === texture
+      ) as { restoreContent(): AssetPromise<Texture2D> };
+
+      resourceManager.baseUrl = baseUrlB;
+      expect(await restorer.restoreContent()).toBe(texture);
+      expect(requestSpy.mock.calls.map(([url]) => url)).toEqual([remoteUrlA, remoteUrlA]);
+    } finally {
+      resourceManager.baseUrl = null;
+      requestSpy.mockRestore();
+    }
+  });
+
   it("keeps the resource identity when image decoding fails during content restoration", async () => {
     const resourceManager = engine.resourceManager;
     const virtualPath = "Texture/Migrated/page.tex";


### PR DESCRIPTION
## 问题

Editor Preview 会将工程文件注册为 VFS 虚拟资源。SpriteAtlas 元数据中的页面路径 `./auto-atlas_image_0.tex`，必须先基于 Atlas 的逻辑路径 `SpriteAtlas/.../auto-atlas.atlas` 推导为 `SpriteAtlas/.../auto-atlas_image_0.tex`，再由 `ResourceManager` 映射到 Blob 或 CDN 等物理加载地址。

此前 `LoadItem.url` 在进入 Loader 前被改写为物理 URL；后续相对路径推导随之基于物理 URL 运行，VFS key 因而丢失。对于无 scheme 的路径，原先的 `file://` 用法还会把首段当作 host 并按 URL 规则小写化，导致 `SpriteAtlas/...` 被请求为 `spriteatlas/...`，Preview 无法启动。

## 修复

- 已注册虚拟资源的 `LoadItem.url` 始终保留 `virtualPath`；`baseUrl` 只作用于普通、未注册的相对传输 URL。
- `ResourceManager` 的加载、子资源回调、缓存查询与取消统一通过 `_getRemoteUrl` 派生物理 key；内部 cache/loading pool 仍只保存一份物理 key。
- 虚拟相对路径通过 `file:///` 的 pathname 解析，避免首段进入 host 规范化，并保留 leading slash 语义。
- 纹理解码与内容恢复复用同一解码和 Object URL 释放路径；失败信息包含逻辑资源标识与字节数。

## 覆盖

- Loader 收到 virtualPath，且 `baseUrl` 不会改写已注册 VFS key。
- SpriteAtlas → 相对页面纹理 → ResourceManager 的端到端映射。
- 虚拟资源加载后可按 virtualPath 从公开缓存接口取回同一对象。
- pending 虚拟资源可按 virtualPath 从公开取消接口终止。
- Texture content restoration 的解码失败诊断。

## 分支边界

这是 #3079 在 `dev/2.0` 上的等价修复：基于 `dev/2.0@bd34daa` 重放 #3079 的最终 loader 改动。后续提交仅对齐项目的英文注释规范并闭环 review 反馈，不包含迁移分支的其他提交。

## 验证

- `HEADLESS=true pnpm vitest run`：124 files / 1658 tests passed
- focused loader/resource tests：4 files / 28 tests passed
- `pnpm b:module`
- `pnpm b:types`：12 个 package project 均通过
- `pnpm lint`：0 errors；1622 existing warnings
- `pnpm format:check` 与改动测试文件的 Prettier check
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of relative and leading-slash asset paths, including textures referenced from atlas files.
  * Preserved virtual asset identity end-to-end so dependent requests, caching, and cancellation use the expected virtual paths.
  * Refined non-HDR texture decoding/restoration and improved decode-failure errors to include the resource path and decoded byte length.
* **Documentation**
  * Clarified documentation of virtual resource identity for URL handling.
* **Tests**
  * Added/extended coverage for virtual atlas loading and virtual texture restoration, plus updated path-resolution assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->