### PR TITLE
feat(core): add progressive runtime environment light capture

### DIFF
--- a/packages/core/src/RenderPipeline/RenderQueue.ts
+++ b/packages/core/src/RenderPipeline/RenderQueue.ts
@@ -62,6 +62,13 @@ export class RenderQueue {
     const { instanceId: sceneId, shaderData: sceneData, _maskManager: maskManager } = scene;
     const renderCount = engine._renderCount;
     const rhi = engine._hardwareRenderer;
+    const realtimeSphericalHarmonicsBuffer = scene.ambientLight._realtimeSphericalHarmonicsBuffer;
+    if (realtimeSphericalHarmonicsBuffer) {
+      rhi.bindUniformBufferBase(
+        ConstantBufferBindingPoint.RealtimeIBLSphericalHarmonics,
+        realtimeSphericalHarmonicsBuffer._platformBuffer
+      );
+    }
     const pipelineStageKey = RenderContext.pipelineStageKey;
     const renderQueueType = this.renderQueueType;
     const needMaskType = maskType !== RenderQueueMaskType.No;

--- a/packages/core/src/lighting/AmbientLight.ts
+++ b/packages/core/src/lighting/AmbientLight.ts
@@ -2,6 +2,7 @@ import { Color, SphericalHarmonics3 } from "@galacean/engine-math";
 import { ReferResource } from "../asset/ReferResource";
 import { Engine } from "../Engine";
 import { Scene } from "../Scene";
+import { Buffer } from "../graphic/Buffer";
 import { ShaderData } from "../shader";
 import { ShaderMacro } from "../shader/ShaderMacro";
 import { ShaderProperty } from "../shader/ShaderProperty";
@@ -12,7 +13,11 @@ import { DiffuseMode } from "./enums/DiffuseMode";
  * Ambient light.
  */
 export class AmbientLight extends ReferResource {
+  /** GPU-authored pre-scaled SH used while runtime environment capture owns the diffuse environment. @internal */
+  _realtimeSphericalHarmonicsBuffer: Buffer | null = null;
+
   private static _shMacro: ShaderMacro = ShaderMacro.getByName("SCENE_USE_SH");
+  private static _realtimeSHMacro: ShaderMacro = ShaderMacro.getByName("SCENE_USE_REALTIME_SH");
   private static _specularMacro: ShaderMacro = ShaderMacro.getByName("SCENE_USE_SPECULAR_ENV");
 
   private static _diffuseColorProperty: ShaderProperty = ShaderProperty.getByName("scene_EnvMapLight.diffuse");
@@ -74,6 +79,7 @@ export class AmbientLight extends ReferResource {
   }
 
   set diffuseSphericalHarmonics(value: SphericalHarmonics3) {
+    this._setRealtimeSphericalHarmonicsBuffer(null);
     this._diffuseSphericalHarmonics = value;
     if (value) {
       this._preComputeSH(value, this._shArray);
@@ -144,6 +150,7 @@ export class AmbientLight extends ReferResource {
     shaderData.setFloatArray(AmbientLight._diffuseSHProperty, this._shArray);
 
     this._setDiffuseMode(shaderData);
+    this._setRealtimeSphericalHarmonicsMode(shaderData);
     this._setSpecularTexture(shaderData);
   }
 
@@ -158,10 +165,29 @@ export class AmbientLight extends ReferResource {
     const shaderData = scene.shaderData;
     shaderData.setTexture(AmbientLight._specularTextureProperty, null);
     shaderData.disableMacro(AmbientLight._specularMacro);
+    shaderData.disableMacro(AmbientLight._realtimeSHMacro);
   }
 
   constructor(engine: Engine) {
     super(engine);
+  }
+
+  /** Installs or clears the GPU-authored runtime SH override. @internal */
+  _setRealtimeSphericalHarmonicsBuffer(buffer: Buffer | null): void {
+    const wasEnabled = this._realtimeSphericalHarmonicsBuffer !== null;
+    const isEnabled = buffer !== null;
+    this._realtimeSphericalHarmonicsBuffer = buffer;
+    if (wasEnabled !== isEnabled) {
+      const scenes = this._scenes;
+      for (let i = 0, n = scenes.length; i < n; i++) {
+        this._setRealtimeSphericalHarmonicsMode(scenes[i].shaderData);
+      }
+    }
+  }
+
+  /** Returns the CPU-authored pre-scaled SH fallback used to seed runtime GPU projection. @internal */
+  _getDiffuseSphericalHarmonicsData(): Float32Array {
+    return this._shArray;
   }
 
   private _setDiffuseMode(sceneShaderData: ShaderData): void {
@@ -169,6 +195,14 @@ export class AmbientLight extends ReferResource {
       sceneShaderData.enableMacro(AmbientLight._shMacro);
     } else {
       sceneShaderData.disableMacro(AmbientLight._shMacro);
+    }
+  }
+
+  private _setRealtimeSphericalHarmonicsMode(sceneShaderData: ShaderData): void {
+    if (this._realtimeSphericalHarmonicsBuffer) {
+      sceneShaderData.enableMacro(AmbientLight._realtimeSHMacro);
+    } else {
+      sceneShaderData.disableMacro(AmbientLight._realtimeSHMacro);
     }
   }
 

--- a/packages/core/src/lighting/environment/EnvironmentLightCapture.ts
+++ b/packages/core/src/lighting/environment/EnvironmentLightCapture.ts
@@ -1,0 +1,668 @@
+import { Color, Matrix, Quaternion, type SphericalHarmonics3, Vector3 } from "@galacean/engine-math";
+import { Camera } from "../../Camera";
+import { Engine } from "../../Engine";
+import { Scene } from "../../Scene";
+import { GLCapabilityType } from "../../base/Constant";
+import { CameraClearFlags } from "../../enums/CameraClearFlags";
+import { BackgroundMode } from "../../enums/BackgroundMode";
+import { Mesh } from "../../graphic";
+import { Material } from "../../material";
+import { MeshRenderer, PrimitiveMesh } from "../../mesh";
+import { Shader } from "../../shader";
+import { SkyEnvironmentCaptureMacro } from "../../sky";
+import { RenderTarget, TextureCube, TextureCubeFace, TextureFilterMode, TextureFormat } from "../../texture";
+import { AmbientLight } from "../AmbientLight";
+import { DirectLight } from "../DirectLight";
+import { DiffuseMode } from "../enums/DiffuseMode";
+import { createRealtimeIBLPrefilterSchedule, type RealtimeIBLPrefilterFrame } from "./RealtimeIBLPrefilterSchedule";
+import {
+  createRealtimeIBLSourceMipmapSchedule,
+  type RealtimeIBLSourceMipmapFrame
+} from "./RealtimeIBLSourceMipmapSchedule";
+import { RealtimeSphericalHarmonicsGPU } from "./RealtimeSphericalHarmonicsGPU";
+
+const CAPTURE_FACE_COUNT = 6;
+const PREFILTER_FRAME_COUNT = 12;
+const SOURCE_MIPMAP_MAX_DRAW_COUNT = 24;
+const SAMPLE_BATCH_SIZE = 32;
+const SPHERICAL_HARMONICS_SOURCE_RESOLUTION = 16;
+
+/** Individually measurable stage in one progressive real-time IBL update. */
+export type EnvironmentLightCaptureProfileStage =
+  | "start"
+  | "sh-project"
+  | "source-capture"
+  | "source-mipmap"
+  | "ggx-prefilter"
+  | "publish";
+
+/** Optional observer used to profile stage boundaries without coupling environment capture to a timer implementation. */
+export interface EnvironmentLightCaptureProfiler {
+  /** Begin one synchronous stage sample. */
+  beginSample(revision: number, frame: number, stage: EnvironmentLightCaptureProfileStage): void;
+  /** End the current synchronous stage sample. */
+  endSample(): void;
+}
+
+/** Options for one progressive real-time environment-light capture. */
+export interface EnvironmentLightCaptureOptions {
+  /** Width and height of each published cubemap face. @defaultValue `128` */
+  resolution?: number;
+  /** GGX samples accumulated per roughness texel before publication. @defaultValue `64` */
+  sampleCount?: number;
+  /**
+   * Whether environment capture includes a sky shader's solar disk. @defaultValue `false`
+   * @remarks
+   * Sky shaders can distinguish environment capture with `SCENE_ENVIRONMENT_CAPTURE` and inspect
+   * `SCENE_ENVIRONMENT_CAPTURE_INCLUDE_SUN` before drawing an analytic solar disk. This does not remove a disk that is
+   * already authored into a static cubemap.
+   */
+  includeSun?: boolean;
+  /** Optional stage observer for diagnostics. */
+  profiler?: EnvironmentLightCaptureProfiler;
+}
+
+/** Current state of one progressively scheduled environment update. */
+export interface EnvironmentLightCaptureSnapshot {
+  readonly phase: "idle" | "capture" | "prefilter" | "publish";
+  readonly frame: number;
+  readonly activeRevision: number | null;
+  readonly pendingRevision: number | null;
+  readonly publishedRevision: number;
+  readonly progress: number;
+  readonly resolution: number;
+  readonly sampleCount: number;
+  readonly includeSun: boolean;
+}
+
+interface SkySnapshot {
+  revision: number;
+  mesh: Mesh;
+  material: Material;
+  sunEnabled: boolean;
+  sunColor: Color;
+  sunWorldRotation: Quaternion;
+}
+
+interface ActiveBake {
+  snapshot: SkySnapshot;
+  frame: number;
+  stagingBuffer: number;
+  sphericalHarmonicsComplete: boolean;
+}
+
+interface FirstBakeWaiter {
+  resolve: (texture: TextureCube) => void;
+  reject: (reason: Error) => void;
+}
+
+/**
+ * Progressively captures and convolves the Scene sky into diffuse SH and a GGX-prefiltered specular cubemap.
+ *
+ * @remarks
+ * Every update freezes one sky revision. Six frames capture the source faces, dependency-ordered source mips are packed
+ * under texel and draw budgets, and twelve frames distribute cost-balanced GGX work into a staging cubemap. The final
+ * frame projects the source cubemap's 16-pixel mip into SH on the GPU, then atomically publishes diffuse and specular
+ * lighting. Call {@link EnvironmentLightCapture.requestUpdate} to enqueue a revision, then call
+ * {@link EnvironmentLightCapture.update} once per frame until it is published.
+ *
+ * A revision clones the sky Material and snapshots `Scene.sun`. Custom sky parameters that must remain stable during
+ * capture should therefore live in the sky Material's shader data. Arbitrary Scene shader data is intentionally not
+ * copied into the private capture Scene because it can contain unrelated lighting, fog, and render-state ownership.
+ */
+export class EnvironmentLightCapture {
+  readonly resolution: number;
+  readonly sampleCount: number;
+  readonly includeSun: boolean;
+
+  private static readonly _owners = new WeakMap<AmbientLight, EnvironmentLightCapture>();
+
+  private readonly _engine: Engine;
+  private readonly _sourceScene: Scene;
+  private readonly _ambientLight: AmbientLight;
+  private readonly _bakerScene: Scene;
+  private readonly _camera: Camera;
+  private readonly _planeRenderer: MeshRenderer;
+  private readonly _planeMesh: Mesh;
+  private readonly _bakerSun: DirectLight;
+  private readonly _sourceTexture: TextureCube;
+  private readonly _sourceRenderTarget: RenderTarget;
+  private readonly _sphericalHarmonicsMipLevel: number;
+  private readonly _sourceMipmapSchedule: readonly RealtimeIBLSourceMipmapFrame[];
+  private readonly _prefilterSchedule: readonly RealtimeIBLPrefilterFrame[];
+  private readonly _prefilterStartFrame: number;
+  private readonly _shProjectFrame: number;
+  private readonly _publishFrame: number;
+  private readonly _accumulationTextures: readonly [TextureCube, TextureCube];
+  private readonly _accumulationRenderTargets: readonly [RenderTarget, RenderTarget];
+  private readonly _outputTextures: readonly [TextureCube, TextureCube];
+  private readonly _outputRenderTargets: readonly [RenderTarget, RenderTarget];
+  private readonly _accumulationMaterial: Material;
+  private readonly _resolveMaterial: Material;
+  private readonly _gpuSphericalHarmonics: RealtimeSphericalHarmonicsGPU;
+  private readonly _profiler: EnvironmentLightCaptureProfiler | undefined;
+  private readonly _initialDiffuseMode: DiffuseMode;
+  private readonly _initialSphericalHarmonics: SphericalHarmonics3 | undefined;
+  private readonly _initialSpecularTexture: TextureCube | null;
+  private readonly _captureViewMatrix = new Matrix();
+  private readonly _firstBakeWaiters: FirstBakeWaiter[] = [];
+
+  private _activeBake: ActiveBake | null = null;
+  private _pendingSnapshot: SkySnapshot | null = null;
+  private _latestRevision = 0;
+  private _publishedRevision = 0;
+  private _publishedBuffer = -1;
+  private _destroyed = false;
+
+  constructor(scene: Scene, options: EnvironmentLightCaptureOptions = {}) {
+    const resolution = options.resolution ?? 128;
+    const sampleCount = options.sampleCount ?? 64;
+    validateOptions(resolution, sampleCount);
+
+    const engine = (this._engine = scene.engine);
+    if (!engine._hardwareRenderer.isWebGL2) {
+      throw new Error("EnvironmentLightCapture requires WebGL2 cubemap mip rendering.");
+    }
+    if (
+      !engine._hardwareRenderer.canIUse(GLCapabilityType.textureHalfFloat) ||
+      !engine._hardwareRenderer.canIUse(GLCapabilityType.colorBufferHalfFloat)
+    ) {
+      throw new Error("EnvironmentLightCapture requires renderable half-float textures.");
+    }
+    const ambientLight = scene.ambientLight;
+    if (EnvironmentLightCapture._owners.has(ambientLight)) {
+      throw new Error("EnvironmentLightCapture requires exclusive ownership of the Scene AmbientLight.");
+    }
+    this._sourceScene = scene;
+    this._ambientLight = ambientLight;
+    this.resolution = resolution;
+    this.sampleCount = sampleCount;
+    this.includeSun = options.includeSun ?? false;
+    this._profiler = options.profiler;
+
+    this._initialDiffuseMode = ambientLight.diffuseMode;
+    this._initialSphericalHarmonics = ambientLight.diffuseSphericalHarmonics;
+    this._initialSpecularTexture = ambientLight.specularTexture ?? null;
+
+    const accumulationShader = Shader.find("Lighting/RealtimeIBLAccumulate");
+    const resolveShader = Shader.find("Lighting/RealtimeIBLResolve");
+    if (!accumulationShader || !resolveShader) {
+      throw new Error("EnvironmentLightCapture shaders are not registered. Run the shader precompile step before use.");
+    }
+    this._accumulationMaterial = new Material(engine, accumulationShader);
+    this._resolveMaterial = new Material(engine, resolveShader);
+
+    const bakerScene = (this._bakerScene = new Scene(engine));
+    bakerScene.name = "Realtime IBL Baker";
+    bakerScene.isActive = false;
+    bakerScene.background.solidColor.set(0, 0, 0, 1);
+    bakerScene.shaderData.enableMacro(SkyEnvironmentCaptureMacro.Capture);
+    if (this.includeSun) {
+      bakerScene.shaderData.enableMacro(SkyEnvironmentCaptureMacro.IncludeSun);
+    }
+    engine.sceneManager.addScene(bakerScene);
+
+    const root = bakerScene.createRootEntity("Realtime IBL Baker");
+    const camera = (this._camera = root.addComponent(Camera));
+    camera.enabled = false;
+    camera.enableFrustumCulling = false;
+    camera.enableHDR = true;
+    camera.isAlphaOutputRequired = true;
+    camera.enablePostProcess = false;
+    camera.fieldOfView = 90;
+    camera.aspectRatio = 1;
+    camera.clearFlags = CameraClearFlags.Color;
+
+    const sunEntity = root.createChild("Realtime IBL Sun");
+    this._bakerSun = sunEntity.addComponent(DirectLight);
+    bakerScene.sun = this._bakerSun;
+
+    const planeEntity = root.createChild("Realtime IBL Fullscreen Plane");
+    planeEntity.isActive = false;
+    const planeRenderer = (this._planeRenderer = planeEntity.addComponent(MeshRenderer));
+    const planeMesh = (this._planeMesh = PrimitiveMesh.createPlane(engine, 2, 2));
+    planeRenderer.mesh = planeMesh;
+    planeRenderer.setMaterial(this._resolveMaterial);
+
+    const sourceTexture = (this._sourceTexture = createCubemap(engine, resolution, true, TextureFilterMode.Point));
+    this._sourceRenderTarget = createRenderTarget(engine, resolution, sourceTexture);
+    const sphericalHarmonicsSourceResolution = Math.min(resolution, SPHERICAL_HARMONICS_SOURCE_RESOLUTION);
+    this._sphericalHarmonicsMipLevel = Math.log2(resolution / sphericalHarmonicsSourceResolution);
+    this._sourceMipmapSchedule = createRealtimeIBLSourceMipmapSchedule({
+      resolution,
+      mipCount: sourceTexture.mipmapCount,
+      maximumDrawCount: SOURCE_MIPMAP_MAX_DRAW_COUNT
+    });
+    this._prefilterStartFrame = CAPTURE_FACE_COUNT + this._sourceMipmapSchedule.length;
+    this._shProjectFrame = this._prefilterStartFrame + PREFILTER_FRAME_COUNT;
+    this._publishFrame = this._shProjectFrame;
+    this._prefilterSchedule = createRealtimeIBLPrefilterSchedule({
+      resolution,
+      mipCount: sourceTexture.mipmapCount,
+      sampleCount,
+      sampleBatchSize: SAMPLE_BATCH_SIZE,
+      frameCount: PREFILTER_FRAME_COUNT
+    });
+    this._gpuSphericalHarmonics = new RealtimeSphericalHarmonicsGPU(
+      engine,
+      ambientLight._getDiffuseSphericalHarmonicsData()
+    );
+    this._gpuSphericalHarmonics.warmUp(sourceTexture, 0, ambientLight._getDiffuseSphericalHarmonicsData());
+
+    const accumulationTexture0 = createCubemap(engine, resolution, true, TextureFilterMode.Point);
+    const accumulationTexture1 = createCubemap(engine, resolution, true, TextureFilterMode.Point);
+    this._accumulationTextures = [accumulationTexture0, accumulationTexture1];
+    this._accumulationRenderTargets = [
+      createRenderTarget(engine, resolution, accumulationTexture0),
+      createRenderTarget(engine, resolution, accumulationTexture1)
+    ];
+
+    const outputTexture0 = createCubemap(engine, resolution, true, TextureFilterMode.Trilinear);
+    const outputTexture1 = createCubemap(engine, resolution, true, TextureFilterMode.Trilinear);
+    outputTexture0.name = "RealtimeIBL-0";
+    outputTexture1.name = "RealtimeIBL-1";
+    this._outputTextures = [outputTexture0, outputTexture1];
+    this._outputRenderTargets = [
+      createRenderTarget(engine, resolution, outputTexture0),
+      createRenderTarget(engine, resolution, outputTexture1)
+    ];
+    EnvironmentLightCapture._owners.set(ambientLight, this);
+  }
+
+  /**
+   * Clone the current Scene sky and queue it as the newest environment-lighting revision.
+   * @remarks Calling this again replaces an older pending revision without interrupting a revision already in flight.
+   */
+  requestUpdate(): number {
+    this._assertAlive();
+    const revision = this._latestRevision + 1;
+    const snapshot = this._captureSnapshot(revision);
+    this._latestRevision = revision;
+    if (this._pendingSnapshot) {
+      this._releaseSnapshot(this._pendingSnapshot);
+    }
+    this._pendingSnapshot = snapshot;
+    return snapshot.revision;
+  }
+
+  /** Process exactly one frame in the generated capture schedule. */
+  update(): void {
+    this._assertAlive();
+    if (!this._activeBake && this._pendingSnapshot) {
+      const pendingSnapshot = this._pendingSnapshot;
+      this._profileStage(pendingSnapshot.revision, 0, "start", () => this._startPendingBake());
+    }
+    const activeBake = this._activeBake;
+    if (!activeBake) {
+      return;
+    }
+
+    if (activeBake.frame <= this._shProjectFrame) {
+      this._withBakerSceneActive(() => this._processGpuFrame(activeBake));
+    }
+    if (activeBake.frame === this._publishFrame && activeBake.sphericalHarmonicsComplete) {
+      this._profileStage(activeBake.snapshot.revision, activeBake.frame, "publish", () => this._publish(activeBake));
+      this._activeBake = null;
+    } else if (activeBake.frame < this._publishFrame) {
+      activeBake.frame++;
+    }
+  }
+
+  /** Resolves with the first fully published specular cubemap. */
+  waitForFirstUpdate(): Promise<TextureCube> {
+    if (this._publishedBuffer >= 0) {
+      return Promise.resolve(this._outputTextures[this._publishedBuffer]);
+    }
+    if (this._destroyed) {
+      return Promise.reject(new Error("EnvironmentLightCapture was destroyed before publishing."));
+    }
+    return new Promise<TextureCube>((resolve, reject) => this._firstBakeWaiters.push({ resolve, reject }));
+  }
+
+  /** Return a detached status snapshot for diagnostics. */
+  getSnapshot(): EnvironmentLightCaptureSnapshot {
+    const active = this._activeBake;
+    const frame = active?.frame ?? -1;
+    return {
+      phase:
+        frame < 0
+          ? "idle"
+          : frame < CAPTURE_FACE_COUNT
+            ? "capture"
+            : frame < this._shProjectFrame
+              ? "prefilter"
+              : "publish",
+      frame,
+      activeRevision: active?.snapshot.revision ?? null,
+      pendingRevision: this._pendingSnapshot?.revision ?? null,
+      publishedRevision: this._publishedRevision,
+      progress: active ? frame / this._publishFrame : this._publishedRevision > 0 ? 1 : 0,
+      resolution: this.resolution,
+      sampleCount: this.sampleCount,
+      includeSun: this.includeSun
+    };
+  }
+
+  /** Restore the scene's original ambient assets and release all runtime-owned GPU resources. */
+  destroy(): void {
+    if (this._destroyed) {
+      return;
+    }
+    this._destroyed = true;
+    const ambientLight = this._ambientLight;
+    if (this._gpuSphericalHarmonics.ownsCurrentBuffer(ambientLight._realtimeSphericalHarmonicsBuffer)) {
+      ambientLight._setRealtimeSphericalHarmonicsBuffer(null);
+      if (this._initialSphericalHarmonics) {
+        ambientLight.diffuseSphericalHarmonics = this._initialSphericalHarmonics;
+      }
+      ambientLight.diffuseMode = this._initialDiffuseMode;
+    }
+    if (
+      ambientLight.specularTexture === this._outputTextures[0] ||
+      ambientLight.specularTexture === this._outputTextures[1]
+    ) {
+      ambientLight.specularTexture = this._initialSpecularTexture!;
+    }
+
+    this._camera.renderTarget = null;
+    const activeSnapshot = this._activeBake?.snapshot;
+    const pendingSnapshot = this._pendingSnapshot;
+    this._bakerScene.destroy();
+    if (activeSnapshot) {
+      this._releaseSnapshot(activeSnapshot);
+    }
+    if (pendingSnapshot) {
+      this._releaseSnapshot(pendingSnapshot);
+    }
+    this._activeBake = null;
+    this._pendingSnapshot = null;
+    this._sourceRenderTarget.destroy(true);
+    this._accumulationRenderTargets[0].destroy(true);
+    this._accumulationRenderTargets[1].destroy(true);
+    this._outputRenderTargets[0].destroy(true);
+    this._outputRenderTargets[1].destroy(true);
+    this._sourceTexture.destroy(true);
+    this._accumulationTextures[0].destroy(true);
+    this._accumulationTextures[1].destroy(true);
+    this._outputTextures[0].destroy(true);
+    this._outputTextures[1].destroy(true);
+    this._planeMesh.destroy(true);
+    this._accumulationMaterial.destroy(true);
+    this._resolveMaterial.destroy(true);
+    this._gpuSphericalHarmonics.destroy();
+
+    const error = new Error("EnvironmentLightCapture was destroyed before publishing.");
+    for (let i = 0; i < this._firstBakeWaiters.length; i++) {
+      this._firstBakeWaiters[i].reject(error);
+    }
+    this._firstBakeWaiters.length = 0;
+    if (EnvironmentLightCapture._owners.get(ambientLight) === this) {
+      EnvironmentLightCapture._owners.delete(ambientLight);
+    }
+  }
+
+  private _captureSnapshot(revision: number): SkySnapshot {
+    const sourceScene = this._sourceScene;
+    const material = sourceScene.background.sky.material;
+    const mesh = sourceScene.background.sky.mesh;
+    if (sourceScene.background.mode !== BackgroundMode.Sky || !material || !mesh) {
+      throw new Error("EnvironmentLightCapture requires an active Scene sky with a material and mesh.");
+    }
+    if (material.destroyed || mesh.destroyed) {
+      throw new Error("EnvironmentLightCapture cannot capture a destroyed Scene sky resource.");
+    }
+
+    const capturedMaterial = material.clone();
+    capturedMaterial._addReferCount(1);
+    mesh._addReferCount(1);
+    const sun = sourceScene.sun;
+    return {
+      revision,
+      mesh,
+      material: capturedMaterial,
+      sunEnabled: sun?.enabled ?? false,
+      sunColor: sun?.color.clone() ?? new Color(0, 0, 0, 1),
+      sunWorldRotation: sun?.entity.transform.worldRotationQuaternion.clone() ?? new Quaternion()
+    };
+  }
+
+  private _startPendingBake(): void {
+    const snapshot = this._pendingSnapshot!;
+    this._pendingSnapshot = null;
+    this._activeBake = {
+      snapshot,
+      frame: 0,
+      stagingBuffer: this._publishedBuffer === 0 ? 1 : 0,
+      sphericalHarmonicsComplete: false
+    };
+    this._sourceTexture.filterMode = TextureFilterMode.Point;
+
+    this._bakerScene.background.sky.mesh = snapshot.mesh;
+    this._bakerScene.background.sky.material = snapshot.material;
+    this._bakerScene.background.mode = BackgroundMode.Sky;
+    this._bakerSun.enabled = snapshot.sunEnabled;
+    this._bakerSun.color.copyFrom(snapshot.sunColor);
+    this._bakerSun.entity.transform.worldRotationQuaternion = snapshot.sunWorldRotation;
+
+    const ambientLight = this._ambientLight;
+    if (!this._gpuSphericalHarmonics.ownsCurrentBuffer(ambientLight._realtimeSphericalHarmonicsBuffer)) {
+      this._gpuSphericalHarmonics.resetCurrent(ambientLight._getDiffuseSphericalHarmonicsData());
+    }
+  }
+
+  private _processGpuFrame(activeBake: ActiveBake): void {
+    const frame = activeBake.frame;
+    if (frame < CAPTURE_FACE_COUNT) {
+      const revision = activeBake.snapshot.revision;
+      this._profileStage(revision, frame, "source-capture", () => this._captureSourceFace(activeBake, frame));
+    } else if (frame < this._prefilterStartFrame) {
+      this._profileStage(activeBake.snapshot.revision, frame, "source-mipmap", () =>
+        this._processSourceMipmapFrame(frame)
+      );
+    } else if (frame < this._shProjectFrame) {
+      this._profileStage(activeBake.snapshot.revision, frame, "ggx-prefilter", () =>
+        this._processPrefilterFrame(activeBake)
+      );
+    } else if (frame === this._shProjectFrame) {
+      this._profileStage(activeBake.snapshot.revision, frame, "sh-project", () => {
+        this._gpuSphericalHarmonics.project(this._sourceTexture, this._sphericalHarmonicsMipLevel);
+        activeBake.sphericalHarmonicsComplete = true;
+      });
+    }
+  }
+
+  private _processSourceMipmapFrame(frame: number): void {
+    const scheduleFrame = this._sourceMipmapSchedule[frame - CAPTURE_FACE_COUNT];
+    for (let i = 0; i < scheduleFrame.mips.length; i++) {
+      this._downsampleSourceMip(scheduleFrame.mips[i]);
+    }
+    if (frame === this._prefilterStartFrame - 1) {
+      this._sourceTexture.filterMode = TextureFilterMode.Trilinear;
+    }
+  }
+
+  private _downsampleSourceMip(mip: number): void {
+    const shaderData = this._resolveMaterial.shaderData;
+    shaderData.setTexture("material_SourceMap", this._sourceTexture);
+    shaderData.setFloat("material_SourceLod", mip - 1);
+    shaderData.setFloat("material_ResolveAccumulation", 0);
+    shaderData.setFloat("material_Downsample", 1);
+    shaderData.setFloat("material_TargetSize", Math.max(1, this.resolution / 2 ** mip));
+    for (let face = 0; face < 6; face++) {
+      shaderData.setFloat("material_Face", face);
+      this._renderPlane(this._resolveMaterial, this._accumulationRenderTargets[0], face, mip);
+    }
+
+    shaderData.setTexture("material_SourceMap", this._accumulationTextures[0]);
+    shaderData.setFloat("material_SourceLod", mip);
+    shaderData.setFloat("material_Downsample", 0);
+    for (let face = 0; face < 6; face++) {
+      shaderData.setFloat("material_Face", face);
+      this._renderPlane(this._resolveMaterial, this._sourceRenderTarget, face, mip);
+    }
+  }
+
+  private _captureSourceFace(activeBake: ActiveBake, face: number): void {
+    this._planeRenderer.entity.isActive = false;
+    this._bakerScene.background.mode = BackgroundMode.Sky;
+    this._camera.renderTarget = this._sourceRenderTarget;
+    this._setCaptureView(face);
+    this._camera.render(TextureCubeFace.PositiveX + face);
+
+    const shaderData = this._resolveMaterial.shaderData;
+    shaderData.setTexture("material_SourceMap", this._sourceTexture);
+    shaderData.setFloat("material_Face", face);
+    shaderData.setFloat("material_SourceLod", 0);
+    shaderData.setFloat("material_ResolveAccumulation", 0);
+    shaderData.setFloat("material_Downsample", 0);
+    this._renderPlane(this._resolveMaterial, this._outputRenderTargets[activeBake.stagingBuffer], face, 0);
+  }
+
+  private _processPrefilterFrame(activeBake: ActiveBake): void {
+    const frame = this._prefilterSchedule[activeBake.frame - this._prefilterStartFrame];
+    for (let i = 0; i < frame.items.length; i++) {
+      const item = frame.items[i];
+      this._accumulateBatch(item.face, item.mip, item.batchIndex);
+      if (item.resolveSurface) {
+        this._resolveSurface(activeBake.stagingBuffer, item.face, item.mip, item.batchIndex & 1);
+      }
+    }
+  }
+
+  private _accumulateBatch(face: number, mip: number, batchIndex: number): void {
+    const writeBuffer = batchIndex & 1;
+    const readBuffer = writeBuffer ^ 1;
+    const shaderData = this._accumulationMaterial.shaderData;
+    shaderData.setTexture("material_EnvironmentMap", this._sourceTexture);
+    shaderData.setTexture("material_PreviousAccumulationMap", this._accumulationTextures[readBuffer]);
+    shaderData.setFloat("material_Face", face);
+    shaderData.setFloat("material_Roughness", mip / (this._sourceTexture.mipmapCount - 1));
+    shaderData.setFloat("material_EnvironmentSize", this.resolution);
+    shaderData.setFloat("material_AccumulationLod", mip);
+    shaderData.setFloat("material_SampleOffset", batchIndex * SAMPLE_BATCH_SIZE);
+    shaderData.setFloat("material_TotalSampleCount", this.sampleCount);
+    this._renderPlane(this._accumulationMaterial, this._accumulationRenderTargets[writeBuffer], face, mip);
+  }
+
+  private _resolveSurface(stagingBuffer: number, face: number, mip: number, accumulationBuffer: number): void {
+    const shaderData = this._resolveMaterial.shaderData;
+    shaderData.setTexture("material_SourceMap", this._accumulationTextures[accumulationBuffer]);
+    shaderData.setFloat("material_Face", face);
+    shaderData.setFloat("material_SourceLod", mip);
+    shaderData.setFloat("material_ResolveAccumulation", 1);
+    shaderData.setFloat("material_Downsample", 0);
+    this._renderPlane(this._resolveMaterial, this._outputRenderTargets[stagingBuffer], face, mip);
+  }
+
+  private _renderPlane(material: Material, target: RenderTarget, face: number, mip: number): void {
+    this._bakerScene.background.mode = BackgroundMode.SolidColor;
+    this._planeRenderer.setMaterial(material);
+    this._planeRenderer.entity.isActive = true;
+    this._camera.renderTarget = target;
+    this._camera.render(TextureCubeFace.PositiveX + face, mip);
+  }
+
+  private _publish(activeBake: ActiveBake): void {
+    const ambientLight = this._ambientLight;
+    ambientLight.diffuseMode = DiffuseMode.SphericalHarmonics;
+    ambientLight._setRealtimeSphericalHarmonicsBuffer(this._gpuSphericalHarmonics.currentBuffer);
+    ambientLight.specularTexture = this._outputTextures[activeBake.stagingBuffer];
+    this._publishedBuffer = activeBake.stagingBuffer;
+    this._publishedRevision = activeBake.snapshot.revision;
+    const texture = this._outputTextures[this._publishedBuffer];
+    for (let i = 0; i < this._firstBakeWaiters.length; i++) {
+      this._firstBakeWaiters[i].resolve(texture);
+    }
+    this._firstBakeWaiters.length = 0;
+    this._bakerScene.background.sky.material = null;
+    this._bakerScene.background.sky.mesh = null;
+    this._releaseSnapshot(activeBake.snapshot);
+  }
+
+  private _setCaptureView(face: number): void {
+    const basis = CUBE_FACE_BASES[face];
+    Matrix.lookAt(CAPTURE_ORIGIN, basis.forward, basis.up, this._captureViewMatrix);
+    this._camera.viewMatrix = this._captureViewMatrix;
+  }
+
+  private _withBakerSceneActive(action: () => void): void {
+    this._bakerScene.isActive = true;
+    try {
+      this._bakerScene._updateShaderData();
+      action();
+    } finally {
+      this._planeRenderer.entity.isActive = false;
+      this._bakerScene.isActive = false;
+    }
+  }
+
+  private _profileStage(
+    revision: number,
+    frame: number,
+    stage: EnvironmentLightCaptureProfileStage,
+    action: () => void
+  ): void {
+    const profiler = this._profiler;
+    if (!profiler) {
+      action();
+      return;
+    }
+    profiler.beginSample(revision, frame, stage);
+    try {
+      action();
+    } finally {
+      profiler.endSample();
+    }
+  }
+
+  private _releaseSnapshot(snapshot: SkySnapshot): void {
+    snapshot.material._addReferCount(-1);
+    snapshot.material.destroy();
+    snapshot.mesh._addReferCount(-1);
+  }
+
+  private _assertAlive(): void {
+    if (this._destroyed) {
+      throw new Error("EnvironmentLightCapture has been destroyed.");
+    }
+    if (this._sourceScene.ambientLight !== this._ambientLight) {
+      throw new Error("EnvironmentLightCapture requires the Scene AmbientLight assigned at construction.");
+    }
+  }
+}
+
+const CAPTURE_ORIGIN = new Vector3();
+const CUBE_FACE_BASES = [
+  { forward: new Vector3(1, 0, 0), up: new Vector3(0, -1, 0) },
+  { forward: new Vector3(-1, 0, 0), up: new Vector3(0, -1, 0) },
+  { forward: new Vector3(0, 1, 0), up: new Vector3(0, 0, 1) },
+  { forward: new Vector3(0, -1, 0), up: new Vector3(0, 0, -1) },
+  { forward: new Vector3(0, 0, 1), up: new Vector3(0, -1, 0) },
+  { forward: new Vector3(0, 0, -1), up: new Vector3(0, -1, 0) }
+] as const;
+
+function createCubemap(
+  engine: Engine,
+  resolution: number,
+  mipmap: boolean,
+  filterMode: TextureFilterMode
+): TextureCube {
+  const texture = new TextureCube(engine, resolution, TextureFormat.R16G16B16A16, mipmap, false);
+  texture.filterMode = filterMode;
+  return texture;
+}
+
+function createRenderTarget(engine: Engine, resolution: number, texture: TextureCube): RenderTarget {
+  const renderTarget = new RenderTarget(engine, resolution, resolution, texture);
+  renderTarget.autoGenerateMipmaps = false;
+  return renderTarget;
+}
+
+function validateOptions(resolution: number, sampleCount: number): void {
+  if (!Number.isInteger(resolution) || resolution < 2 || (resolution & (resolution - 1)) !== 0) {
+    throw new RangeError("EnvironmentLightCapture resolution must be a power-of-two integer greater than one.");
+  }
+  if (!Number.isInteger(sampleCount) || sampleCount < SAMPLE_BATCH_SIZE || sampleCount % SAMPLE_BATCH_SIZE !== 0) {
+    throw new RangeError(`EnvironmentLightCapture sampleCount must be a multiple of ${SAMPLE_BATCH_SIZE}.`);
+  }
+}

--- a/packages/core/src/lighting/environment/RealtimeIBLPrefilterSchedule.ts
+++ b/packages/core/src/lighting/environment/RealtimeIBLPrefilterSchedule.ts
@@ -1,0 +1,217 @@
+const CUBEMAP_FACE_COUNT = 6;
+
+/** @internal */
+export interface RealtimeIBLPrefilterScheduleOptions {
+  readonly resolution: number;
+  readonly mipCount: number;
+  readonly sampleCount: number;
+  readonly sampleBatchSize: number;
+  readonly frameCount: number;
+}
+
+/** @internal */
+export interface RealtimeIBLPrefilterWorkItem {
+  readonly face: number;
+  readonly mip: number;
+  readonly batchIndex: number;
+  readonly resolveSurface: boolean;
+  readonly estimatedSampleWork: number;
+  readonly estimatedDrawCount: number;
+}
+
+/** @internal */
+export interface RealtimeIBLPrefilterFrame {
+  readonly items: readonly RealtimeIBLPrefilterWorkItem[];
+  readonly estimatedSampleWork: number;
+  readonly estimatedDrawCount: number;
+}
+
+interface MutablePrefilterFrame {
+  items: RealtimeIBLPrefilterWorkItem[];
+  estimatedSampleWork: number;
+  estimatedDrawCount: number;
+}
+
+interface CandidateScore {
+  frameIndices: readonly number[];
+  maxNormalizedLoad: number;
+  squaredNormalizedLoad: number;
+  maxSampleWorkRatio: number;
+  maxDrawCountRatio: number;
+}
+
+/**
+ * Build a deterministic GGX schedule that balances texel/sample work and draw count across frames.
+ *
+ * @internal
+ */
+export function createRealtimeIBLPrefilterSchedule(
+  options: RealtimeIBLPrefilterScheduleOptions
+): readonly RealtimeIBLPrefilterFrame[] {
+  const { resolution, mipCount, sampleCount, sampleBatchSize, frameCount } = options;
+  const batchesPerSurface = sampleCount / sampleBatchSize;
+  const surfaceWorkItems: RealtimeIBLPrefilterWorkItem[][] = [];
+  let totalSampleWork = 0;
+  let totalDrawCount = 0;
+
+  for (let mip = 1; mip < mipCount; mip++) {
+    const mipResolution = Math.max(1, Math.floor(resolution / 2 ** mip));
+    const texelCount = mipResolution * mipResolution;
+    for (let face = 0; face < CUBEMAP_FACE_COUNT; face++) {
+      const items: RealtimeIBLPrefilterWorkItem[] = [];
+      for (let batchIndex = 0; batchIndex < batchesPerSurface; batchIndex++) {
+        const resolveSurface = batchIndex === batchesPerSurface - 1;
+        const estimatedSampleWork = texelCount * (sampleBatchSize + (resolveSurface ? 1 : 0));
+        const estimatedDrawCount = resolveSurface ? 2 : 1;
+        items.push({ face, mip, batchIndex, resolveSurface, estimatedSampleWork, estimatedDrawCount });
+        totalSampleWork += estimatedSampleWork;
+        totalDrawCount += estimatedDrawCount;
+      }
+      surfaceWorkItems.push(items);
+    }
+  }
+
+  const frames: MutablePrefilterFrame[] = Array.from({ length: frameCount }, () => ({
+    items: [],
+    estimatedSampleWork: 0,
+    estimatedDrawCount: 0
+  }));
+  const idealSampleWork = totalSampleWork / frameCount;
+  const idealDrawCount = totalDrawCount / frameCount;
+
+  // Expensive surfaces are placed first. Each surface keeps nondecreasing frame indices, so its accumulation
+  // batches remain ordered while independent faces and mips fill the lightest frames
+  for (let surfaceIndex = 0; surfaceIndex < surfaceWorkItems.length; surfaceIndex++) {
+    const items = surfaceWorkItems[surfaceIndex];
+    const frameIndices = findBestFrameIndices(frames, items, idealSampleWork, idealDrawCount);
+    applyAssignment(frames, items, frameIndices);
+  }
+
+  return frames;
+}
+
+function findBestFrameIndices(
+  frames: readonly MutablePrefilterFrame[],
+  items: readonly RealtimeIBLPrefilterWorkItem[],
+  idealSampleWork: number,
+  idealDrawCount: number
+): readonly number[] {
+  if (items.length <= 4) {
+    const frameIndices = new Array<number>(items.length);
+    let bestScore: CandidateScore | null = null;
+    const search = (itemIndex: number, minimumFrame: number): void => {
+      if (itemIndex === items.length) {
+        const score = scoreAssignment(frames, items, frameIndices, idealSampleWork, idealDrawCount);
+        if (!bestScore || isBetterScore(score, bestScore)) {
+          bestScore = score;
+        }
+        return;
+      }
+      for (let frameIndex = minimumFrame; frameIndex < frames.length; frameIndex++) {
+        frameIndices[itemIndex] = frameIndex;
+        search(itemIndex + 1, frameIndex);
+      }
+    };
+    search(0, 0);
+    return bestScore!.frameIndices;
+  }
+
+  const frameIndices = new Array<number>(items.length);
+  let minimumFrame = 0;
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    let bestScore: CandidateScore | null = null;
+    for (let frameIndex = minimumFrame; frameIndex < frames.length; frameIndex++) {
+      frameIndices[itemIndex] = frameIndex;
+      const score = scoreAssignment(
+        frames,
+        items.slice(0, itemIndex + 1),
+        frameIndices.slice(0, itemIndex + 1),
+        idealSampleWork,
+        idealDrawCount
+      );
+      if (!bestScore || isBetterScore(score, bestScore)) {
+        bestScore = score;
+      }
+    }
+    frameIndices[itemIndex] = bestScore!.frameIndices[itemIndex];
+    minimumFrame = frameIndices[itemIndex];
+  }
+  return frameIndices;
+}
+
+function scoreAssignment(
+  frames: readonly MutablePrefilterFrame[],
+  items: readonly RealtimeIBLPrefilterWorkItem[],
+  frameIndices: readonly number[],
+  idealSampleWork: number,
+  idealDrawCount: number
+): CandidateScore {
+  const addedSampleWork = new Array<number>(frames.length).fill(0);
+  const addedDrawCount = new Array<number>(frames.length).fill(0);
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    const frameIndex = frameIndices[itemIndex];
+    addedSampleWork[frameIndex] += items[itemIndex].estimatedSampleWork;
+    addedDrawCount[frameIndex] += items[itemIndex].estimatedDrawCount;
+  }
+
+  let maxNormalizedLoad = 0;
+  let squaredNormalizedLoad = 0;
+  let maxSampleWorkRatio = 0;
+  let maxDrawCountRatio = 0;
+
+  for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
+    const frame = frames[frameIndex];
+    const sampleWorkRatio = (frame.estimatedSampleWork + addedSampleWork[frameIndex]) / idealSampleWork;
+    const drawCountRatio = (frame.estimatedDrawCount + addedDrawCount[frameIndex]) / idealDrawCount;
+    const normalizedLoad = Math.max(sampleWorkRatio, drawCountRatio);
+    maxNormalizedLoad = Math.max(maxNormalizedLoad, normalizedLoad);
+    squaredNormalizedLoad += sampleWorkRatio * sampleWorkRatio + drawCountRatio * drawCountRatio;
+    maxSampleWorkRatio = Math.max(maxSampleWorkRatio, sampleWorkRatio);
+    maxDrawCountRatio = Math.max(maxDrawCountRatio, drawCountRatio);
+  }
+
+  return {
+    frameIndices: frameIndices.slice(),
+    maxNormalizedLoad,
+    squaredNormalizedLoad,
+    maxSampleWorkRatio,
+    maxDrawCountRatio
+  };
+}
+
+function isBetterScore(candidate: CandidateScore, current: CandidateScore): boolean {
+  const candidateValues = [
+    candidate.maxNormalizedLoad,
+    candidate.squaredNormalizedLoad,
+    candidate.maxSampleWorkRatio,
+    candidate.maxDrawCountRatio,
+    ...candidate.frameIndices
+  ];
+  const currentValues = [
+    current.maxNormalizedLoad,
+    current.squaredNormalizedLoad,
+    current.maxSampleWorkRatio,
+    current.maxDrawCountRatio,
+    ...current.frameIndices
+  ];
+  for (let i = 0; i < candidateValues.length; i++) {
+    if (candidateValues[i] !== currentValues[i]) {
+      return candidateValues[i] < currentValues[i];
+    }
+  }
+  return false;
+}
+
+function applyAssignment(
+  frames: MutablePrefilterFrame[],
+  items: readonly RealtimeIBLPrefilterWorkItem[],
+  frameIndices: readonly number[]
+): void {
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    const item = items[itemIndex];
+    const frame = frames[frameIndices[itemIndex]];
+    frame.items.push(item);
+    frame.estimatedSampleWork += item.estimatedSampleWork;
+    frame.estimatedDrawCount += item.estimatedDrawCount;
+  }
+}

--- a/packages/core/src/lighting/environment/RealtimeIBLSourceMipmapSchedule.ts
+++ b/packages/core/src/lighting/environment/RealtimeIBLSourceMipmapSchedule.ts
@@ -1,0 +1,70 @@
+const CUBEMAP_FACE_COUNT = 6;
+const PASSES_PER_MIP = 2;
+
+/** @internal */
+export interface RealtimeIBLSourceMipmapScheduleOptions {
+  readonly resolution: number;
+  readonly mipCount: number;
+  readonly maximumDrawCount: number;
+}
+
+/** @internal */
+export interface RealtimeIBLSourceMipmapFrame {
+  readonly mips: readonly number[];
+  readonly estimatedTexelWork: number;
+  readonly estimatedDrawCount: number;
+}
+
+/**
+ * Packs dependent source mips into ordered frames without exceeding the first mip's texel work or a draw budget.
+ *
+ * @internal
+ */
+export function createRealtimeIBLSourceMipmapSchedule(
+  options: RealtimeIBLSourceMipmapScheduleOptions
+): readonly RealtimeIBLSourceMipmapFrame[] {
+  const { resolution, mipCount, maximumDrawCount } = options;
+  const drawCountPerMip = CUBEMAP_FACE_COUNT * PASSES_PER_MIP;
+  if (mipCount <= 1) {
+    return [];
+  }
+  if (!Number.isInteger(maximumDrawCount) || maximumDrawCount < drawCountPerMip) {
+    throw new RangeError(`Realtime IBL source mip draw budget must be at least ${drawCountPerMip}.`);
+  }
+
+  const maximumTexelWork = estimateTexelWork(resolution, 1);
+  const frames: RealtimeIBLSourceMipmapFrame[] = [];
+  let mips: number[] = [];
+  let estimatedTexelWork = 0;
+  let estimatedDrawCount = 0;
+
+  const flush = (): void => {
+    if (mips.length === 0) {
+      return;
+    }
+    frames.push({ mips, estimatedTexelWork, estimatedDrawCount });
+    mips = [];
+    estimatedTexelWork = 0;
+    estimatedDrawCount = 0;
+  };
+
+  for (let mip = 1; mip < mipCount; mip++) {
+    const texelWork = estimateTexelWork(resolution, mip);
+    if (
+      mips.length > 0 &&
+      (estimatedTexelWork + texelWork > maximumTexelWork || estimatedDrawCount + drawCountPerMip > maximumDrawCount)
+    ) {
+      flush();
+    }
+    mips.push(mip);
+    estimatedTexelWork += texelWork;
+    estimatedDrawCount += drawCountPerMip;
+  }
+  flush();
+  return frames;
+}
+
+function estimateTexelWork(resolution: number, mip: number): number {
+  const mipResolution = Math.max(1, Math.floor(resolution / 2 ** mip));
+  return mipResolution * mipResolution * CUBEMAP_FACE_COUNT * PASSES_PER_MIP;
+}

--- a/packages/core/src/lighting/environment/RealtimeSphericalHarmonicsGPU.ts
+++ b/packages/core/src/lighting/environment/RealtimeSphericalHarmonicsGPU.ts
@@ -1,0 +1,95 @@
+import { Engine } from "../../Engine";
+import { Buffer } from "../../graphic/Buffer";
+import { MeshTopology } from "../../graphic/enums/MeshTopology";
+import { TransformFeedbackSimulator } from "../../graphic/TransformFeedbackSimulator";
+import { Shader } from "../../shader/Shader";
+import { ShaderData } from "../../shader/ShaderData";
+import { ShaderProperty } from "../../shader/ShaderProperty";
+import { ShaderDataGroup } from "../../shader/enums/ShaderDataGroup";
+import { TextureCube } from "../../texture";
+
+const COEFFICIENT_COUNT = 9;
+const COEFFICIENT_STRIDE = 16;
+const PROJECTION_STRIDE = COEFFICIENT_COUNT * COEFFICIENT_STRIDE;
+const PROJECT_SHADER_NAME = "Lighting/RealtimeIBLProjectSH";
+
+/** Double-buffered GPU projection for one pre-scaled three-band SH set. @internal */
+export class RealtimeSphericalHarmonicsGPU {
+  private static readonly _sourceMapProperty = ShaderProperty.getByName("renderer_SHSourceMap");
+  private static readonly _sourceMipLevelProperty = ShaderProperty.getByName("renderer_SHSourceMipLevel");
+
+  private readonly _projectionSimulator: TransformFeedbackSimulator;
+  private readonly _projectionShaderData = new ShaderData(ShaderDataGroup.Renderer);
+  private readonly _packedCoefficients = new Float32Array(COEFFICIENT_COUNT * 4);
+
+  /** Buffer currently consumed by realtime-lighting shaders. */
+  get currentBuffer(): Buffer {
+    return this._projectionSimulator.readBinding.buffer;
+  }
+
+  constructor(engine: Engine, initialPreScaledCoefficients: Float32Array) {
+    const projectionShader = Shader.find(PROJECT_SHADER_NAME);
+    if (!projectionShader) {
+      throw new Error(
+        "Realtime IBL SH shader is not registered. Run the shader precompile step before constructing the baker."
+      );
+    }
+
+    this._projectionSimulator = new TransformFeedbackSimulator(
+      engine,
+      PROJECTION_STRIDE,
+      projectionShader.subShaders[0].passes[0]
+    );
+    this._projectionSimulator.resize(1);
+    this.resetCurrent(initialPreScaledCoefficients);
+  }
+
+  /** Whether the buffer belongs to the projection staging/current ping-pong pair. */
+  ownsCurrentBuffer(buffer: Buffer | null): boolean {
+    return (
+      buffer === this._projectionSimulator.readBinding.buffer ||
+      buffer === this._projectionSimulator.writeBinding.buffer
+    );
+  }
+
+  /** Seeds both projection buffers from the ordinary CPU-authored ambient-light representation. */
+  resetCurrent(preScaledCoefficients: Float32Array): void {
+    const packed = this._packedCoefficients;
+    for (let coefficient = 0; coefficient < COEFFICIENT_COUNT; coefficient++) {
+      const sourceOffset = coefficient * 3;
+      const destinationOffset = coefficient * 4;
+      packed[destinationOffset] = preScaledCoefficients[sourceOffset];
+      packed[destinationOffset + 1] = preScaledCoefficients[sourceOffset + 1];
+      packed[destinationOffset + 2] = preScaledCoefficients[sourceOffset + 2];
+      packed[destinationOffset + 3] = 0;
+    }
+    this._projectionSimulator.readBinding.buffer.setData(packed);
+    this._projectionSimulator.writeBinding.buffer.setData(packed);
+  }
+
+  /** Compiles and submits the TF program before realtime frame profiling begins. */
+  warmUp(sourceMap: TextureCube, sourceMipLevel: number, initialPreScaledCoefficients: Float32Array): void {
+    this.project(sourceMap, sourceMipLevel);
+    this.resetCurrent(initialPreScaledCoefficients);
+  }
+
+  /** Projects a uniformly sampled source mip into a GPU-resident target SH buffer. */
+  project(sourceMap: TextureCube, sourceMipLevel: number): void {
+    const shaderData = this._projectionShaderData;
+    shaderData.setTexture(RealtimeSphericalHarmonicsGPU._sourceMapProperty, sourceMap);
+    shaderData.setFloat(RealtimeSphericalHarmonicsGPU._sourceMipLevelProperty, sourceMipLevel);
+    const simulator = this._projectionSimulator;
+    if (!simulator.beginUpdate(shaderData, [], simulator.readBinding, [])) {
+      throw new Error("Realtime IBL GPU SH projection shader failed to compile.");
+    }
+    try {
+      simulator.draw(MeshTopology.Points, 0, 1);
+    } finally {
+      simulator.endUpdate();
+    }
+  }
+
+  destroy(): void {
+    this._projectionSimulator.destroy();
+  }
+}

--- a/packages/core/src/lighting/environment/index.ts
+++ b/packages/core/src/lighting/environment/index.ts
@@ -1,0 +1,7 @@
+export { EnvironmentLightCapture } from "./EnvironmentLightCapture";
+export type {
+  EnvironmentLightCaptureOptions,
+  EnvironmentLightCaptureProfiler,
+  EnvironmentLightCaptureProfileStage,
+  EnvironmentLightCaptureSnapshot
+} from "./EnvironmentLightCapture";

--- a/packages/core/src/lighting/index.ts
+++ b/packages/core/src/lighting/index.ts
@@ -5,3 +5,4 @@ export { Light } from "./Light";
 export { PointLight } from "./PointLight";
 export { SpotLight } from "./SpotLight";
 export { AmbientOcclusion, AmbientOcclusionQuality } from "./ambientOcclusion";
+export * from "./environment";

--- a/packages/core/src/shader/ShaderFactory.ts
+++ b/packages/core/src/shader/ShaderFactory.ts
@@ -15,10 +15,13 @@ import { ShaderProperty } from "./ShaderProperty";
  */
 export class ShaderFactory {
   static readonly RENDERER_INSTANCE_BLOCK_NAME = "RendererInstanceData";
+  static readonly REALTIME_IBL_SH_BLOCK_NAME = "RealtimeIBLSphericalHarmonics";
 
   static readonly uniformBlockBindingMap: Record<number, number> = {
     [ShaderBlockProperty.getByName(ShaderFactory.RENDERER_INSTANCE_BLOCK_NAME)._uniqueId]:
-      ConstantBufferBindingPoint.RendererInstance
+      ConstantBufferBindingPoint.RendererInstance,
+    [ShaderBlockProperty.getByName(ShaderFactory.REALTIME_IBL_SH_BLOCK_NAME)._uniqueId]:
+      ConstantBufferBindingPoint.RealtimeIBLSphericalHarmonics
   };
 
   static readonly includeMap: Record<string, string> = {};
@@ -198,6 +201,16 @@ mat3 _normalMatFromModel(mat3 m) {
     }
 
     return shader;
+  }
+
+  /** Replaces the runtime SH array uniform with a std140 block after ShaderLab preprocessing. @internal */
+  static injectRealtimeIBLUniformBlocks(shader: string): string {
+    return shader.replace(
+      /uniform\s+(?:(?:lowp|mediump|highp)\s+)?vec4\s+scene_RealtimeEnvSH\s*\[\s*9\s*\]\s*;/g,
+      `layout(std140) uniform ${ShaderFactory.REALTIME_IBL_SH_BLOCK_NAME} {\n` +
+        "    vec4 scene_RealtimeEnvSH[9];\n" +
+        "};"
+    );
   }
 
   /**

--- a/packages/core/src/shader/ShaderPass.ts
+++ b/packages/core/src/shader/ShaderPass.ts
@@ -155,6 +155,11 @@ export class ShaderPass extends ShaderPart {
     let vertexSource = ShaderMacroProcessor.evaluate(this._vertexShaderInstructions, macroMap);
     let fragmentSource = ShaderMacroProcessor.evaluate(this._fragmentShaderInstructions, macroMap);
 
+    if (isWebGL2) {
+      vertexSource = ShaderFactory.injectRealtimeIBLUniformBlocks(vertexSource);
+      fragmentSource = ShaderFactory.injectRealtimeIBLUniformBlocks(fragmentSource);
+    }
+
     let instanceLayout: InstanceBufferLayout | null = null;
     if (isGPUInstance) {
       const injected = ShaderFactory.injectInstanceUBO(engine, vertexSource, fragmentSource);

--- a/packages/core/src/shader/enums/ConstantBufferBindingPoint.ts
+++ b/packages/core/src/shader/enums/ConstantBufferBindingPoint.ts
@@ -3,5 +3,6 @@
  * Constant buffer binding point allocation.
  */
 export enum ConstantBufferBindingPoint {
-  RendererInstance = 0
+  RendererInstance = 0,
+  RealtimeIBLSphericalHarmonics = 1
 }

--- a/packages/core/src/sky/Sky.ts
+++ b/packages/core/src/sky/Sky.ts
@@ -7,6 +7,19 @@ import { Shader } from "../shader/Shader";
 import { ShaderMacroCollection } from "../shader/ShaderMacroCollection";
 
 /**
+ * Shader macros supplied while a sky is rendered into environment lighting.
+ * @remarks
+ * Custom sky shaders can use {@link SkyEnvironmentCaptureMacro.Capture} to distinguish environment capture from the
+ * visible sky and {@link SkyEnvironmentCaptureMacro.IncludeSun} to decide whether to draw an analytic solar disk.
+ */
+export enum SkyEnvironmentCaptureMacro {
+  /** Defined for diffuse SH and specular cubemap capture. */
+  Capture = "SCENE_ENVIRONMENT_CAPTURE",
+  /** Defined when the captured environment should contain the analytic solar disk. */
+  IncludeSun = "SCENE_ENVIRONMENT_CAPTURE_INCLUDE_SUN"
+}
+
+/**
  * Sky.
  */
 export class Sky {

--- a/packages/core/src/sky/index.ts
+++ b/packages/core/src/sky/index.ts
@@ -1,3 +1,3 @@
-export { Sky } from "./Sky";
+export { Sky, SkyEnvironmentCaptureMacro } from "./Sky";
 export { SkyBoxMaterial } from "./SkyBoxMaterial";
 export { SkyProceduralMaterial, SunMode } from "./SkyProceduralMaterial";

--- a/packages/galacean/src/ShaderPool.ts
+++ b/packages/galacean/src/ShaderPool.ts
@@ -22,6 +22,9 @@ import {
   FinalSRGBSource,
   FinalAntiAliasingSource,
   BloomSource,
+  RealtimeIBLAccumulateSource,
+  RealtimeIBLProjectSHSource,
+  RealtimeIBLResolveSource,
   ScalableAmbientOcclusionSource
 } from "@galacean/engine-shader";
 
@@ -74,12 +77,16 @@ export class ShaderPool {
       FinalSRGBSource,
       FinalAntiAliasingSource,
       BloomSource,
+      // Environment IBL baking shaders
+      RealtimeIBLAccumulateSource,
+      RealtimeIBLProjectSHSource,
+      RealtimeIBLResolveSource,
       // AO shader
       ScalableAmbientOcclusionSource
     ];
 
     for (const source of sources) {
-      // @ts-ignore — `_createFromPrecompiled` is `Shader` @internal.
+      // @ts-expect-error — `_createFromPrecompiled` is `Shader` @internal.
       Shader._createFromPrecompiled(source);
     }
 
@@ -87,7 +94,21 @@ export class ShaderPool {
     // The pass itself is later looked up via `Shader.find` inside
     // `ParticleTransformFeedbackSimulator`, so no caching needed here.
     const feedbackPass = Shader.find("Effect/ParticleFeedback").subShaders[0].passes[0];
-    // @ts-ignore — `_feedbackVaryings` is `ShaderPass` @internal.
+    // @ts-expect-error — `_feedbackVaryings` is `ShaderPass` @internal.
     feedbackPass._feedbackVaryings = ["v_FeedbackPosition", "v_FeedbackVelocity"];
+
+    const projectSphericalHarmonicsPass = Shader.find("Lighting/RealtimeIBLProjectSH").subShaders[0].passes[0];
+    // @ts-expect-error — `_feedbackVaryings` is `ShaderPass` @internal.
+    projectSphericalHarmonicsPass._feedbackVaryings = [
+      "v_SH0",
+      "v_SH1",
+      "v_SH2",
+      "v_SH3",
+      "v_SH4",
+      "v_SH5",
+      "v_SH6",
+      "v_SH7",
+      "v_SH8"
+    ];
   }
 }

--- a/packages/shader/src/ShaderLibrary/Lighting/Light.glsl
+++ b/packages/shader/src/ShaderLibrary/Lighting/Light.glsl
@@ -124,7 +124,11 @@ struct EnvMapLight {
 EnvMapLight scene_EnvMapLight;
 
 #ifdef SCENE_USE_SH
-    vec3 scene_EnvSH[9];
+    #ifdef SCENE_USE_REALTIME_SH
+        #include "ShaderLibrary/Lighting/RealtimeSphericalHarmonics.glsl"
+    #else
+        vec3 scene_EnvSH[9];
+    #endif
 #endif
 
 #ifdef SCENE_USE_SPECULAR_ENV

--- a/packages/shader/src/ShaderLibrary/Lighting/RealtimeSphericalHarmonics.glsl
+++ b/packages/shader/src/ShaderLibrary/Lighting/RealtimeSphericalHarmonics.glsl
@@ -1,0 +1,37 @@
+#ifndef REALTIME_SPHERICAL_HARMONICS_INCLUDED
+#define REALTIME_SPHERICAL_HARMONICS_INCLUDED
+
+#ifdef SCENE_USE_REALTIME_SH
+    vec4 scene_RealtimeEnvSH[9];
+
+    vec3 getRealtimeLightProbeIrradiance(vec3 normal) {
+        vec3 result = scene_RealtimeEnvSH[0].xyz +
+            scene_RealtimeEnvSH[1].xyz * normal.y +
+            scene_RealtimeEnvSH[2].xyz * normal.z +
+            scene_RealtimeEnvSH[3].xyz * normal.x +
+            scene_RealtimeEnvSH[4].xyz * (normal.y * normal.x) +
+            scene_RealtimeEnvSH[5].xyz * (normal.y * normal.z) +
+            scene_RealtimeEnvSH[6].xyz * (3.0 * normal.z * normal.z - 1.0) +
+            scene_RealtimeEnvSH[7].xyz * (normal.z * normal.x) +
+            scene_RealtimeEnvSH[8].xyz * (normal.x * normal.x - normal.y * normal.y);
+        return max(result, vec3(0.0));
+    }
+
+    vec3 getRealtimeLightProbeRadiance(vec3 direction) {
+        float x = direction.x;
+        float y = direction.y;
+        float z = direction.z;
+        vec3 radiance = scene_RealtimeEnvSH[0].xyz * (0.282095 / 0.886227);
+        radiance += scene_RealtimeEnvSH[1].xyz * ((-0.488603 / -1.023327) * y);
+        radiance += scene_RealtimeEnvSH[2].xyz * ((0.488603 / 1.023327) * z);
+        radiance += scene_RealtimeEnvSH[3].xyz * ((-0.488603 / -1.023327) * x);
+        radiance += scene_RealtimeEnvSH[4].xyz * ((1.092548 / 0.858086) * x * y);
+        radiance += scene_RealtimeEnvSH[5].xyz * ((-1.092548 / -0.858086) * y * z);
+        radiance += scene_RealtimeEnvSH[6].xyz * ((0.315392 / 0.247708) * (3.0 * z * z - 1.0));
+        radiance += scene_RealtimeEnvSH[7].xyz * ((-1.092548 / -0.858086) * x * z);
+        radiance += scene_RealtimeEnvSH[8].xyz * ((0.546274 / 0.429042) * (x * x - y * y));
+        return max(radiance, vec3(0.0));
+    }
+#endif
+
+#endif

--- a/packages/shader/src/ShaderLibrary/PBR/LightIndirectPBR.glsl
+++ b/packages/shader/src/ShaderLibrary/PBR/LightIndirectPBR.glsl
@@ -40,7 +40,11 @@ vec3 getLightProbeIrradiance(vec3 sh[9], vec3 normal){
 
 void evaluateDiffuseIBL(Varyings varyings, SurfaceData surfaceData, BSDFData bsdfData, inout vec3 diffuseColor){
     #ifdef SCENE_USE_SH
-        vec3 irradiance = getLightProbeIrradiance(scene_EnvSH, surfaceData.normal);
+        #ifdef SCENE_USE_REALTIME_SH
+            vec3 irradiance = getRealtimeLightProbeIrradiance(surfaceData.normal);
+        #else
+            vec3 irradiance = getLightProbeIrradiance(scene_EnvSH, surfaceData.normal);
+        #endif
         irradiance *= scene_EnvMapLight.diffuseIntensity;
     #else
        vec3 irradiance = scene_EnvMapLight.diffuse * scene_EnvMapLight.diffuseIntensity;

--- a/packages/shader/src/ShaderLibrary/index.ts
+++ b/packages/shader/src/ShaderLibrary/index.ts
@@ -12,6 +12,7 @@ import Common_Transform from "./Common/Transform.glsl";
 import Lighting_AmbientOcclusion_BilateralBlur from "./Lighting/AmbientOcclusion/BilateralBlur.glsl";
 import Lighting_AmbientOcclusion_ScalableAmbientOcclusion from "./Lighting/AmbientOcclusion/ScalableAmbientOcclusion.glsl";
 import Lighting_Light from "./Lighting/Light.glsl";
+import Lighting_RealtimeSphericalHarmonics from "./Lighting/RealtimeSphericalHarmonics.glsl";
 import Noise_NoiseCommon from "./Noise/NoiseCommon.glsl";
 import Noise_NoiseSimplexGrad from "./Noise/NoiseSimplexGrad.glsl";
 import PBR_BSDF from "./PBR/BSDF.glsl";
@@ -73,6 +74,7 @@ export const shaderLibrary: IShaderSource[] = [
   { source: Lighting_AmbientOcclusion_BilateralBlur, path: "ShaderLibrary/Lighting/AmbientOcclusion/BilateralBlur.glsl" },
   { source: Lighting_AmbientOcclusion_ScalableAmbientOcclusion, path: "ShaderLibrary/Lighting/AmbientOcclusion/ScalableAmbientOcclusion.glsl" },
   { source: Lighting_Light, path: "ShaderLibrary/Lighting/Light.glsl" },
+  { source: Lighting_RealtimeSphericalHarmonics, path: "ShaderLibrary/Lighting/RealtimeSphericalHarmonics.glsl" },
   { source: Noise_NoiseCommon, path: "ShaderLibrary/Noise/NoiseCommon.glsl" },
   { source: Noise_NoiseSimplexGrad, path: "ShaderLibrary/Noise/NoiseSimplexGrad.glsl" },
   { source: PBR_BSDF, path: "ShaderLibrary/PBR/BSDF.glsl" },

--- a/packages/shader/src/Shaders/Lighting/RealtimeIBLAccumulate.shader
+++ b/packages/shader/src/Shaders/Lighting/RealtimeIBLAccumulate.shader
@@ -1,0 +1,155 @@
+Shader "Lighting/RealtimeIBLAccumulate" {
+  SubShader "Default" {
+    Pass "Forward" {
+      Tags { pipelineStage = "Forward" }
+
+      DepthState = {
+        Enabled = false;
+        WriteEnabled = false;
+      }
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      #include "ShaderLibrary/Common/Common.glsl"
+
+      samplerCube material_EnvironmentMap;
+      samplerCube material_PreviousAccumulationMap;
+      float material_Face;
+      float material_Roughness;
+      float material_EnvironmentSize;
+      float material_AccumulationLod;
+      float material_SampleOffset;
+      float material_TotalSampleCount;
+
+      const uint SAMPLE_BATCH_SIZE = 32u;
+      const float MIN_ALPHA = 0.002025;
+      const float HDR_LINEAR = 1024.0;
+      const float HDR_MAX = 16384.0;
+
+      struct Attributes {
+        vec3 POSITION;
+        vec2 TEXCOORD_0;
+      };
+
+      struct Varyings {
+        vec2 v_uv;
+      };
+
+      Varyings vert(Attributes attr) {
+        Varyings v;
+        gl_Position = vec4(attr.POSITION.xzy, 1.0);
+        gl_Position.y *= -1.0;
+        v.v_uv = attr.TEXCOORD_0;
+        return v;
+      }
+
+      vec3 cubeDirection(vec2 uv, float face) {
+        float cx = uv.x * 2.0 - 1.0;
+        float cy = uv.y * 2.0 - 1.0;
+        vec3 direction;
+        if (face == 0.0) direction = vec3(1.0, cy, -cx);
+        else if (face == 1.0) direction = vec3(-1.0, cy, cx);
+        else if (face == 2.0) direction = vec3(cx, 1.0, -cy);
+        else if (face == 3.0) direction = vec3(cx, -1.0, cy);
+        else if (face == 4.0) direction = vec3(cx, cy, 1.0);
+        else direction = vec3(-cx, cy, -1.0);
+        return normalize(direction);
+      }
+
+      vec3 compressHDR(vec3 color) {
+        const vec3 rec709 = vec3(0.2126, 0.7152, 0.0722);
+        float luma = dot(color, rec709);
+        float scale = 1.0;
+        if (luma > HDR_LINEAR) {
+          scale = (HDR_LINEAR * HDR_LINEAR - HDR_MAX * luma) /
+            ((2.0 * HDR_LINEAR - HDR_MAX - luma) * luma);
+        }
+        return color * scale;
+      }
+
+      float D_GGX(float alpha, float NoH) {
+        float f = (alpha - 1.0) * ((alpha + 1.0) * (NoH * NoH)) + 1.0;
+        return (alpha * alpha) / (PI * f * f);
+      }
+
+      float radicalInverseVdC(uint bits) {
+        bits = (bits << 16u) | (bits >> 16u);
+        bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+        bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+        bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+        bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+        return float(bits) * 2.3283064365386963e-10;
+      }
+
+      vec2 hammersley(uint index, uint count) {
+        return vec2(float(index) / float(count), radicalInverseVdC(index));
+      }
+
+      vec3 importanceSampleGGX(vec2 xi, vec3 normal, float roughness) {
+        float alpha = roughness * roughness;
+        float phi = 2.0 * PI * xi.x;
+        float cosTheta2 = (1.0 - xi.y) / (1.0 + (alpha + 1.0) * ((alpha - 1.0) * xi.y));
+        float cosTheta = sqrt(cosTheta2);
+        float sinTheta = sqrt(1.0 - cosTheta2);
+        vec3 halfVector = vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+
+        vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+        vec3 tangent = normalize(cross(up, normal));
+        vec3 bitangent = cross(normal, tangent);
+        return normalize(tangent * halfVector.x + bitangent * halfVector.y + normal * halfVector.z);
+      }
+
+      vec3 cosineSampleHemisphere(vec2 xi, vec3 normal) {
+        float phi = 2.0 * PI * xi.x;
+        float radius = sqrt(xi.y);
+        vec3 localDirection = vec3(cos(phi) * radius, sin(phi) * radius, sqrt(1.0 - xi.y));
+        vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+        vec3 tangent = normalize(cross(up, normal));
+        vec3 bitangent = cross(normal, tangent);
+        return normalize(tangent * localDirection.x + bitangent * localDirection.y + normal * localDirection.z);
+      }
+
+      void frag(Varyings v) {
+        vec3 normal = cubeDirection(v.v_uv, material_Face);
+        vec4 accumulation = material_SampleOffset == 0.0
+          ? vec4(0.0)
+          : textureCubeLodEXT(material_PreviousAccumulationMap, normal, material_AccumulationLod);
+        float omegaP = 4.0 * PI / (6.0 * material_EnvironmentSize * material_EnvironmentSize);
+        uint totalSampleCount = uint(material_TotalSampleCount);
+        uint sampleOffset = uint(material_SampleOffset);
+
+        for (uint localIndex = 0u; localIndex < SAMPLE_BATCH_SIZE; ++localIndex) {
+          uint sampleIndex = sampleOffset + localIndex;
+          vec2 xi = hammersley(sampleIndex, totalSampleCount);
+          xi.y *= 0.995;
+          if (material_Roughness > 0.99) {
+            vec3 light = cosineSampleHemisphere(xi, normal);
+            float NoL = max(dot(normal, light), 0.000001);
+            float omegaS = PI / (material_TotalSampleCount * NoL);
+            float sourceLod = max(0.5 * log2(omegaS / (2.0 * omegaP)), 0.0);
+            accumulation.rgb += compressHDR(textureCubeLodEXT(material_EnvironmentMap, light, sourceLod).rgb) /
+              material_TotalSampleCount;
+            accumulation.a += 1.0 / material_TotalSampleCount;
+            continue;
+          }
+          vec3 halfVector = importanceSampleGGX(xi, normal, material_Roughness);
+          vec3 light = normalize(2.0 * dot(normal, halfVector) * halfVector - normal);
+          float NoL = max(dot(normal, light), 0.0);
+          if (NoL > 0.0) {
+            float NoH = max(dot(normal, halfVector), 0.0);
+            float alpha = max(MIN_ALPHA, material_Roughness * material_Roughness);
+            float pdf = D_GGX(alpha, NoH) * 0.25;
+            float omegaS = 1.0 / (material_TotalSampleCount * pdf);
+            float sourceLod = max(0.5 * log2(omegaS / (2.0 * omegaP)), 0.0);
+            vec3 radiance = compressHDR(textureCubeLodEXT(material_EnvironmentMap, light, sourceLod).rgb);
+            accumulation.rgb += radiance * NoL / material_TotalSampleCount;
+            accumulation.a += NoL / material_TotalSampleCount;
+          }
+        }
+
+        gl_FragColor = accumulation;
+      }
+    }
+  }
+}

--- a/packages/shader/src/Shaders/Lighting/RealtimeIBLProjectSH.shader
+++ b/packages/shader/src/Shaders/Lighting/RealtimeIBLProjectSH.shader
@@ -1,0 +1,129 @@
+Shader "Lighting/RealtimeIBLProjectSH" {
+  SubShader "Default" {
+    Pass "TransformFeedback" {
+      Tags { pipelineStage = "TransformFeedback" }
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      samplerCube renderer_SHSourceMap;
+      float renderer_SHSourceMipLevel;
+
+      const float PI = 3.14159265359;
+      const float FOUR_PI = 12.5663706144;
+      const int SAMPLE_AXIS_COUNT = 8;
+      const float SAMPLE_COUNT = 64.0;
+
+      struct Attributes {
+        float a_Dummy;
+      };
+
+      struct Varyings {
+        vec4 v_SH0;
+        vec4 v_SH1;
+        vec4 v_SH2;
+        vec4 v_SH3;
+        vec4 v_SH4;
+        vec4 v_SH5;
+        vec4 v_SH6;
+        vec4 v_SH7;
+        vec4 v_SH8;
+      };
+
+      vec3 uniformSampleSphere(int sampleX, int sampleY) {
+        vec2 samplePoint = (vec2(float(sampleX), float(sampleY)) + 0.5) / float(SAMPLE_AXIS_COUNT);
+        float z = 1.0 - 2.0 * samplePoint.y;
+        float radius = sqrt(max(0.0, 1.0 - z * z));
+        float phi = 2.0 * PI * samplePoint.x;
+        return vec3(radius * cos(phi), radius * sin(phi), z);
+      }
+
+      void evaluateBasis(vec3 direction, out float basis[9]) {
+        float x = direction.x;
+        float y = direction.y;
+        float z = direction.z;
+        basis[0] = 0.282095;
+        basis[1] = -0.488603 * y;
+        basis[2] = 0.488603 * z;
+        basis[3] = -0.488603 * x;
+        basis[4] = 1.092548 * x * y;
+        basis[5] = -1.092548 * y * z;
+        basis[6] = 0.315392 * (3.0 * z * z - 1.0);
+        basis[7] = -1.092548 * x * z;
+        basis[8] = 0.546274 * (x * x - y * y);
+      }
+
+      float preScale(int coefficient) {
+        if (coefficient == 0) {
+          return 0.886227;
+        }
+        if (coefficient == 1) {
+          return -1.023327;
+        }
+        if (coefficient == 2) {
+          return 1.023327;
+        }
+        if (coefficient == 3) {
+          return -1.023327;
+        }
+        if (coefficient == 4) {
+          return 0.858086;
+        }
+        if (coefficient == 5) {
+          return -0.858086;
+        }
+        if (coefficient == 6) {
+          return 0.247708;
+        }
+        if (coefficient == 7) {
+          return -0.858086;
+        }
+        return 0.429042;
+      }
+
+      vec4 packCoefficient(vec3 coefficient, int index) {
+        return vec4(coefficient * preScale(index), 0.0);
+      }
+
+      Varyings vert(Attributes attr) {
+        Varyings varyings;
+        vec3 coefficients[9];
+        for (int coefficient = 0; coefficient < 9; coefficient++) {
+          coefficients[coefficient] = vec3(0.0);
+        }
+
+        for (int sampleY = 0; sampleY < SAMPLE_AXIS_COUNT; sampleY++) {
+          for (int sampleX = 0; sampleX < SAMPLE_AXIS_COUNT; sampleX++) {
+            vec3 direction = uniformSampleSphere(sampleX, sampleY);
+            vec3 radiance = textureCubeLodEXT(renderer_SHSourceMap, direction, renderer_SHSourceMipLevel).rgb;
+            float basis[9];
+            evaluateBasis(direction, basis);
+            for (int coefficient = 0; coefficient < 9; coefficient++) {
+              coefficients[coefficient] += radiance * basis[coefficient];
+            }
+          }
+        }
+
+        float normalization = FOUR_PI / SAMPLE_COUNT;
+        for (int coefficient = 0; coefficient < 9; coefficient++) {
+          coefficients[coefficient] *= normalization;
+        }
+        varyings.v_SH0 = packCoefficient(coefficients[0], 0);
+        varyings.v_SH1 = packCoefficient(coefficients[1], 1);
+        varyings.v_SH2 = packCoefficient(coefficients[2], 2);
+        varyings.v_SH3 = packCoefficient(coefficients[3], 3);
+        varyings.v_SH4 = packCoefficient(coefficients[4], 4);
+        varyings.v_SH5 = packCoefficient(coefficients[5], 5);
+        varyings.v_SH6 = packCoefficient(coefficients[6], 6);
+        varyings.v_SH7 = packCoefficient(coefficients[7], 7);
+        varyings.v_SH8 = packCoefficient(coefficients[8], 8);
+        gl_Position = vec4(0.0);
+        return varyings;
+      }
+
+      void frag(Varyings varyings) {
+        discard;
+      }
+    }
+  }
+}

--- a/packages/shader/src/Shaders/Lighting/RealtimeIBLResolve.shader
+++ b/packages/shader/src/Shaders/Lighting/RealtimeIBLResolve.shader
@@ -1,0 +1,97 @@
+Shader "Lighting/RealtimeIBLResolve" {
+  SubShader "Default" {
+    Pass "Forward" {
+      Tags { pipelineStage = "Forward" }
+
+      DepthState = {
+        Enabled = false;
+        WriteEnabled = false;
+      }
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      samplerCube material_SourceMap;
+      float material_Face;
+      float material_SourceLod;
+      float material_ResolveAccumulation;
+      float material_Downsample;
+      float material_TargetSize;
+
+      struct Attributes {
+        vec3 POSITION;
+        vec2 TEXCOORD_0;
+      };
+
+      struct Varyings {
+        vec2 v_uv;
+      };
+
+      Varyings vert(Attributes attr) {
+        Varyings v;
+        gl_Position = vec4(attr.POSITION.xzy, 1.0);
+        gl_Position.y *= -1.0;
+        v.v_uv = attr.TEXCOORD_0;
+        return v;
+      }
+
+      vec3 cubeDirectionFromScaled(vec2 scaledUV, float face) {
+        float cx = scaledUV.x;
+        float cy = scaledUV.y;
+        vec3 direction;
+        if (face == 0.0) direction = vec3(1.0, cy, -cx);
+        else if (face == 1.0) direction = vec3(-1.0, cy, cx);
+        else if (face == 2.0) direction = vec3(cx, 1.0, -cy);
+        else if (face == 3.0) direction = vec3(cx, -1.0, cy);
+        else if (face == 4.0) direction = vec3(cx, cy, 1.0);
+        else direction = vec3(-cx, cy, -1.0);
+        return normalize(direction);
+      }
+
+      vec3 cubeDirection(vec2 uv, float face) {
+        return cubeDirectionFromScaled(uv * 2.0 - 1.0, face);
+      }
+
+      vec4 downsampleCube(vec2 uv, float face) {
+        vec2 scaledUV = uv * 2.0 - 1.0;
+        vec3 normal = cubeDirectionFromScaled(scaledUV, face);
+        vec3 tangentX = normalize(cross(cubeDirectionFromScaled(scaledUV + vec2(0.0, 1.0), face), normal));
+        vec3 tangentY = cross(normal, tangentX);
+        float sampleOffset = 4.0 / material_TargetSize;
+        vec2 offsets[8];
+        offsets[0] = vec2(-0.7, -0.7);
+        offsets[1] = vec2(0.7, -0.7);
+        offsets[2] = vec2(-0.7, 0.7);
+        offsets[3] = vec2(0.7, 0.7);
+        offsets[4] = vec2(0.0, -1.0);
+        offsets[5] = vec2(-1.0, 0.0);
+        offsets[6] = vec2(1.0, 0.0);
+        offsets[7] = vec2(0.0, 1.0);
+
+        vec4 color = textureCubeLodEXT(material_SourceMap, normal, material_SourceLod);
+        for (int index = 0; index < 8; index++) {
+          vec3 sampleDirection = normalize(
+            normal + tangentX * offsets[index].x * sampleOffset + tangentY * offsets[index].y * sampleOffset
+          );
+          color += textureCubeLodEXT(material_SourceMap, sampleDirection, material_SourceLod) * 0.375;
+        }
+        return color * 0.25;
+      }
+
+      void frag(Varyings v) {
+        if (material_Downsample > 0.5) {
+          gl_FragColor = downsampleCube(v.v_uv, material_Face);
+        } else {
+          vec3 direction = cubeDirection(v.v_uv, material_Face);
+          vec4 source = textureCubeLodEXT(material_SourceMap, direction, material_SourceLod);
+          if (material_ResolveAccumulation > 0.5) {
+            source = vec4(source.rgb / max(source.a, 0.000001), 1.0);
+          } else {
+            source.a = 1.0;
+          }
+          gl_FragColor = source;
+        }
+      }
+    }
+  }
+}

--- a/packages/shader/src/Shaders/Sky/SkyProcedural.shader
+++ b/packages/shader/src/Shaders/Sky/SkyProcedural.shader
@@ -260,7 +260,7 @@ Shader "Sky/SkyProcedural" {
 
         col = mix(varyings.v_SkyColor, varyings.v_GroundColor, clamp(y, 0.0, 1.0));
 
-        #if defined(MATERIAL_SUN_HIGH_QUALITY) || defined(MATERIAL_SUN_SIMPLE)
+        #if (defined(MATERIAL_SUN_HIGH_QUALITY) || defined(MATERIAL_SUN_SIMPLE)) && (!defined(SCENE_ENVIRONMENT_CAPTURE) || defined(SCENE_ENVIRONMENT_CAPTURE_INCLUDE_SUN))
           if (y < 0.0)
             col += varyings.v_SunColor * calcSunAttenuation(-scene_SunlightDirection, -ray);
         #endif

--- a/packages/shader/src/Shaders/index.ts
+++ b/packages/shader/src/Shaders/index.ts
@@ -10,6 +10,9 @@ import Blit_BlitScreen from "./Blit/BlitScreen.shader";
 import Effect_Particle from "./Effect/Particle.shader";
 import Effect_ParticleFeedback from "./Effect/ParticleFeedback.shader";
 import Effect_Trail from "./Effect/Trail.shader";
+import Lighting_RealtimeIBLAccumulate from "./Lighting/RealtimeIBLAccumulate.shader";
+import Lighting_RealtimeIBLProjectSH from "./Lighting/RealtimeIBLProjectSH.shader";
+import Lighting_RealtimeIBLResolve from "./Lighting/RealtimeIBLResolve.shader";
 import Lighting_ScalableAmbientOcclusion from "./Lighting/ScalableAmbientOcclusion.shader";
 import PBR from "./PBR.shader";
 import Pipeline_DepthOnly from "./Pipeline/DepthOnly.shader";
@@ -40,6 +43,9 @@ export const shaders: IShaderSource[] = [
   { source: Effect_Particle, path: "Shaders/Effect/Particle.shader" },
   { source: Effect_ParticleFeedback, path: "Shaders/Effect/ParticleFeedback.shader" },
   { source: Effect_Trail, path: "Shaders/Effect/Trail.shader" },
+  { source: Lighting_RealtimeIBLAccumulate, path: "Shaders/Lighting/RealtimeIBLAccumulate.shader" },
+  { source: Lighting_RealtimeIBLProjectSH, path: "Shaders/Lighting/RealtimeIBLProjectSH.shader" },
+  { source: Lighting_RealtimeIBLResolve, path: "Shaders/Lighting/RealtimeIBLResolve.shader" },
   { source: Lighting_ScalableAmbientOcclusion, path: "Shaders/Lighting/ScalableAmbientOcclusion.shader" },
   { source: PBR, path: "Shaders/PBR.shader" },
   { source: Pipeline_DepthOnly, path: "Shaders/Pipeline/DepthOnly.shader" },

--- a/tests/src/core/EnvironmentLightCapture.test.ts
+++ b/tests/src/core/EnvironmentLightCapture.test.ts
@@ -1,0 +1,67 @@
+import {
+  BackgroundMode,
+  Camera,
+  DiffuseMode,
+  DirectLight,
+  EnvironmentLightCapture,
+  Material,
+  MeshRenderer,
+  PBRMaterial,
+  PrimitiveMesh,
+  Shader,
+  SkyEnvironmentCaptureMacro,
+  SkyProceduralMaterial
+} from "@galacean/engine-core";
+import { WebGLEngine } from "@galacean/engine";
+import { describe, expect, it } from "vitest";
+
+describe("EnvironmentLightCapture", () => {
+  it("captures an arbitrary sky material and atomically publishes diffuse and specular IBL", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 32;
+    canvas.height = 32;
+    const engine = await WebGLEngine.create({ canvas });
+    const scene = engine.sceneManager.activeScene;
+    const root = scene.createRootEntity("Environment");
+    scene.sun = root.createChild("Sun").addComponent(DirectLight);
+
+    const proceduralMaterial = new SkyProceduralMaterial(engine);
+    const customMaterial = new Material(engine, Shader.find("Sky/SkyProcedural"));
+    proceduralMaterial.cloneTo(customMaterial);
+    proceduralMaterial.destroy();
+    scene.background.mode = BackgroundMode.Sky;
+    scene.background.sky.material = customMaterial;
+    scene.background.sky.mesh = PrimitiveMesh.createSphere(engine, 1);
+
+    const cameraEntity = root.createChild("Camera");
+    cameraEntity.transform.setPosition(0, 0, 3);
+    cameraEntity.addComponent(Camera);
+    const sphere = root.createChild("Sphere");
+    const renderer = sphere.addComponent(MeshRenderer);
+    renderer.mesh = PrimitiveMesh.createSphere(engine, 0.5);
+    renderer.setMaterial(new PBRMaterial(engine));
+
+    const initialDiffuseMode = scene.ambientLight.diffuseMode;
+    const capture = new EnvironmentLightCapture(scene, { resolution: 16, sampleCount: 32 });
+    expect(() => new EnvironmentLightCapture(scene, { resolution: 16, sampleCount: 32 })).toThrow(
+      "exclusive ownership"
+    );
+    expect(capture.includeSun).toBe(false);
+    expect(capture.requestUpdate()).toBe(1);
+
+    for (let frame = 0; frame < 64 && capture.getSnapshot().publishedRevision === 0; frame++) {
+      capture.update();
+    }
+
+    expect(capture.getSnapshot().publishedRevision).toBe(1);
+    expect(scene.ambientLight.diffuseMode).toBe(DiffuseMode.SphericalHarmonics);
+    expect(scene.ambientLight.specularTexture).toBeTruthy();
+    expect(SkyEnvironmentCaptureMacro.Capture).toBe("SCENE_ENVIRONMENT_CAPTURE");
+    expect(SkyEnvironmentCaptureMacro.IncludeSun).toBe("SCENE_ENVIRONMENT_CAPTURE_INCLUDE_SUN");
+    expect(() => engine.update()).not.toThrow();
+
+    capture.destroy();
+    expect(scene.ambientLight.diffuseMode).toBe(initialDiffuseMode);
+    engine.destroy();
+  });
+});

--- a/tests/src/core/RealtimeIBLPrefilterSchedule.test.ts
+++ b/tests/src/core/RealtimeIBLPrefilterSchedule.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createRealtimeIBLPrefilterSchedule } from "../../../packages/core/src/lighting/environment/RealtimeIBLPrefilterSchedule";
+
+describe("Realtime IBL GGX prefilter schedule", () => {
+  it("keeps every surface batch ordered while balancing the default shader workload", () => {
+    const frameCount = 12;
+    const sampleBatchSize = 32;
+    const sampleCount = 64;
+    const mipCount = 8;
+    const schedule = createRealtimeIBLPrefilterSchedule({
+      resolution: 128,
+      mipCount,
+      sampleCount,
+      sampleBatchSize,
+      frameCount
+    });
+    const batchesPerSurface = sampleCount / sampleBatchSize;
+    const batchesBySurface = new Map<string, number[]>();
+
+    expect(schedule).toHaveLength(frameCount);
+    for (let frameIndex = 0; frameIndex < schedule.length; frameIndex++) {
+      const frame = schedule[frameIndex];
+      expect(frame.items.length).toBeGreaterThan(0);
+      for (let itemIndex = 0; itemIndex < frame.items.length; itemIndex++) {
+        const item = frame.items[itemIndex];
+        const surface = `${item.mip}:${item.face}`;
+        const batches = batchesBySurface.get(surface) ?? [];
+        batches.push(item.batchIndex);
+        batchesBySurface.set(surface, batches);
+        expect(item.resolveSurface).toBe(item.batchIndex === batchesPerSurface - 1);
+      }
+    }
+
+    expect(batchesBySurface.size).toBe((mipCount - 1) * 6);
+    const expectedBatches = Array.from({ length: batchesPerSurface }, (_, index) => index);
+    for (const batches of batchesBySurface.values()) {
+      expect(batches).toEqual(expectedBatches);
+    }
+
+    const totalSampleWork = schedule.reduce((total, frame) => total + frame.estimatedSampleWork, 0);
+    const idealSampleWork = totalSampleWork / frameCount;
+    const sampleWork = schedule.map((frame) => frame.estimatedSampleWork);
+    const drawCounts = schedule.map((frame) => frame.estimatedDrawCount);
+    expect(Math.max(...sampleWork) / idealSampleWork).toBeLessThan(1.13);
+    expect(Math.min(...sampleWork) / idealSampleWork).toBeGreaterThan(0.8);
+    expect(Math.max(...drawCounts) - Math.min(...drawCounts)).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/src/core/RealtimeIBLSourceMipmapSchedule.test.ts
+++ b/tests/src/core/RealtimeIBLSourceMipmapSchedule.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createRealtimeIBLSourceMipmapSchedule } from "../../../packages/core/src/lighting/environment/RealtimeIBLSourceMipmapSchedule";
+
+describe("Realtime IBL source mip schedule", () => {
+  it("keeps dependent mips ordered while packing small levels under texel and draw budgets", () => {
+    const schedule = createRealtimeIBLSourceMipmapSchedule({
+      resolution: 128,
+      mipCount: 8,
+      maximumDrawCount: 24
+    });
+
+    expect(schedule.map((frame) => frame.mips)).toEqual([[1], [2, 3], [4, 5], [6, 7]]);
+    expect(schedule.flatMap((frame) => frame.mips)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(Math.max(...schedule.map((frame) => frame.estimatedTexelWork))).toBe(schedule[0].estimatedTexelWork);
+    expect(Math.max(...schedule.map((frame) => frame.estimatedDrawCount))).toBe(24);
+  });
+
+  it("rejects a draw budget that cannot complete both cubemap passes for one mip", () => {
+    expect(() => createRealtimeIBLSourceMipmapSchedule({ resolution: 128, mipCount: 8, maximumDrawCount: 11 })).toThrow(
+      "at least 12"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `EnvironmentLightCapture` to progressively capture the active `Scene.background.sky` into diffuse L2 SH and a GGX-prefiltered specular cubemap.
- Spread six source-face captures, source-mipmap generation, and twelve GGX work slices across frames, then publish the double-buffered diffuse/specular result together through `Scene.ambientLight`.
- Keep SH projection and consumption on the GPU with Transform Feedback and a uniform buffer, avoiding a GPU-to-CPU readback during runtime updates.
- Support ordinary skybox materials and custom procedural sky materials through a frozen Material snapshot plus `Scene.sun` snapshot.

## API and ownership

```ts
const capture = new EnvironmentLightCapture(scene, {
  resolution: 128,
  sampleCount: 64,
  includeSun: false
});

capture.requestUpdate();

// Call once from the application's frame update while work is pending.
capture.update();
```

V1 is deliberately On Demand: `requestUpdate()` records the newest sky revision and `update()` submits one scheduled work slice. A newer pending revision replaces an older pending one without interrupting the revision already in flight.

`AmbientLight` remains the authoritative owner consumed by PBR shading. `EnvironmentLightCapture` owns only the capture transaction, staging resources, and publication schedule. Only one capture object can own an `AmbientLight` at a time, and publication switches SH plus the specular cubemap in the same update.

## Custom skies and the sun disk

Unity HDRP exposes the equivalent context as `SkyRenderer.RenderSky(..., renderForCubemap, renderSunDisk)`. Galacean skies are Material/shader based rather than `SkyRenderer` subclasses, so this change provides the shader equivalents:

- `SCENE_ENVIRONMENT_CAPTURE`
- `SCENE_ENVIRONMENT_CAPTURE_INCLUDE_SUN`

The built-in procedural sky now keeps atmospheric scattering in the capture but omits its analytic solar disk by default. Direct sunlight still comes from `Scene.sun`. A custom procedural sky can use the same macros around its analytic disk; a disk already authored into a static cubemap cannot be removed after capture.

Each requested revision clones the sky Material and snapshots `Scene.sun`. Capture-varying custom parameters should live in Material shader data. Opaque Scene shader data is not copied into the private capture Scene because it also contains unrelated lighting, fog, and render-state ownership.

References:

- Unity HDRP `SkyRenderer`: https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyRenderer.cs
- Unity HDRP `SkySettings` update modes and `includeSunInBaking`: https://docs.unity3d.com/cn/Packages/com.unity.render-pipelines.high-definition%407.4/api/UnityEngine.Rendering.HighDefinition.SkySettings.html
- Unreal Engine 5.8 Sky Light capture and Real Time Capture: https://dev.epicgames.com/documentation/en-us/unreal-engine/sky-lights-in-unreal-engine

## Scope

- This is distant-sky environment lighting (diffuse SH plus specular IBL), not dynamic-geometry GI, DDGI, SSR, or local reflection probes.
- The implementation requires WebGL2 and renderable half-float textures. The public capture contract does not expose WebGL objects, leaving room for a future WebGPU implementation.
- Target-mobile GPU timing and final quality presets are intentionally left for follow-up profiling; the default `128` resolution and `64` GGX samples are initial quality parameters, not measured performance claims.

## Verification

- `corepack pnpm build`
- `corepack pnpm lint` (0 errors; existing repository warnings remain)
- `corepack pnpm vitest run tests/src/core/EnvironmentLightCapture.test.ts tests/src/core/RealtimeIBLPrefilterSchedule.test.ts tests/src/core/RealtimeIBLSourceMipmapSchedule.test.ts` (3 files, 4 tests)
- `git diff --check origin/dev/2.0...HEAD`
