### PR TITLE
fix(core): preserve instance buffer during resource gc

### DIFF
--- a/packages/core/src/RenderPipeline/InstanceBuffer.ts
+++ b/packages/core/src/RenderPipeline/InstanceBuffer.ts
@@ -39,6 +39,7 @@ export class InstanceBuffer {
       this._intView = new Int32Array(this._data);
       this.buffer?.destroy();
       this.buffer = new Buffer(this._engine, BufferBindFlag.ConstantBuffer, totalBytes, BufferUsage.Dynamic);
+      this.buffer.isGCIgnored = true;
     }
   }
 

--- a/tests/src/core/RenderPipeline/InstanceBuffer.test.ts
+++ b/tests/src/core/RenderPipeline/InstanceBuffer.test.ts
@@ -1,0 +1,25 @@
+import { WebGLEngine } from "@galacean/engine";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("InstanceBuffer", () => {
+  let engine: WebGLEngine | undefined;
+
+  afterEach(() => {
+    engine?.destroy();
+    engine = undefined;
+  });
+
+  it("keeps its engine-owned buffer alive across resource-manager garbage collection", async () => {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+    const instanceBuffer = engine._batcherManager.instanceBuffer;
+    instanceBuffer.setLayout({ instanceFields: [], instanceMaxCount: 1, structSize: 16 });
+    const buffer = instanceBuffer.buffer;
+
+    engine.resourceManager.gc();
+
+    expect(buffer.destroyed).toBe(false);
+
+    engine._batcherManager.destroy();
+    expect(buffer.destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- keep the render pipeline's engine-owned instance buffer alive during ordinary resource-manager garbage collection
- add focused Chromium regression coverage for GC retention and explicit batcher teardown

## Root cause

`InstanceBuffer` owns its GPU `Buffer` outside component reference counting. The buffer therefore has a zero reference count and was not excluded from ordinary resource GC. `ResourceManager.gc()` could destroy it while `BatcherManager` still retained the wrapper, so the next instanced upload reused a destroyed platform buffer.

The fix marks every newly allocated instance buffer as `isGCIgnored`. Explicit reallocation, `BatcherManager.destroy()`, and forced engine teardown still destroy the buffer through their existing ownership paths.

## Scope

This is a minimal rework of #3065, revalidated against the latest `dev/2.0` baseline. It intentionally excludes the broader render-pass teardown and render-target-pool changes from `39a191d`, which require separate ownership semantics and behavior-level coverage.

## Validation

- pre-fix Chromium regression reproduced the bug: `buffer.destroyed` was `true` after `resourceManager.gc()`
- `HEADLESS=true pnpm exec vitest run tests/src/core/RenderPipeline/InstanceBuffer.test.ts`
- `pnpm run b:module`
- `pnpm run b:types`
- `pnpm run lint`
- `pnpm exec prettier --check packages/core/src/RenderPipeline/InstanceBuffer.ts tests/src/core/RenderPipeline/InstanceBuffer.test.ts`
- `git diff --check origin/dev/2.0...HEAD`

Fixes #3064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented newly created rendering buffers from being incorrectly removed during garbage collection.
  * Ensured engine-owned buffers remain available until their associated rendering resources are explicitly destroyed.

* **Tests**
  * Added coverage for buffer lifecycle and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->