### PR TITLE
fix(audio): recover playback on first iOS gesture

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -38,7 +38,7 @@ export class AudioManager {
    */
   static resume(): Promise<void> {
     AudioManager._suspendedByCaller = false;
-    return AudioManager._resumePromise ?? AudioManager._startResume(false);
+    return AudioManager._requestResume(navigator.userActivation?.isActive === true);
   }
 
   /**
@@ -79,11 +79,20 @@ export class AudioManager {
     return AudioManager.getContext().state === "running";
   }
 
+  private static _requestResume(fromUserGesture: boolean): Promise<void> {
+    const resumePromise = AudioManager._resumePromise;
+    return resumePromise && (!fromUserGesture || AudioManager._resumeAttemptFromUserGesture)
+      ? resumePromise
+      : AudioManager._startResume(fromUserGesture);
+  }
+
   private static _startResume(fromUserGesture: boolean): Promise<void> {
     const resumePromise = AudioManager.getContext()
       .resume()
       .then(() => {
-        AudioManager._needsUserGestureResume = false;
+        if (AudioManager._resumePromise === resumePromise) {
+          AudioManager._needsUserGestureResume = false;
+        }
       })
       .finally(() => {
         if (AudioManager._resumePromise === resumePromise) {
@@ -144,7 +153,12 @@ export class AudioManager {
     }
   }
 
-  private static _onUserGesture(): void {
+  private static _onUserGesture(event: Event): void {
+    // Ignore synthetic events unless a real user activation is already active
+    if (!event.isTrusted && !navigator.userActivation?.isActive) {
+      return;
+    }
+
     // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context)
     if (AudioManager._recovering || AudioManager._suspendedByCaller) {
       return;
@@ -159,12 +173,8 @@ export class AudioManager {
       return;
     }
 
-    // A trusted gesture may supersede a pending programmatic attempt, while repeated
-    // events coalesce with the active gesture attempt
-    const resumePromise =
-      AudioManager._resumePromise && AudioManager._resumeAttemptFromUserGesture
-        ? AudioManager._resumePromise
-        : AudioManager._startResume(true);
+    // A real gesture may supersede a pending programmatic attempt, while repeated events coalesce
+    const resumePromise = AudioManager._requestResume(true);
     resumePromise.catch((e) => {
       console.warn("Failed to resume AudioContext:", e);
     });

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -38,7 +38,7 @@ export class AudioManager {
    */
   static resume(): Promise<void> {
     AudioManager._suspendedByCaller = false;
-    return AudioManager._requestResume(navigator.userActivation?.isActive === true);
+    return AudioManager._requestResume(AudioManager._isUserGestureActive());
   }
 
   /**
@@ -105,6 +105,16 @@ export class AudioManager {
     return resumePromise;
   }
 
+  private static _isUserGestureActive(event: Event | undefined = window.event): boolean {
+    if (navigator.userActivation?.isActive === true) {
+      return true;
+    }
+    // Safari 16.3 and earlier expose the current listener event but not the User Activation API
+    return (
+      event?.isTrusted === true && (event.type === "touchstart" || event.type === "touchend" || event.type === "click")
+    );
+  }
+
   private static _onVisibilityChange(): void {
     if (document.hidden) {
       // Desktop/Android don't auto-suspend a running WebAudio context when backgrounded (only iOS does),
@@ -154,8 +164,7 @@ export class AudioManager {
   }
 
   private static _onUserGesture(event: Event): void {
-    // Ignore synthetic events unless a real user activation is already active
-    if (!event.isTrusted && !navigator.userActivation?.isActive) {
+    if (!AudioManager._isUserGestureActive(event)) {
       return;
     }
 

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -12,7 +12,7 @@ export class AudioManager {
   private static _context: AudioContext;
   private static _gainNode: GainNode;
   private static _resumePromise: Promise<void> = null;
-  private static _needsUserGestureResume = false;
+  private static _interruptionRecoveryPending = false;
   private static _suspendedByCaller = false;
   private static _recovering = false;
 
@@ -91,7 +91,7 @@ export class AudioManager {
       .resume()
       .then(() => {
         if (AudioManager._resumePromise === resumePromise) {
-          AudioManager._needsUserGestureResume = false;
+          AudioManager._interruptionRecoveryPending = false;
         }
       })
       .finally(() => {
@@ -142,7 +142,7 @@ export class AudioManager {
       return;
     }
     AudioManager._recovering = true;
-    AudioManager._needsUserGestureResume = true; // fallback if the auto-resume below is rejected
+    AudioManager._interruptionRecoveryPending = true; // Remains pending if the automatic resume fails or stalls
     const context = AudioManager.getContext();
     context.suspend().catch(() => {});
     // 100ms empirical delay (resume too soon after suspend is unreliable on iOS); _recovering is cleared
@@ -176,7 +176,7 @@ export class AudioManager {
     }
 
     const context = AudioManager._context;
-    if (context.state === "running" || (!AudioManager._needsUserGestureResume && !AudioManager._resumePromise)) {
+    if (context.state === "running" || (!AudioManager._interruptionRecoveryPending && !AudioManager._resumePromise)) {
       return;
     }
 

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -105,10 +105,12 @@ export class AudioManager {
     return resumePromise;
   }
 
-  private static _isUserGestureActive(event: Event | undefined = window.event): boolean {
-    if (navigator.userActivation?.isActive === true) {
-      return true;
+  private static _isUserGestureActive(event?: Event): boolean {
+    const userActivation = navigator.userActivation;
+    if (userActivation) {
+      return userActivation.isActive;
     }
+    event ??= window.event;
     // Safari 16.3 and earlier expose the current listener event but not the User Activation API
     return (
       event?.isTrusted === true && (event.type === "touchstart" || event.type === "touchend" || event.type === "click")

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -4,6 +4,10 @@
 export class AudioManager {
   /** @internal */
   static _playingCount = 0;
+  /** @internal */
+  static _resumeAttemptId = 0;
+  /** @internal */
+  static _resumeAttemptFromUserGesture = false;
 
   private static _context: AudioContext;
   private static _gainNode: GainNode;
@@ -34,14 +38,7 @@ export class AudioManager {
    */
   static resume(): Promise<void> {
     AudioManager._suspendedByCaller = false;
-    return (AudioManager._resumePromise ??= AudioManager.getContext()
-      .resume()
-      .then(() => {
-        AudioManager._needsUserGestureResume = false;
-      })
-      .finally(() => {
-        AudioManager._resumePromise = null;
-      }));
+    return AudioManager._resumePromise ?? AudioManager._startResume(false);
   }
 
   /**
@@ -55,9 +52,9 @@ export class AudioManager {
       // iOS Safari bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
       window.addEventListener("pageshow", AudioManager._onPageShow);
       // iOS Safari requires a user gesture to resume the AudioContext
-      document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, { passive: true });
-      document.addEventListener("touchend", AudioManager._resumeAfterInterruption, { passive: true });
-      document.addEventListener("click", AudioManager._resumeAfterInterruption);
+      document.addEventListener("touchstart", AudioManager._onUserGesture, { passive: true, capture: true });
+      document.addEventListener("touchend", AudioManager._onUserGesture, { passive: true, capture: true });
+      document.addEventListener("click", AudioManager._onUserGesture, true);
     }
     return context;
   }
@@ -80,6 +77,23 @@ export class AudioManager {
    */
   static isAudioContextRunning(): boolean {
     return AudioManager.getContext().state === "running";
+  }
+
+  private static _startResume(fromUserGesture: boolean): Promise<void> {
+    const resumePromise = AudioManager.getContext()
+      .resume()
+      .then(() => {
+        AudioManager._needsUserGestureResume = false;
+      })
+      .finally(() => {
+        if (AudioManager._resumePromise === resumePromise) {
+          AudioManager._resumePromise = null;
+        }
+      });
+    AudioManager._resumeAttemptId++;
+    AudioManager._resumeAttemptFromUserGesture = fromUserGesture;
+    AudioManager._resumePromise = resumePromise;
+    return resumePromise;
   }
 
   private static _onVisibilityChange(): void {
@@ -117,8 +131,8 @@ export class AudioManager {
       if (document.hidden || AudioManager._suspendedByCaller) {
         return;
       }
-      // Go through AudioManager.resume() so _resumePromise coalesces any gesture-resume racing us during
-      // the slow iOS interrupted->running transition; a bare context.resume() here wouldn't dedupe
+      // Track the timer attempt through AudioManager.resume(): programmatic callers coalesce with it,
+      // while a later trusted gesture can supersede it if WebKit leaves it pending
       AudioManager.resume().catch(() => {});
     }, 100);
   }
@@ -130,13 +144,28 @@ export class AudioManager {
     }
   }
 
-  private static _resumeAfterInterruption(): void {
-    // iOS Safari gesture fallback for when auto-resume is blocked.
+  private static _onUserGesture(): void {
     // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context)
-    if (AudioManager._recovering || AudioManager._suspendedByCaller || !AudioManager._needsUserGestureResume) {
+    if (AudioManager._recovering || AudioManager._suspendedByCaller) {
       return;
     }
-    AudioManager.resume().catch((e) => {
+
+    const context = AudioManager._context;
+    if (
+      !context ||
+      context.state === "running" ||
+      (!AudioManager._needsUserGestureResume && !AudioManager._resumePromise)
+    ) {
+      return;
+    }
+
+    // A trusted gesture may supersede a pending programmatic attempt, while repeated
+    // events coalesce with the active gesture attempt
+    const resumePromise =
+      AudioManager._resumePromise && AudioManager._resumeAttemptFromUserGesture
+        ? AudioManager._resumePromise
+        : AudioManager._startResume(true);
+    resumePromise.catch((e) => {
       console.warn("Failed to resume AudioContext:", e);
     });
   }

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -176,11 +176,7 @@ export class AudioManager {
     }
 
     const context = AudioManager._context;
-    if (
-      !context ||
-      context.state === "running" ||
-      (!AudioManager._needsUserGestureResume && !AudioManager._resumePromise)
-    ) {
+    if (context.state === "running" || (!AudioManager._needsUserGestureResume && !AudioManager._resumePromise)) {
       return;
     }
 

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -14,7 +14,7 @@ export class AudioSource extends Component {
   @ignoreClone
   private _isPlaying = false;
   @ignoreClone
-  private _pendingPlay = false;
+  private _pendingPlay: Promise<void> | null = null;
 
   private _clip: AudioClip;
   @ignoreClone
@@ -161,17 +161,17 @@ export class AudioSource extends Component {
     } else {
       // iOS Safari requires resume() to be called within the same user gesture callback that triggers playback.
       // Document-level events won't work - must call resume() directly here in play().
-      this._pendingPlay = true;
       const resumePromise = AudioManager.resume();
+      this._pendingPlay = resumePromise;
       const resumeAttemptId = AudioManager._resumeAttemptId;
       const resumeAttemptFromUserGesture = AudioManager._resumeAttemptFromUserGesture;
       resumePromise.then(
         () => {
-          // Check if cancelled by stop()/pause()
-          if (!this._pendingPlay) {
+          // Only the request that installed this Promise may consume or clear it
+          if (this._pendingPlay !== resumePromise) {
             return;
           }
-          this._pendingPlay = false;
+          this._pendingPlay = null;
           // A later gesture superseded the resume attempt, so this one-shot request is now stale
           if (!resumeAttemptFromUserGesture && resumeAttemptId !== AudioManager._resumeAttemptId) {
             return;
@@ -183,7 +183,10 @@ export class AudioSource extends Component {
           this._startPlayback();
         },
         (e) => {
-          this._pendingPlay = false;
+          if (this._pendingPlay !== resumePromise) {
+            return;
+          }
+          this._pendingPlay = null;
           if (resumeAttemptFromUserGesture || resumeAttemptId === AudioManager._resumeAttemptId) {
             console.warn("Failed to resume AudioContext:", e);
           }
@@ -196,7 +199,7 @@ export class AudioSource extends Component {
    * Stops playing the clip.
    */
   stop(): void {
-    this._pendingPlay = false;
+    this._pendingPlay = null;
 
     if (this._isPlaying) {
       this._clearSourceNode();
@@ -213,7 +216,7 @@ export class AudioSource extends Component {
    * Pauses playing the clip.
    */
   pause(): void {
-    this._pendingPlay = false;
+    this._pendingPlay = null;
 
     if (this._isPlaying) {
       this._clearSourceNode();

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -159,8 +159,7 @@ export class AudioSource extends Component {
     if (AudioManager.isAudioContextRunning()) {
       this._startPlayback();
     } else {
-      // iOS Safari requires resume() to be called within the same user gesture callback that triggers playback.
-      // Document-level events won't work - must call resume() directly here in play().
+      // Join the Manager-owned resume attempt so document capture and playback share the same request
       const resumePromise = AudioManager.resume();
       this._pendingPlay = resumePromise;
       const resumeAttemptId = AudioManager._resumeAttemptId;

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -162,13 +162,20 @@ export class AudioSource extends Component {
       // iOS Safari requires resume() to be called within the same user gesture callback that triggers playback.
       // Document-level events won't work - must call resume() directly here in play().
       this._pendingPlay = true;
-      AudioManager.resume().then(
+      const resumePromise = AudioManager.resume();
+      const resumeAttemptId = AudioManager._resumeAttemptId;
+      const resumeAttemptFromUserGesture = AudioManager._resumeAttemptFromUserGesture;
+      resumePromise.then(
         () => {
           // Check if cancelled by stop()/pause()
           if (!this._pendingPlay) {
             return;
           }
           this._pendingPlay = false;
+          // A later gesture superseded the resume attempt, so this one-shot request is now stale
+          if (!resumeAttemptFromUserGesture && resumeAttemptId !== AudioManager._resumeAttemptId) {
+            return;
+          }
           // Check if still valid to play after async resume (page may have been hidden meanwhile)
           if (this._destroyed || !this.enabled || !this._clip || document.hidden) {
             return;
@@ -177,7 +184,9 @@ export class AudioSource extends Component {
         },
         (e) => {
           this._pendingPlay = false;
-          console.warn("Failed to resume AudioContext:", e);
+          if (resumeAttemptFromUserGesture || resumeAttemptId === AudioManager._resumeAttemptId) {
+            console.warn("Failed to resume AudioContext:", e);
+          }
         }
       );
     }

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -163,16 +163,16 @@ export class AudioSource extends Component {
       const resumePromise = AudioManager.resume();
       this._pendingPlay = resumePromise;
       const resumeAttemptId = AudioManager._resumeAttemptId;
-      const resumeAttemptFromUserGesture = AudioManager._resumeAttemptFromUserGesture;
+      const resumeAttemptCanBeSuperseded = !AudioManager._resumeAttemptFromUserGesture;
       resumePromise.then(
         () => {
-          // Only the request that installed this Promise may consume or clear it
+          // The source may cancel this play or switch to another resume attempt before this one settles
           if (this._pendingPlay !== resumePromise) {
             return;
           }
           this._pendingPlay = null;
-          // A later gesture superseded the resume attempt, so this one-shot request is now stale
-          if (!resumeAttemptFromUserGesture && resumeAttemptId !== AudioManager._resumeAttemptId) {
+          // Drop a pre-gesture play if a user gesture replaced the resume attempt it was waiting for
+          if (resumeAttemptCanBeSuperseded && resumeAttemptId !== AudioManager._resumeAttemptId) {
             return;
           }
           // Check if still valid to play after async resume (page may have been hidden meanwhile)
@@ -186,9 +186,10 @@ export class AudioSource extends Component {
             return;
           }
           this._pendingPlay = null;
-          if (resumeAttemptFromUserGesture || resumeAttemptId === AudioManager._resumeAttemptId) {
-            console.warn("Failed to resume AudioContext:", e);
+          if (resumeAttemptCanBeSuperseded && resumeAttemptId !== AudioManager._resumeAttemptId) {
+            return;
           }
+          console.warn("Failed to resume AudioContext:", e);
         }
       );
     }

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -166,12 +166,12 @@ export class AudioSource extends Component {
       const resumeAttemptCanBeSuperseded = !AudioManager._resumeAttemptFromUserGesture;
       resumePromise.then(
         () => {
-          // The source may cancel this play or switch to another resume attempt before this one settles
+          // Source-local guard: stop(), pause(), or a newer request may revoke this callback's ownership
           if (this._pendingPlay !== resumePromise) {
             return;
           }
           this._pendingPlay = null;
-          // Drop a pre-gesture play if a user gesture replaced the resume attempt it was waiting for
+          // Manager-global guard: discard playback tied to a pre-gesture attempt superseded by a gesture
           if (resumeAttemptCanBeSuperseded && resumeAttemptId !== AudioManager._resumeAttemptId) {
             return;
           }

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -95,13 +95,15 @@ function createAudioSource(): AudioSource {
 function resetAudioManagerState(): void {
   document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
   window.removeEventListener("pageshow", (AudioManager as any)._onPageShow);
-  document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption);
-  document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption);
-  document.removeEventListener("click", (AudioManager as any)._resumeAfterInterruption);
+  document.removeEventListener("touchstart", (AudioManager as any)._onUserGesture, true);
+  document.removeEventListener("touchend", (AudioManager as any)._onUserGesture, true);
+  document.removeEventListener("click", (AudioManager as any)._onUserGesture, true);
 
   (AudioManager as any)._context = null;
   (AudioManager as any)._gainNode = null;
   (AudioManager as any)._resumePromise = null;
+  (AudioManager as any)._resumeAttemptId = 0;
+  (AudioManager as any)._resumeAttemptFromUserGesture = false;
   (AudioManager as any)._needsUserGestureResume = false;
   (AudioManager as any)._suspendedByCaller = false;
   (AudioManager as any)._recovering = false;
@@ -314,6 +316,65 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
 
     expect(audioSource.isPlaying).to.be.false;
+  });
+
+  it("lets an iOS gesture supersede a pending cold-start resume without replaying the stale source", async () => {
+    const opening = createAudioSource();
+    const bgm = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveColdStartResume: () => void;
+    let resolveGestureResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      // iOS may leave a resume issued before user activation pending indefinitely
+      new Promise<void>((resolve) => {
+        resolveColdStartResume = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        resolveGestureResume = resolve;
+      })
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    opening.play();
+    const coldStartResumePromise = (AudioManager as any)._resumePromise;
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((opening as any)._pendingPlay).to.be.true;
+
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    canvas.addEventListener("touchend", () => bgm.play(), { capture: true, passive: true, once: true });
+    canvas.dispatchEvent(new Event("touchend", { bubbles: true }));
+
+    const gestureResumePromise = (AudioManager as any)._resumePromise;
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect(gestureResumePromise).not.toBe(coldStartResumePromise);
+    expect((bgm as any)._pendingPlay).to.be.true;
+
+    // Repeated events coalesce once a gesture-originated attempt is active
+    document.dispatchEvent(new Event("click"));
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+
+    // The superseded Promise may settle later, but it must not clear the gesture attempt or replay opening
+    resolveColdStartResume!();
+    await coldStartResumePromise;
+    await flushAsync();
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+    expect((opening as any)._pendingPlay).to.be.false;
+    expect(opening.isPlaying).to.be.false;
+    expect(bgm.isPlaying).to.be.false;
+
+    resolveGestureResume!();
+    await gestureResumePromise;
+    await flushAsync();
+    expect((bgm as any)._pendingPlay).to.be.false;
+    expect(bgm.isPlaying).to.be.true;
+    expect(opening.isPlaying).to.be.false;
+    canvas.remove();
+
+    expect((AudioManager as any)._resumePromise).to.be.null;
   });
 
   it("cancels a one-shot pending play before resume resolves", async () => {
@@ -617,9 +678,7 @@ describe("AudioSource playback lifecycle", () => {
     expect(context.state).to.equal("running");
   });
 
-  // a storm of clicks AFTER the 100ms guard window but BEFORE the resume settles must coalesce via
-  // _resumePromise into the timer's resume (the timer goes through AudioManager.resume() now)
-  it("coalesces a click-storm during the slow iOS resume settle into a single context.resume()", async () => {
+  it("lets a gesture supersede a pending recovery resume and coalesces later events", async () => {
     vi.useFakeTimers();
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
@@ -628,11 +687,14 @@ describe("AudioSource playback lifecycle", () => {
     audioSource.play();
     context.state = "suspended";
 
-    // hold resume unresolved to simulate the slow iOS interrupted->running transition
-    let releaseResume: () => void;
+    let resolveRecoveryResume: () => void;
+    let resolveGestureResume: () => void;
     MockAudioContext.resumeResultQueue = [
       new Promise<void>((resolve) => {
-        releaseResume = resolve;
+        resolveRecoveryResume = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        resolveGestureResume = resolve;
       })
     ];
 
@@ -640,23 +702,39 @@ describe("AudioSource playback lifecycle", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     const resumeSpy = vi.spyOn(context, "resume");
 
-    // 100ms timer fires -> timer calls AudioManager.resume() which sets _resumePromise
     vi.advanceTimersByTime(100);
     await flushAsync();
+    const recoveryResumePromise = (AudioManager as any)._resumePromise;
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     expect((AudioManager as any)._recovering).to.be.false;
-    expect((AudioManager as any)._resumePromise).to.not.be.null;
+    expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.false;
 
-    // storm of clicks while the resume is still pending -> _resumePromise coalesces them
+    document.dispatchEvent(new Event("click"));
+    const gestureResumePromise = (AudioManager as any)._resumePromise;
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect(gestureResumePromise).not.toBe(recoveryResumePromise);
+    expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.true;
+
     for (let i = 0; i < 10; i++) {
       document.dispatchEvent(new Event("click"));
     }
     await flushAsync();
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
 
-    releaseResume!();
+    resolveRecoveryResume!();
+    await recoveryResumePromise;
+    await flushAsync();
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+
+    resolveGestureResume!();
+    await gestureResumePromise;
     await flushAsync();
     documentHidden.restore();
+
+    expect(context.state).to.equal("running");
+    expect((AudioManager as any)._resumePromise).to.be.null;
+    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
   });
 
   it("treats a non-persisted pageshow as a no-op", () => {

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -594,13 +594,9 @@ describe("AudioSource playback lifecycle", () => {
     context.state = "suspended";
 
     let resolveEarlyResume: () => void;
-    let resolveDocumentResume: () => void;
     MockAudioContext.resumeResultQueue = [
       new Promise<void>((resolve) => {
         resolveEarlyResume = resolve;
-      }),
-      new Promise<void>((resolve) => {
-        resolveDocumentResume = resolve;
       })
     ];
     const resumeSpy = vi.spyOn(context, "resume");
@@ -612,11 +608,10 @@ describe("AudioSource playback lifecycle", () => {
     const earlyResumePromise = (AudioManager as any)._resumePromise as Promise<void>;
     (AudioManager as any)._onUserGesture(touchEnd);
     const documentResumePromise = (AudioManager as any)._resumePromise as Promise<void>;
+    expect(documentResumePromise).toBe(earlyResumePromise);
 
     resolveEarlyResume!();
     await earlyResumePromise;
-    resolveDocumentResume!();
-    await documentResumePromise;
     await flushAsync();
 
     expect(audioSource.isPlaying).to.be.true;

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -2,6 +2,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AudioManager, AudioSource } from "@galacean/engine-core/src/audio";
 
 const originalAudioContext = window.AudioContext;
+let restoreUserActivation: (() => void) | null = null;
+
+function mockUserActivation(initialActive: boolean): { set(active: boolean): void } {
+  restoreUserActivation?.();
+  const ownDescriptor = Object.getOwnPropertyDescriptor(navigator, "userActivation");
+  let active = initialActive;
+  Object.defineProperty(navigator, "userActivation", {
+    configurable: true,
+    get: () => ({ hasBeenActive: active, isActive: active })
+  });
+  restoreUserActivation = () => {
+    if (ownDescriptor) {
+      Object.defineProperty(navigator, "userActivation", ownDescriptor);
+    } else {
+      delete (navigator as any).userActivation;
+    }
+    restoreUserActivation = null;
+  };
+  return {
+    set(value: boolean) {
+      active = value;
+    }
+  };
+}
 
 class MockGainNode {
   gain = {
@@ -143,6 +167,7 @@ function mockDocumentHidden(initialHidden: boolean): { set(hidden: boolean): voi
 describe("AudioSource playback lifecycle", () => {
   beforeEach(() => {
     resetAudioManagerState();
+    mockUserActivation(false);
     (window as any).AudioContext = MockAudioContext;
     MockAudioContext.shouldResumeSucceed = true;
     MockAudioContext.shouldSuspendSucceed = true;
@@ -152,6 +177,7 @@ describe("AudioSource playback lifecycle", () => {
   afterEach(async () => {
     await flushAsync();
     resetAudioManagerState();
+    restoreUserActivation?.();
     (window as any).AudioContext = originalAudioContext;
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -235,7 +261,7 @@ describe("AudioSource playback lifecycle", () => {
     // (c) pending play -> noop
     audioSource.stop();
     context.state = "suspended";
-    (audioSource as any)._pendingPlay = true;
+    (audioSource as any)._pendingPlay = Promise.resolve();
     audioSource.play();
     expect(audioSource.isPlaying).to.be.false;
   });
@@ -254,7 +280,7 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
 
     expect(audioSource.isPlaying).to.be.false;
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
     expect(ctxSuspendSpy).not.toHaveBeenCalled();
     expect(managerSuspendSpy).not.toHaveBeenCalled();
   });
@@ -268,7 +294,7 @@ describe("AudioSource playback lifecycle", () => {
     const documentHidden = mockDocumentHidden(true);
     audioSource.play();
     expect(audioSource.isPlaying).to.be.false;
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
 
     documentHidden.set(false);
     document.dispatchEvent(new Event("visibilitychange"));
@@ -277,7 +303,7 @@ describe("AudioSource playback lifecycle", () => {
     documentHidden.restore();
 
     expect(audioSource.isPlaying).to.be.false;
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
   });
 
   it("replays the pending play on the resume it triggered", async () => {
@@ -287,12 +313,12 @@ describe("AudioSource playback lifecycle", () => {
     context.state = "suspended";
 
     audioSource.play();
-    expect((audioSource as any)._pendingPlay).to.be.true;
+    expect((audioSource as any)._pendingPlay).to.not.be.null;
 
     await flushAsync();
     documentHidden.restore();
 
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
     expect(audioSource.isPlaying).to.be.true;
   });
 
@@ -308,10 +334,11 @@ describe("AudioSource playback lifecycle", () => {
     audioSource.play();
     await flushAsync();
 
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
     expect(audioSource.isPlaying).to.be.false;
 
     MockAudioContext.shouldResumeSucceed = true;
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click"));
     await flushAsync();
 
@@ -340,17 +367,18 @@ describe("AudioSource playback lifecycle", () => {
     opening.play();
     const coldStartResumePromise = (AudioManager as any)._resumePromise;
     expect(resumeSpy).toHaveBeenCalledTimes(1);
-    expect((opening as any)._pendingPlay).to.be.true;
+    expect((opening as any)._pendingPlay).to.not.be.null;
 
     const canvas = document.createElement("canvas");
     document.body.appendChild(canvas);
     canvas.addEventListener("touchend", () => bgm.play(), { capture: true, passive: true, once: true });
+    mockUserActivation(true);
     canvas.dispatchEvent(new Event("touchend", { bubbles: true }));
 
     const gestureResumePromise = (AudioManager as any)._resumePromise;
     expect(resumeSpy).toHaveBeenCalledTimes(2);
     expect(gestureResumePromise).not.toBe(coldStartResumePromise);
-    expect((bgm as any)._pendingPlay).to.be.true;
+    expect((bgm as any)._pendingPlay).to.not.be.null;
 
     // Repeated events coalesce once a gesture-originated attempt is active
     document.dispatchEvent(new Event("click"));
@@ -362,19 +390,69 @@ describe("AudioSource playback lifecycle", () => {
     await coldStartResumePromise;
     await flushAsync();
     expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
-    expect((opening as any)._pendingPlay).to.be.false;
+    expect((opening as any)._pendingPlay).to.be.null;
     expect(opening.isPlaying).to.be.false;
     expect(bgm.isPlaying).to.be.false;
 
     resolveGestureResume!();
     await gestureResumePromise;
     await flushAsync();
-    expect((bgm as any)._pendingPlay).to.be.false;
+    expect((bgm as any)._pendingPlay).to.be.null;
     expect(bgm.isPlaying).to.be.true;
     expect(opening.isPlaying).to.be.false;
     canvas.remove();
 
     expect((AudioManager as any)._resumePromise).to.be.null;
+  });
+
+  it("keeps a restarted play pending when the superseded resume settles", async () => {
+    const audioSource = createAudioSource();
+    const documentHidden = mockDocumentHidden(false);
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveColdStartResume: () => void;
+    let resolveGestureResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveColdStartResume = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        resolveGestureResume = resolve;
+      })
+    ];
+
+    audioSource.play();
+    const coldStartResumePromise = (AudioManager as any)._resumePromise;
+
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    canvas.addEventListener(
+      "touchend",
+      () => {
+        audioSource.stop();
+        audioSource.play();
+      },
+      { capture: true, passive: true, once: true }
+    );
+    mockUserActivation(true);
+    canvas.dispatchEvent(new Event("touchend", { bubbles: true }));
+
+    const gestureResumePromise = (AudioManager as any)._resumePromise;
+    expect(gestureResumePromise).not.toBe(coldStartResumePromise);
+
+    resolveColdStartResume!();
+    await coldStartResumePromise;
+    await flushAsync();
+    expect(audioSource.isPlaying).to.be.false;
+
+    resolveGestureResume!();
+    await gestureResumePromise;
+    await flushAsync();
+    documentHidden.restore();
+    canvas.remove();
+
+    expect(audioSource.isPlaying).to.be.true;
   });
 
   it("cancels a one-shot pending play before resume resolves", async () => {
@@ -391,10 +469,10 @@ describe("AudioSource playback lifecycle", () => {
     ];
 
     audioSource.play();
-    expect((audioSource as any)._pendingPlay).to.be.true;
+    expect((audioSource as any)._pendingPlay).to.not.be.null;
 
     audioSource.stop();
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
 
     resolveResume!();
     await flushAsync();
@@ -417,10 +495,11 @@ describe("AudioSource playback lifecycle", () => {
     audioSource.play();
     await flushAsync();
 
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
     expect((AudioManager as any)._needsUserGestureResume).to.be.false;
 
     MockAudioContext.shouldResumeSucceed = true;
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click"));
     await flushAsync();
 
@@ -463,6 +542,51 @@ describe("AudioSource playback lifecycle", () => {
     expect(resumeSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores synthetic gesture events while allowing an activated resume to supersede", async () => {
+    createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveProgrammaticResume: () => void;
+    let resolveGestureResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveProgrammaticResume = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        resolveGestureResume = resolve;
+      })
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+    const userActivation = mockUserActivation(false);
+
+    const programmaticResumePromise = AudioManager.resume();
+    document.dispatchEvent(new Event("click"));
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((AudioManager as any)._resumePromise).toBe(programmaticResumePromise);
+    expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.false;
+
+    userActivation.set(true);
+    const gestureResumePromise = AudioManager.resume();
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect(gestureResumePromise).not.toBe(programmaticResumePromise);
+    expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.true;
+
+    document.dispatchEvent(new Event("click"));
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+
+    resolveProgrammaticResume!();
+    await programmaticResumePromise;
+    await flushAsync();
+    expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+
+    resolveGestureResume!();
+    await gestureResumePromise;
+    await flushAsync();
+    expect((AudioManager as any)._resumePromise).to.be.null;
+  });
+
   it("does not auto-resume a caller-controlled suspend on a later gesture", async () => {
     createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
@@ -472,6 +596,7 @@ describe("AudioSource playback lifecycle", () => {
     await AudioManager.suspend();
     await flushAsync();
 
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click"));
     document.dispatchEvent(new Event("touchend"));
     await flushAsync();
@@ -617,6 +742,7 @@ describe("AudioSource playback lifecycle", () => {
     vi.useRealTimers();
     MockAudioContext.resumeResultQueue = null;
     MockAudioContext.shouldResumeSucceed = true;
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click"));
     await flushAsync();
     documentHidden.restore();
@@ -665,6 +791,7 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._recovering).to.be.true;
 
     const resumeSpy = vi.spyOn(context, "resume");
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click")); // gesture inside the 100ms window
     await flushAsync();
     expect(resumeSpy).not.toHaveBeenCalled(); // gesture did NOT resume (recovery owns it)
@@ -709,6 +836,7 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._recovering).to.be.false;
     expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.false;
 
+    mockUserActivation(true);
     document.dispatchEvent(new Event("click"));
     const gestureResumePromise = (AudioManager as any)._resumePromise;
     expect(resumeSpy).toHaveBeenCalledTimes(2);
@@ -726,6 +854,7 @@ describe("AudioSource playback lifecycle", () => {
     await recoveryResumePromise;
     await flushAsync();
     expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
+    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
 
     resolveGestureResume!();
     await gestureResumePromise;
@@ -794,7 +923,7 @@ describe("AudioSource playback lifecycle", () => {
     expect((audioSource as any)._pausedTime).to.equal(-1);
     expect((audioSource as any)._playTime).to.equal(-1);
     expect((AudioManager as any)._playingCount).to.equal(playingCount2 - 1);
-    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.null;
   });
 
   // stop() from a PAUSED state must reset the offset so the next play() starts from 0, not the pause point

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -369,10 +369,16 @@ describe("AudioSource playback lifecycle", () => {
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     expect((opening as any)._pendingPlay).to.not.be.null;
 
+    const userActivation = mockUserActivation(false);
+    (AudioManager as any)._onUserGesture({ isTrusted: true, type: "touchstart" } as Event);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((AudioManager as any)._resumePromise).toBe(coldStartResumePromise);
+    expect((AudioManager as any)._resumeAttemptFromUserGesture).to.be.false;
+
     const canvas = document.createElement("canvas");
     document.body.appendChild(canvas);
     canvas.addEventListener("touchend", () => bgm.play(), { capture: true, passive: true, once: true });
-    mockUserActivation(true);
+    userActivation.set(true);
     canvas.dispatchEvent(new Event("touchend", { bubbles: true }));
 
     const gestureResumePromise = (AudioManager as any)._resumePromise;

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -4,13 +4,13 @@ import { AudioManager, AudioSource } from "@galacean/engine-core/src/audio";
 const originalAudioContext = window.AudioContext;
 let restoreUserActivation: (() => void) | null = null;
 
-function mockUserActivation(initialActive: boolean): { set(active: boolean): void } {
+function mockUserActivation(initialActive: boolean | undefined): { set(active: boolean): void } {
   restoreUserActivation?.();
   const ownDescriptor = Object.getOwnPropertyDescriptor(navigator, "userActivation");
   let active = initialActive;
   Object.defineProperty(navigator, "userActivation", {
     configurable: true,
-    get: () => ({ hasBeenActive: active, isActive: active })
+    get: () => (active === undefined ? undefined : { hasBeenActive: active, isActive: active })
   });
   restoreUserActivation = () => {
     if (ownDescriptor) {
@@ -585,6 +585,42 @@ describe("AudioSource playback lifecycle", () => {
     await gestureResumePromise;
     await flushAsync();
     expect((AudioManager as any)._resumePromise).to.be.null;
+  });
+
+  it("recognizes a pre-document gesture play without the User Activation API", async () => {
+    mockUserActivation(undefined);
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveEarlyResume: () => void;
+    let resolveDocumentResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveEarlyResume = resolve;
+      }),
+      new Promise<void>((resolve) => {
+        resolveDocumentResume = resolve;
+      })
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+    const touchEnd = { isTrusted: true, type: "touchend" } as Event;
+    vi.spyOn(window, "event", "get").mockReturnValue(touchEnd);
+
+    // An application window-capture listener runs before AudioManager's document-capture listener
+    audioSource.play();
+    const earlyResumePromise = (AudioManager as any)._resumePromise as Promise<void>;
+    (AudioManager as any)._onUserGesture(touchEnd);
+    const documentResumePromise = (AudioManager as any)._resumePromise as Promise<void>;
+
+    resolveEarlyResume!();
+    await earlyResumePromise;
+    resolveDocumentResume!();
+    await documentResumePromise;
+    await flushAsync();
+
+    expect(audioSource.isPlaying).to.be.true;
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not auto-resume a caller-controlled suspend on a later gesture", async () => {

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -128,7 +128,7 @@ function resetAudioManagerState(): void {
   (AudioManager as any)._resumePromise = null;
   (AudioManager as any)._resumeAttemptId = 0;
   (AudioManager as any)._resumeAttemptFromUserGesture = false;
-  (AudioManager as any)._needsUserGestureResume = false;
+  (AudioManager as any)._interruptionRecoveryPending = false;
   (AudioManager as any)._suspendedByCaller = false;
   (AudioManager as any)._recovering = false;
   (AudioManager as any)._playingCount = 0;
@@ -502,7 +502,7 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
 
     expect((audioSource as any)._pendingPlay).to.be.null;
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.false;
 
     MockAudioContext.shouldResumeSucceed = true;
     mockUserActivation(true);
@@ -516,12 +516,12 @@ describe("AudioSource playback lifecycle", () => {
     createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "suspended";
-    (AudioManager as any)._needsUserGestureResume = true;
+    (AudioManager as any)._interruptionRecoveryPending = true;
 
     await AudioManager.resume();
 
     expect(context.state).to.equal("running");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.false;
   });
 
   it("coalesces overlapping resume() calls and re-issues a later resume", async () => {
@@ -640,7 +640,7 @@ describe("AudioSource playback lifecycle", () => {
 
     expect(resumeSpy).not.toHaveBeenCalled();
     expect(context.state).to.equal("suspended");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.false;
   });
 
   it("keeps a playing source playing across a hide without tearing down the node", async () => {
@@ -773,7 +773,7 @@ describe("AudioSource playback lifecycle", () => {
     vi.advanceTimersByTime(100);
     await flushAsync();
 
-    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.true;
     expect(context.state).to.equal("suspended");
 
     vi.useRealTimers();
@@ -784,7 +784,7 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
     documentHidden.restore();
 
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.false;
     expect(context.state).to.equal("running");
   });
 
@@ -891,7 +891,7 @@ describe("AudioSource playback lifecycle", () => {
     await recoveryResumePromise;
     await flushAsync();
     expect((AudioManager as any)._resumePromise).toBe(gestureResumePromise);
-    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.true;
 
     resolveGestureResume!();
     await gestureResumePromise;
@@ -900,7 +900,7 @@ describe("AudioSource playback lifecycle", () => {
 
     expect(context.state).to.equal("running");
     expect((AudioManager as any)._resumePromise).to.be.null;
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect((AudioManager as any)._interruptionRecoveryPending).to.be.false;
   });
 
   it("treats a non-persisted pageshow as a no-op", () => {


### PR DESCRIPTION
## Summary

- let a real user gesture supersede an indefinitely pending programmatic AudioContext resume attempt
- keep programmatic resume attempts single-flight while coalescing repeated events with the active gesture attempt
- derive gesture identity from active user activation or the trusted current touch/click event on legacy Safari, so synthetic events cannot poison coalescing
- guard AudioManager and per-source cleanup by Promise identity so an older attempt cannot clear its replacement
- preserve one-shot semantics: the stale opening sound is dropped, while playback requested in the gesture can start
- avoid user-agent sniffing and avoid introducing a global pending-playback queue

## Root cause

This is not an AudioClip loading or decoding failure: the reproduction fully preloads both clips. On iOS Safari, a native AudioContext resume issued before user activation may remain pending indefinitely. AudioManager previously coalesced the later gesture playback onto that stale Promise, so no fresh native resume occurred within the valid gesture. This PR changes only audio resume/playback coordination; ResourceManager and loaders are unchanged.

## Regression coverage

The tests deterministically model the iOS-only pending behavior:

1. a cold-start resume issued before user activation remains pending
2. a Canvas touchend capture handler supersedes it with a gesture-originated native resume
3. a timer-driven foreground recovery resume remains pending and is superseded by the first later gesture
4. the same AudioSource can stop/play onto the newer attempt without the older Promise clearing it
5. a synthetic click does not supersede a programmatic attempt, while an activated direct resume does
6. repeated events coalesce with the active gesture attempt, and an older Promise settling cannot clear it
7. the stale opening sound is not replayed, while BGM requested by the gesture starts
8. Safari 16.3 and earlier, where the User Activation API is absent, preserve playback started by an application listener before AudioManager's document-capture listener

The tests run in Chromium with a mocked AudioContext because the stuck-pending behavior is specific to iOS Safari.

## iPhone Safari A/B test pages

A manual harness builds two self-contained Engine bundles from exact refs and runs both pages with the same shared scenario code; only the imported Engine bundle changes:

```js
opening.play(); // automatically before the first gesture

canvas.addEventListener(
  "touchend",
  () => bgm.play(), // synchronously inside the first real gesture
  { capture: true, passive: true, once: true }
);
```

| Page | Engine ref | Expected evidence | Physical iPhone Safari result |
| --- | --- | --- | --- |
| `baseline.html` | `dev/2.0` at `5669f965d7aea143e2deaf93b5a05756c301ee48` | native `resume()` remains at 1; BGM stays silent | ✅ Reproduced |
| `fixed.html` | PR HEAD `788e6f5b8c694f3eb2c1c5677b52dae925005778` | the gesture issues native `resume()` #2; BGM plays | ⏳ Pending physical verification |

The pages display `AudioContext.state`, native `resume()` call count, both sources' playback state, user activation, and an event timeline. Audio clips are generated as in-page WAV blobs and preloaded through the real `AudioLoader`, confirming that loading and decoding complete before `opening.play()`.

## Verification

- `pnpm run build`
- `HEADLESS=true pnpm exec vitest run tests/src/core/audio --browser.headless` — 40/40 passed
- focused reverse checks against the previous implementation: restarted playback remains stopped; a synthetic click makes 2 native resume calls instead of 1; and the legacy-Safari pre-document playback remains `isPlaying === false`
- `pnpm run lint` — 0 errors
- Prettier and `git diff --check origin/dev/2.0...HEAD`

Physical iPhone/Safari verification has reproduced the defect on the exact `dev/2.0` baseline; the fixed-page result is pending.

Fixes #3086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio recovery after interruptions and cold starts, especially on iOS.
  * User gestures now take priority over pending automatic resume attempts.
  * Prevented stale audio resume operations from replaying sources or overriding newer attempts.
  * Improved handling of repeated gestures and resume failures.
  * Ignored synthetic gestures that lack active user interaction.
  * Improved playback recovery for trusted touch gestures on older Safari versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
