### PR TITLE
refactor(audio): centralize playback intent and context recovery

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -8,6 +8,7 @@ export class AudioManager {
   private static _context: AudioContext;
   private static _gainNode: GainNode;
   private static _resumePromise: Promise<void> = null;
+  private static _gestureResumePromise: Promise<void> = null;
   private static _needsUserGestureResume = false;
   private static _suspendedByCaller = false;
   private static _recovering = false;
@@ -55,9 +56,15 @@ export class AudioManager {
       // iOS Safari bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
       window.addEventListener("pageshow", AudioManager._onPageShow);
       // iOS Safari requires a user gesture to resume the AudioContext
-      document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, { passive: true });
-      document.addEventListener("touchend", AudioManager._resumeAfterInterruption, { passive: true });
-      document.addEventListener("click", AudioManager._resumeAfterInterruption);
+      document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, {
+        passive: true,
+        capture: true
+      });
+      document.addEventListener("touchend", AudioManager._resumeAfterInterruption, {
+        passive: true,
+        capture: true
+      });
+      document.addEventListener("click", AudioManager._resumeAfterInterruption, true);
     }
     return context;
   }
@@ -131,13 +138,50 @@ export class AudioManager {
   }
 
   private static _resumeAfterInterruption(): void {
-    // iOS Safari gesture fallback for when auto-resume is blocked.
-    // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context)
-    if (AudioManager._recovering || AudioManager._suspendedByCaller || !AudioManager._needsUserGestureResume) {
+    // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context).
+    if (AudioManager._recovering || AudioManager._suspendedByCaller) {
       return;
     }
-    AudioManager.resume().catch((e) => {
+
+    // Interruption recovery deliberately coalesces with its timer-driven resume.
+    if (AudioManager._needsUserGestureResume) {
+      AudioManager.resume().catch((e) => {
+        console.warn("Failed to resume AudioContext:", e);
+      });
+      return;
+    }
+
+    const context = AudioManager._context;
+    if (!context || context.state === "running" || !AudioManager._resumePromise || AudioManager._gestureResumePromise) {
+      return;
+    }
+
+    // A cold-start resume issued before user activation may remain pending indefinitely. Calling the
+    // public resume() here would reuse that stale promise, so issue one fresh native resume in the
+    // trusted gesture. Once the context starts, the Web Audio algorithm settles earlier resume promises
+    // and AudioSource continues its pending play.
+    let nativeResumePromise: Promise<void>;
+    try {
+      nativeResumePromise = context.resume();
+    } catch (e) {
       console.warn("Failed to resume AudioContext:", e);
-    });
+      return;
+    }
+
+    const gestureResumePromise = nativeResumePromise
+      .then(() => {
+        if (context.state === "running") {
+          AudioManager._needsUserGestureResume = false;
+        }
+      })
+      .catch((e) => {
+        console.warn("Failed to resume AudioContext:", e);
+      })
+      .finally(() => {
+        if (AudioManager._gestureResumePromise === gestureResumePromise) {
+          AudioManager._gestureResumePromise = null;
+        }
+      });
+    AudioManager._gestureResumePromise = gestureResumePromise;
   }
 }

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -7,24 +7,23 @@ export class AudioManager {
 
   private static _context: AudioContext;
   private static _gainNode: GainNode;
+  private static _desiredState: "running" | "suspended" = "running";
   private static _resumePromise: Promise<void> = null;
-  private static _gestureResumePromise: Promise<void> = null;
-  private static _needsUserGestureResume = false;
-  private static _suspendedByCaller = false;
   private static _recovering = false;
+  private static _pendingPlaybacks = new Set<() => void>();
 
   /**
    * Suspend the audio context.
    * @returns A promise that resolves when the audio context is suspended
    */
   static suspend(): Promise<void> {
-    // No context means nothing is playing: suspending is a no-op and must NOT flag a caller-suspend
-    // (a ghost flag would later block foreground recovery), and don't create a cold context just to suspend
+    // Don't create a cold context just to suspend it. With no context there is no playback state to preserve.
     const context = AudioManager._context;
     if (!context) {
       return Promise.resolve();
     }
-    AudioManager._suspendedByCaller = true;
+
+    AudioManager._desiredState = "suspended";
     return context.suspend();
   }
 
@@ -34,15 +33,8 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is resumed
    */
   static resume(): Promise<void> {
-    AudioManager._suspendedByCaller = false;
-    return (AudioManager._resumePromise ??= AudioManager.getContext()
-      .resume()
-      .then(() => {
-        AudioManager._needsUserGestureResume = false;
-      })
-      .finally(() => {
-        AudioManager._resumePromise = null;
-      }));
+    AudioManager._desiredState = "running";
+    return AudioManager._resumeContext(false);
   }
 
   /**
@@ -52,19 +44,21 @@ export class AudioManager {
     let context = AudioManager._context;
     if (!context) {
       AudioManager._context = context = new window.AudioContext();
+      context.onstatechange = AudioManager._onContextStateChange;
       document.addEventListener("visibilitychange", AudioManager._onVisibilityChange);
-      // iOS Safari bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
+      // iOS Safari bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too.
       window.addEventListener("pageshow", AudioManager._onPageShow);
-      // iOS Safari requires a user gesture to resume the AudioContext
-      document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, {
+      // A resume attempted before user activation may stay pending indefinitely. Each trusted gesture must
+      // therefore be allowed to make a fresh native resume attempt instead of reusing that stale promise.
+      document.addEventListener("touchstart", AudioManager._onUserGesture, {
         passive: true,
         capture: true
       });
-      document.addEventListener("touchend", AudioManager._resumeAfterInterruption, {
+      document.addEventListener("touchend", AudioManager._onUserGesture, {
         passive: true,
         capture: true
       });
-      document.addEventListener("click", AudioManager._resumeAfterInterruption, true);
+      document.addEventListener("click", AudioManager._onUserGesture, true);
     }
     return context;
   }
@@ -89,10 +83,117 @@ export class AudioManager {
     return AudioManager.getContext().state === "running";
   }
 
+  /** @internal */
+  static _canStartPlayback(): boolean {
+    return (
+      AudioManager._desiredState === "running" && !document.hidden && AudioManager.getContext().state === "running"
+    );
+  }
+
+  /** @internal */
+  static _requestPlayback(playback: () => void): void {
+    AudioManager._pendingPlaybacks.add(playback);
+    AudioManager.getContext();
+
+    if (AudioManager._canStartPlayback()) {
+      AudioManager._flushPendingPlaybacks();
+    } else if (
+      AudioManager._desiredState === "running" &&
+      !document.hidden &&
+      !AudioManager._recovering &&
+      !AudioManager._resumePromise
+    ) {
+      AudioManager._resumeContext(false).catch(AudioManager._warnResumeFailure);
+    }
+  }
+
+  /** @internal */
+  static _cancelPendingPlayback(playback: () => void): void {
+    AudioManager._pendingPlaybacks.delete(playback);
+  }
+
+  private static _resumeContext(fromUserGesture: boolean): Promise<void> {
+    const context = AudioManager.getContext();
+    if (AudioManager._desiredState !== "running" || document.hidden) {
+      return Promise.resolve();
+    }
+    if (context.state === "running") {
+      AudioManager._flushPendingPlaybacks();
+      return Promise.resolve();
+    }
+    if (!fromUserGesture && AudioManager._resumePromise) {
+      return AudioManager._resumePromise;
+    }
+
+    let nativeResumePromise: Promise<void>;
+    try {
+      nativeResumePromise = context.resume();
+    } catch (e) {
+      return Promise.reject(e);
+    }
+
+    const resumePromise = nativeResumePromise.then(() => {
+      AudioManager._reconcileContextState();
+    });
+
+    // Programmatic attempts are single-flight. Gesture attempts deliberately are not: a resume made before
+    // activation may remain pending, and a later trusted gesture must be able to issue a fresh native call.
+    if (!fromUserGesture) {
+      const trackedPromise = resumePromise.finally(() => {
+        if (AudioManager._resumePromise === trackedPromise) {
+          AudioManager._resumePromise = null;
+        }
+      });
+      AudioManager._resumePromise = trackedPromise;
+      return trackedPromise;
+    }
+
+    return resumePromise;
+  }
+
+  private static _reconcileContextState(): void {
+    const context = AudioManager._context;
+    if (!context || context.state !== "running") {
+      return;
+    }
+
+    // A successful gesture may start the context while an earlier programmatic resume promise is still
+    // pending. Stop treating that stale promise as the active recovery attempt so a future interruption can
+    // make a new automatic attempt even if the browser never settles the old promise.
+    AudioManager._resumePromise = null;
+
+    if (AudioManager._desiredState === "suspended" || document.hidden) {
+      context.suspend().catch(() => {});
+    } else {
+      AudioManager._flushPendingPlaybacks();
+    }
+  }
+
+  private static _flushPendingPlaybacks(): void {
+    if (!AudioManager._canStartPlayback() || AudioManager._pendingPlaybacks.size === 0) {
+      return;
+    }
+
+    const pendingPlaybacks = Array.from(AudioManager._pendingPlaybacks);
+    AudioManager._pendingPlaybacks.clear();
+    for (let i = 0, n = pendingPlaybacks.length; i < n; i++) {
+      pendingPlaybacks[i]();
+    }
+  }
+
+  private static _hasPlaybackDemand(): boolean {
+    return AudioManager._playingCount > 0 || AudioManager._pendingPlaybacks.size > 0;
+  }
+
+  private static _onContextStateChange(): void {
+    AudioManager._reconcileContextState();
+  }
+
   private static _onVisibilityChange(): void {
     if (document.hidden) {
       // Desktop/Android don't auto-suspend a running WebAudio context when backgrounded (only iOS does),
-      // so suspend here to stop audio in the background; only if a context already exists (don't create one)
+      // so suspend here to stop audio in the background. This physical transition does not change the
+      // caller's desired state, allowing foreground recovery to restore active playback.
       AudioManager._context?.suspend().catch(() => {});
     } else {
       AudioManager._recoverPlaybackContext();
@@ -100,88 +201,63 @@ export class AudioManager {
   }
 
   private static _recoverPlaybackContext(): void {
-    // Returning to foreground with a non-running context (and not a deliberate pause): iOS leaves it
-    // "interrupted", which cannot be resumed directly; suspend() first transitions it to "suspended",
-    // then resume() restarts the pipeline https://bugs.webkit.org/show_bug.cgi?id=263627
-    // _recovering guards re-entry: a bfcache restore fires both visibilitychange and pageshow
+    // Returning to foreground with a non-running context: iOS may leave it "interrupted", which cannot be
+    // resumed directly. suspend() first transitions it to "suspended", then resume() restarts the pipeline.
+    // _recovering guards re-entry because bfcache restore may fire both visibilitychange and pageshow.
     if (
       AudioManager._recovering ||
       document.hidden ||
-      AudioManager._suspendedByCaller ||
-      AudioManager._playingCount <= 0 ||
-      AudioManager.isAudioContextRunning()
+      AudioManager._desiredState !== "running" ||
+      !AudioManager._hasPlaybackDemand()
     ) {
       return;
     }
-    AudioManager._recovering = true;
-    AudioManager._needsUserGestureResume = true; // fallback if the auto-resume below is rejected
+
     const context = AudioManager.getContext();
+    if (context.state === "running") {
+      AudioManager._flushPendingPlaybacks();
+      return;
+    }
+
+    AudioManager._recovering = true;
     context.suspend().catch(() => {});
-    // 100ms empirical delay (resume too soon after suspend is unreliable on iOS); _recovering is cleared
-    // on the timer rather than off a promise because iOS may never settle suspend/resume in interrupted
+    // 100ms empirical delay: resuming too soon after suspend is unreliable on iOS. The guard is timer-based
+    // because WebKit may leave the suspend/resume promises unsettled while the context is interrupted.
     setTimeout(() => {
       AudioManager._recovering = false;
-      if (document.hidden || AudioManager._suspendedByCaller) {
+      if (document.hidden || AudioManager._desiredState !== "running" || !AudioManager._hasPlaybackDemand()) {
         return;
       }
-      // Go through AudioManager.resume() so _resumePromise coalesces any gesture-resume racing us during
-      // the slow iOS interrupted->running transition; a bare context.resume() here wouldn't dedupe
-      AudioManager.resume().catch(() => {});
+      AudioManager._resumeContext(false).catch(AudioManager._warnResumeFailure);
     }, 100);
   }
 
   private static _onPageShow(event: PageTransitionEvent): void {
-    // iOS Safari bfcache restore (persisted) needs recovery; a normal load has no suspended context
+    // iOS Safari bfcache restore (persisted) needs recovery; a normal load has no suspended context.
     if (event.persisted) {
       AudioManager._recoverPlaybackContext();
     }
   }
 
-  private static _resumeAfterInterruption(): void {
-    // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context).
-    if (AudioManager._recovering || AudioManager._suspendedByCaller) {
-      return;
-    }
-
-    // Interruption recovery deliberately coalesces with its timer-driven resume.
-    if (AudioManager._needsUserGestureResume) {
-      AudioManager.resume().catch((e) => {
-        console.warn("Failed to resume AudioContext:", e);
-      });
+  private static _onUserGesture(): void {
+    if (
+      AudioManager._recovering ||
+      document.hidden ||
+      AudioManager._desiredState !== "running" ||
+      !AudioManager._hasPlaybackDemand()
+    ) {
       return;
     }
 
     const context = AudioManager._context;
-    if (!context || context.state === "running" || !AudioManager._resumePromise || AudioManager._gestureResumePromise) {
+    if (!context || context.state === "running") {
       return;
     }
 
-    // A cold-start resume issued before user activation may remain pending indefinitely. Calling the
-    // public resume() here would reuse that stale promise, so issue one fresh native resume in the
-    // trusted gesture. Once the context starts, the Web Audio algorithm settles earlier resume promises
-    // and AudioSource continues its pending play.
-    let nativeResumePromise: Promise<void>;
-    try {
-      nativeResumePromise = context.resume();
-    } catch (e) {
-      console.warn("Failed to resume AudioContext:", e);
-      return;
-    }
+    AudioManager._resumeContext(true).catch(AudioManager._warnResumeFailure);
+  }
 
-    const gestureResumePromise = nativeResumePromise
-      .then(() => {
-        if (context.state === "running") {
-          AudioManager._needsUserGestureResume = false;
-        }
-      })
-      .catch((e) => {
-        console.warn("Failed to resume AudioContext:", e);
-      })
-      .finally(() => {
-        if (AudioManager._gestureResumePromise === gestureResumePromise) {
-          AudioManager._gestureResumePromise = null;
-        }
-      });
-    AudioManager._gestureResumePromise = gestureResumePromise;
+  private static _warnResumeFailure(error: unknown): void {
+    console.warn("Failed to resume AudioContext:", error);
   }
 }

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -15,6 +15,8 @@ export class AudioSource extends Component {
   private _isPlaying = false;
   @ignoreClone
   private _pendingPlay = false;
+  @ignoreClone
+  private _pendingPlaybackCallback: () => void;
 
   private _clip: AudioClip;
   @ignoreClone
@@ -139,6 +141,7 @@ export class AudioSource extends Component {
   constructor(entity: Entity) {
     super(entity);
     this._onPlayEnd = this._onPlayEnd.bind(this);
+    this._pendingPlaybackCallback = this._startPendingPlayback.bind(this);
     // Gain node is created lazily on first play, not here: creating it would spin up the AudioContext
     // before any user gesture, and on iOS such a pre-gesture context never recovers from a phone-call
     // interruption (stays a silent zombie)
@@ -156,30 +159,11 @@ export class AudioSource extends Component {
       return;
     }
 
-    if (AudioManager.isAudioContextRunning()) {
+    if (AudioManager._canStartPlayback()) {
       this._startPlayback();
     } else {
-      // iOS Safari requires resume() to be called within the same user gesture callback that triggers playback.
-      // Document-level events won't work - must call resume() directly here in play().
       this._pendingPlay = true;
-      AudioManager.resume().then(
-        () => {
-          // Check if cancelled by stop()/pause()
-          if (!this._pendingPlay) {
-            return;
-          }
-          this._pendingPlay = false;
-          // Check if still valid to play after async resume (page may have been hidden meanwhile)
-          if (this._destroyed || !this.enabled || !this._clip || document.hidden) {
-            return;
-          }
-          this._startPlayback();
-        },
-        (e) => {
-          this._pendingPlay = false;
-          console.warn("Failed to resume AudioContext:", e);
-        }
-      );
+      AudioManager._requestPlayback(this._pendingPlaybackCallback);
     }
   }
 
@@ -187,6 +171,7 @@ export class AudioSource extends Component {
    * Stops playing the clip.
    */
   stop(): void {
+    AudioManager._cancelPendingPlayback(this._pendingPlaybackCallback);
     this._pendingPlay = false;
 
     if (this._isPlaying) {
@@ -204,6 +189,7 @@ export class AudioSource extends Component {
    * Pauses playing the clip.
    */
   pause(): void {
+    AudioManager._cancelPendingPlayback(this._pendingPlaybackCallback);
     this._pendingPlay = false;
 
     if (this._isPlaying) {
@@ -261,6 +247,23 @@ export class AudioSource extends Component {
     this._pausedTime = -1;
     this._isPlaying = true;
     AudioManager._playingCount++;
+  }
+
+  private _startPendingPlayback(): void {
+    if (!this._pendingPlay) {
+      return;
+    }
+    if (this._destroyed || !this.enabled || !this._clip || document.hidden) {
+      this._pendingPlay = false;
+      return;
+    }
+    if (!AudioManager._canStartPlayback()) {
+      AudioManager._requestPlayback(this._pendingPlaybackCallback);
+      return;
+    }
+
+    this._pendingPlay = false;
+    this._startPlayback();
   }
 
   private _initSourceNode(startTime: number): void {

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -95,13 +95,14 @@ function createAudioSource(): AudioSource {
 function resetAudioManagerState(): void {
   document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
   window.removeEventListener("pageshow", (AudioManager as any)._onPageShow);
-  document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption);
-  document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption);
-  document.removeEventListener("click", (AudioManager as any)._resumeAfterInterruption);
+  document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption, true);
+  document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption, true);
+  document.removeEventListener("click", (AudioManager as any)._resumeAfterInterruption, true);
 
   (AudioManager as any)._context = null;
   (AudioManager as any)._gainNode = null;
   (AudioManager as any)._resumePromise = null;
+  (AudioManager as any)._gestureResumePromise = null;
   (AudioManager as any)._needsUserGestureResume = false;
   (AudioManager as any)._suspendedByCaller = false;
   (AudioManager as any)._recovering = false;
@@ -314,6 +315,48 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
 
     expect(audioSource.isPlaying).to.be.false;
+  });
+
+  it("reissues native resume on the first gesture when a cold-start resume is still pending", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let releaseColdStartResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      // Web Audio keeps resume() pending when the context is not yet allowed to start.
+      new Promise<void>((resolve) => {
+        releaseColdStartResume = resolve;
+      }),
+      // A second native resume issued from the first user gesture is allowed to run.
+      Promise.resolve()
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    // playOnEnabled / startup playback happens before any user gesture.
+    audioSource.play();
+    const coldStartResumePromise = (AudioManager as any)._resumePromise as Promise<void>;
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((audioSource as any)._pendingPlay).to.be.true;
+
+    // jsdom cannot create real user activation; the second queued resume result models the browser
+    // becoming allowed-to-start during this first gesture.
+    document.dispatchEvent(new Event("click"));
+    document.dispatchEvent(new Event("click"));
+    await flushAsync();
+
+    // The gesture must reach the native AudioContext instead of reusing the cold-start Promise, while
+    // back-to-back gesture events still coalesce into one fresh native resume.
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect(context.state).to.equal("running");
+
+    // Per the Web Audio resume algorithm, starting the context settles earlier pending resume promises.
+    releaseColdStartResume!();
+    await coldStartResumePromise;
+    await flushAsync();
+
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
   });
 
   it("cancels a one-shot pending play before resume resolves", async () => {

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -33,6 +33,7 @@ class MockAudioContext {
   currentTime = 0;
   destination = {};
   state: AudioContextState = "suspended";
+  onstatechange: ((event: Event) => void) | null = null;
 
   createBufferSource(): AudioBufferSourceNode {
     return new MockBufferSourceNode() as unknown as AudioBufferSourceNode;
@@ -46,7 +47,7 @@ class MockAudioContext {
     const queuedResult = MockAudioContext.resumeResultQueue?.shift();
     if (queuedResult instanceof Promise) {
       return queuedResult.then(() => {
-        this.state = "running";
+        this._setState("running");
       });
     }
     if (queuedResult instanceof Error) {
@@ -55,7 +56,7 @@ class MockAudioContext {
     if (!MockAudioContext.shouldResumeSucceed) {
       return Promise.reject(new Error("autoplay blocked"));
     }
-    this.state = "running";
+    this._setState("running");
     return Promise.resolve();
   }
 
@@ -63,8 +64,13 @@ class MockAudioContext {
     if (!MockAudioContext.shouldSuspendSucceed) {
       return Promise.reject(new Error("suspend blocked"));
     }
-    this.state = "suspended";
+    this._setState("suspended");
     return Promise.resolve();
+  }
+
+  private _setState(state: AudioContextState): void {
+    this.state = state;
+    this.onstatechange?.(new Event("statechange"));
   }
 }
 
@@ -93,19 +99,22 @@ function createAudioSource(): AudioSource {
 }
 
 function resetAudioManagerState(): void {
+  const context = (AudioManager as any)._context as AudioContext | null;
+  if (context) {
+    context.onstatechange = null;
+  }
   document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
   window.removeEventListener("pageshow", (AudioManager as any)._onPageShow);
-  document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption, true);
-  document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption, true);
-  document.removeEventListener("click", (AudioManager as any)._resumeAfterInterruption, true);
+  document.removeEventListener("touchstart", (AudioManager as any)._onUserGesture, true);
+  document.removeEventListener("touchend", (AudioManager as any)._onUserGesture, true);
+  document.removeEventListener("click", (AudioManager as any)._onUserGesture, true);
 
   (AudioManager as any)._context = null;
   (AudioManager as any)._gainNode = null;
   (AudioManager as any)._resumePromise = null;
-  (AudioManager as any)._gestureResumePromise = null;
-  (AudioManager as any)._needsUserGestureResume = false;
-  (AudioManager as any)._suspendedByCaller = false;
+  (AudioManager as any)._desiredState = "running";
   (AudioManager as any)._recovering = false;
+  (AudioManager as any)._pendingPlaybacks = new Set();
   (AudioManager as any)._playingCount = 0;
 }
 
@@ -284,6 +293,7 @@ describe("AudioSource playback lifecycle", () => {
     const documentHidden = mockDocumentHidden(false);
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "suspended";
+    MockAudioContext.resumeResultQueue = [Promise.resolve()];
 
     audioSource.play();
     expect((audioSource as any)._pendingPlay).to.be.true;
@@ -295,8 +305,35 @@ describe("AudioSource playback lifecycle", () => {
     expect(audioSource.isPlaying).to.be.true;
   });
 
-  // HEADLINE
-  it("drops playback after autoplay-blocked resume instead of replaying on a later gesture", async () => {
+  it("starts every pending source when one shared resume succeeds", async () => {
+    const firstAudioSource = createAudioSource();
+    const secondAudioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveResume = resolve;
+      })
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    firstAudioSource.play();
+    secondAudioSource.play();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((AudioManager as any)._pendingPlaybacks.size).to.equal(2);
+
+    resolveResume!();
+    await flushAsync();
+
+    expect(firstAudioSource.isPlaying).to.be.true;
+    expect(secondAudioSource.isPlaying).to.be.true;
+    expect((AudioManager as any)._pendingPlaybacks.size).to.equal(0);
+  });
+
+  it("retains playback intent after autoplay rejection and starts on a later gesture", async () => {
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "suspended";
@@ -307,14 +344,15 @@ describe("AudioSource playback lifecycle", () => {
     audioSource.play();
     await flushAsync();
 
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.true;
     expect(audioSource.isPlaying).to.be.false;
 
     MockAudioContext.shouldResumeSucceed = true;
     document.dispatchEvent(new Event("click"));
     await flushAsync();
 
-    expect(audioSource.isPlaying).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
   });
 
   it("reissues native resume on the first gesture when a cold-start resume is still pending", async () => {
@@ -342,11 +380,9 @@ describe("AudioSource playback lifecycle", () => {
     // jsdom cannot create real user activation; the second queued resume result models the browser
     // becoming allowed-to-start during this first gesture.
     document.dispatchEvent(new Event("click"));
-    document.dispatchEvent(new Event("click"));
     await flushAsync();
 
-    // The gesture must reach the native AudioContext instead of reusing the cold-start Promise, while
-    // back-to-back gesture events still coalesce into one fresh native resume.
+    // The gesture must reach the native AudioContext instead of reusing the cold-start Promise.
     expect(resumeSpy).toHaveBeenCalledTimes(2);
     expect(context.state).to.equal("running");
 
@@ -357,6 +393,26 @@ describe("AudioSource playback lifecycle", () => {
 
     expect((audioSource as any)._pendingPlay).to.be.false;
     expect(audioSource.isPlaying).to.be.true;
+  });
+
+  it("allows each later gesture to retry when an earlier gesture resume is still pending", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    MockAudioContext.resumeResultQueue = [new Promise<void>(() => {}), new Promise<void>(() => {}), Promise.resolve()];
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    audioSource.play();
+    document.dispatchEvent(new Event("click"));
+    document.dispatchEvent(new Event("click"));
+    await flushAsync();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(3);
+    expect(context.state).to.equal("running");
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
+    expect((AudioManager as any)._resumePromise).to.be.null;
   });
 
   it("cancels a one-shot pending play before resume resolves", async () => {
@@ -385,7 +441,7 @@ describe("AudioSource playback lifecycle", () => {
     expect(audioSource.isPlaying).to.be.false;
   });
 
-  it("drops playback after explicit suspend when resume is autoplay-blocked", async () => {
+  it("keeps play pending during explicit suspend until the caller explicitly resumes", async () => {
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "running";
@@ -393,32 +449,62 @@ describe("AudioSource playback lifecycle", () => {
     await AudioManager.suspend();
     await flushAsync();
 
-    MockAudioContext.shouldResumeSucceed = false;
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-
     audioSource.play();
     await flushAsync();
 
-    expect((audioSource as any)._pendingPlay).to.be.false;
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.true;
+    expect((AudioManager as any)._desiredState).to.equal("suspended");
 
-    MockAudioContext.shouldResumeSucceed = true;
+    const resumeSpy = vi.spyOn(context, "resume");
     document.dispatchEvent(new Event("click"));
     await flushAsync();
 
+    expect(resumeSpy).not.toHaveBeenCalled();
     expect(audioSource.isPlaying).to.be.false;
+
+    await AudioManager.resume();
+
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
   });
 
-  it("resume() unlocks a suspended context and clears the gesture flag", async () => {
+  it("preserves an explicit suspend that races with an earlier resume", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveResume = resolve;
+      })
+    ];
+
+    audioSource.play();
+    await AudioManager.suspend();
+    resolveResume!();
+    await flushAsync();
+
+    expect((AudioManager as any)._desiredState).to.equal("suspended");
+    expect(context.state).to.equal("suspended");
+    expect((audioSource as any)._pendingPlay).to.be.true;
+    expect(audioSource.isPlaying).to.be.false;
+
+    await AudioManager.resume();
+
+    expect(audioSource.isPlaying).to.be.true;
+  });
+
+  it("resume() changes the desired state and unlocks a suspended context", async () => {
     createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "suspended";
-    (AudioManager as any)._needsUserGestureResume = true;
+    (AudioManager as any)._desiredState = "suspended";
 
     await AudioManager.resume();
 
     expect(context.state).to.equal("running");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._desiredState).to.equal("running");
   });
 
   it("coalesces overlapping resume() calls and re-issues a later resume", async () => {
@@ -441,6 +527,7 @@ describe("AudioSource playback lifecycle", () => {
     resolveFirst!();
     await flushAsync();
 
+    context.state = "suspended";
     await AudioManager.resume();
     expect(resumeSpy).toHaveBeenCalledTimes(2);
   });
@@ -460,7 +547,7 @@ describe("AudioSource playback lifecycle", () => {
 
     expect(resumeSpy).not.toHaveBeenCalled();
     expect(context.state).to.equal("suspended");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._desiredState).to.equal("suspended");
   });
 
   it("keeps a playing source playing across a hide without tearing down the node", async () => {
@@ -554,6 +641,31 @@ describe("AudioSource playback lifecycle", () => {
     expect(resumeSpy).not.toHaveBeenCalled();
   });
 
+  it("recovers pending playback demand even when no source has started yet", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    MockAudioContext.shouldResumeSucceed = false;
+    audioSource.play();
+    await flushAsync();
+
+    expect((AudioManager as any)._playingCount).to.equal(0);
+    expect((audioSource as any)._pendingPlay).to.be.true;
+
+    MockAudioContext.shouldResumeSucceed = true;
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
+  });
+
   it("skips recovery after a caller suspend across a hide/show", async () => {
     vi.useFakeTimers();
     const audioSource = createAudioSource();
@@ -584,7 +696,7 @@ describe("AudioSource playback lifecycle", () => {
     audioSource.play();
     context.state = "suspended";
 
-    // the timer's auto-resume rejects, leaving the gesture fallback armed
+    // the timer's auto-resume rejects, but playback demand remains for a later gesture
     MockAudioContext.resumeResultQueue = [new Error("autoplay blocked")];
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -593,7 +705,6 @@ describe("AudioSource playback lifecycle", () => {
     vi.advanceTimersByTime(100);
     await flushAsync();
 
-    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
     expect(context.state).to.equal("suspended");
 
     vi.useRealTimers();
@@ -603,7 +714,6 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
     documentHidden.restore();
 
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
     expect(context.state).to.equal("running");
   });
 
@@ -660,9 +770,8 @@ describe("AudioSource playback lifecycle", () => {
     expect(context.state).to.equal("running");
   });
 
-  // a storm of clicks AFTER the 100ms guard window but BEFORE the resume settles must coalesce via
-  // _resumePromise into the timer's resume (the timer goes through AudioManager.resume() now)
-  it("coalesces a click-storm during the slow iOS resume settle into a single context.resume()", async () => {
+  // A gesture must bypass a stale timer resume. Once the first gesture starts the context, later clicks no-op.
+  it("lets a gesture bypass a slow foreground resume without continuing after the context starts", async () => {
     vi.useFakeTimers();
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
@@ -690,12 +799,12 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._recovering).to.be.false;
     expect((AudioManager as any)._resumePromise).to.not.be.null;
 
-    // storm of clicks while the resume is still pending -> _resumePromise coalesces them
+    // First click makes a fresh gesture-bound attempt; once it starts the context, later clicks no-op.
     for (let i = 0; i < 10; i++) {
       document.dispatchEvent(new Event("click"));
     }
     await flushAsync();
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
 
     releaseResume!();
     await flushAsync();
@@ -802,13 +911,12 @@ describe("AudioSource playback lifecycle", () => {
   });
 
   // suspend() must not create a context just to suspend it (would be the cold-ctx iOS zombie we avoid)
-  // suspend() with no context is a no-op: it must NOT create a context AND must NOT flag a caller-suspend
-  // (a ghost flag would later block foreground recovery once playback starts)
-  it("does not create a context or flag a caller-suspend when suspend() runs before any playback", async () => {
+  // suspend() with no context is a no-op: it must not create a context or change the initial desired state.
+  it("does not create a context or change desired state when suspend() runs before playback", async () => {
     await AudioManager.suspend();
 
     expect((AudioManager as any)._context == null).to.be.true;
-    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+    expect((AudioManager as any)._desiredState).to.equal("running");
   });
 
   // root cause regression: suspend() before first play (no ctx) must not leave a ghost flag that blocks
@@ -820,7 +928,7 @@ describe("AudioSource playback lifecycle", () => {
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "running";
     audioSource.play();
-    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+    expect((AudioManager as any)._desiredState).to.equal("running");
 
     context.state = "suspended";
     const resumeSpy = vi.spyOn(context, "resume");
@@ -861,8 +969,8 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._context == null).to.be.true;
   });
 
-  // hide-suspend uses the bare context.suspend(), so a return to foreground still recovers
-  it("recovers after a hide-suspend (hide does not flag _suspendedByCaller)", async () => {
+  // hide-suspend is a physical transition only, so the desired state stays running and foreground recovers.
+  it("recovers after a hide-suspend without changing desired state", async () => {
     vi.useFakeTimers();
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
@@ -871,7 +979,7 @@ describe("AudioSource playback lifecycle", () => {
 
     const documentHidden = mockDocumentHidden(true);
     document.dispatchEvent(new Event("visibilitychange"));
-    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+    expect((AudioManager as any)._desiredState).to.equal("running");
 
     const resumeSpy = vi.spyOn(context, "resume");
     documentHidden.set(false);


### PR DESCRIPTION
## Summary

- Separate caller intent (running or suspended), physical AudioContext state, and pending AudioSource playback requests.
- Let AudioSource register and cancel playback intent instead of depending on one resume Promise settling.
- Coalesce ordinary programmatic resume attempts, while allowing every trusted gesture to issue a fresh native resume when an older attempt is still pending.
- Reconcile AudioContext state changes centrally, preserve explicit suspend across races, and include pending sources in foreground recovery demand.
- Keep the public AudioManager API unchanged.

## Root cause

Web Audio may leave resume pending while the context is not yet allowed to start: https://www.w3.org/TR/webaudio-1.1/#dom-audiocontext-resume

The previous implementation made each AudioSource await one cached resume Promise. A pre-gesture call could therefore remain pending indefinitely, and later gestures reused the same Promise instead of reaching the native AudioContext. Explicit caller suspension, autoplay unlock, and foreground recovery also shared the same resume path, so a source play could erase caller-controlled suspend state. Finally, foreground recovery only counted already-playing sources and ignored pending playback demand.

## Resulting state model

- Desired state: explicit AudioManager suspend/resume intent.
- Physical state: AudioContext state, reconciled through statechange.
- Playback intent: manager-owned pending callbacks, drained only when desired and physical states both allow playback.
- Recovery: automatic attempts are single-flight; gesture attempts can bypass stale pending attempts; explicit suspend always wins races.

## Regression coverage

The audio lifecycle suite now covers:

- rejected and indefinitely pending cold-start resume;
- repeated trusted gestures;
- multiple pending AudioSources;
- stop/pause cancellation;
- explicit suspend versus source play and resume races;
- pending-only foreground recovery;
- visibility, bfcache, and iOS interrupted-context recovery.

## Verification

- pnpm vitest run tests/src/core/audio --reporter=dot: 41 passed
- pnpm b:types: passed for all workspace packages
- pnpm b:module with Node 22.19: passed
- Prettier check: passed
- ESLint: no errors and no new warnings
- git diff --check: passed