### PR TITLE
fix(loader): reject incomplete shader and material loads

### DIFF
--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -21,19 +21,22 @@ import {
   type IVector4
 } from "./schema";
 
+const materialLoaderTypes = new Set(Object.values(MaterialLoaderType));
+
 @resourceLoader(AssetType.Material, ["mat"])
 class MaterialLoader extends Loader<Material> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Material> {
-    // @ts-ignore
+    // @ts-expect-error _request is @internal
     return resourceManager._request(item.url, { ...item, type: "json" }).then((materialSchema: IMaterialSchema) => {
-      for (const key in materialSchema.shaderData) {
-        if (!Object.values(MaterialLoaderType).includes(materialSchema.shaderData[key].type)) {
-          throw new Error(`MaterialLoader: unsupported shader data type "${materialSchema.shaderData[key].type}".`);
+      const { shaderData, shaderRef, shader: shaderName } = materialSchema;
+      for (const key in shaderData) {
+        const type = shaderData[key].type;
+        if (!materialLoaderTypes.has(type)) {
+          throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
         }
       }
 
       const engine = resourceManager.engine;
-      const { shaderRef, shader: shaderName } = materialSchema;
       const shader = Shader.find(shaderName);
       if (shader) {
         return this._getMaterialByShader(materialSchema, shader, engine);
@@ -41,17 +44,13 @@ class MaterialLoader extends Loader<Material> {
       if (!shaderRef) {
         throw new Error(`MaterialLoader: shader "${shaderName}" not found.`);
       }
-      return (
-        resourceManager
-          // @ts-ignore
-          .getResourceByRef<Shader>(<RefItem>shaderRef)
-          .then((shader) => {
-            if (!(shader instanceof Shader)) {
-              throw new Error(`MaterialLoader: shader reference "${shaderRef.url}" did not resolve to a Shader.`);
-            }
-            return this._getMaterialByShader(materialSchema, shader, engine);
-          })
-      );
+      // @ts-expect-error getResourceByRef is @internal
+      return resourceManager.getResourceByRef<Shader>(<RefItem>shaderRef).then((shader) => {
+        if (!(shader instanceof Shader)) {
+          throw new Error(`MaterialLoader: shader reference "${shaderRef.url}" did not resolve to a Shader.`);
+        }
+        return this._getMaterialByShader(materialSchema, shader, engine);
+      });
     });
   }
 
@@ -63,7 +62,7 @@ class MaterialLoader extends Loader<Material> {
 
     const texturePromises = new Array<Promise<Texture2D>>();
     const materialShaderData = material.shaderData;
-    for (let key in shaderData) {
+    for (const key in shaderData) {
       const { type, value } = shaderData[key];
 
       switch (type) {
@@ -93,7 +92,7 @@ class MaterialLoader extends Loader<Material> {
           break;
         case MaterialLoaderType.Texture:
           texturePromises.push(
-            // @ts-ignore
+            // @ts-expect-error getResourceByRef is @internal
             engine.resourceManager.getResourceByRef<Texture2D>(<RefItem>value).then((texture) => {
               materialShaderData.setTexture(key, texture);
             })
@@ -119,8 +118,6 @@ class MaterialLoader extends Loader<Material> {
       }
     }
 
-    return Promise.all(texturePromises).then(() => {
-      return material;
-    });
+    return Promise.all(texturePromises).then(() => material);
   }
 }

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -52,6 +52,22 @@ class MaterialLoader extends Loader<Material> {
   private _getMaterialByShader(materialSchema: IMaterialSchema, shader: Shader, engine: Engine): Promise<Material> {
     const { name, shaderData, macros } = materialSchema;
 
+    for (let key in shaderData) {
+      switch (shaderData[key].type) {
+        case MaterialLoaderType.Vector2:
+        case MaterialLoaderType.Vector3:
+        case MaterialLoaderType.Vector4:
+        case MaterialLoaderType.Color:
+        case MaterialLoaderType.Float:
+        case MaterialLoaderType.Texture:
+        case MaterialLoaderType.Boolean:
+        case MaterialLoaderType.Integer:
+          break;
+        default:
+          throw new Error(`MaterialLoader: unsupported shader data type "${shaderData[key].type}".`);
+      }
+    }
+
     const material = new Material(engine, shader);
     material.name = name;
 

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -54,85 +54,81 @@ class MaterialLoader extends Loader<Material> {
     });
   }
 
-  private async _getMaterialByShader(
-    materialSchema: IMaterialSchema,
-    shader: Shader,
-    engine: Engine
-  ): Promise<Material> {
+  private _getMaterialByShader(materialSchema: IMaterialSchema, shader: Shader, engine: Engine): Promise<Material> {
     const { name, shaderData, macros } = materialSchema;
 
     const material = new Material(engine, shader);
-    try {
-      material.name = name;
+    material.name = name;
 
-      const texturePromises = new Array<AssetPromise<void>>();
-      const materialShaderData = material.shaderData;
-      for (const key in shaderData) {
-        const { type, value } = shaderData[key];
+    const texturePromises = new Array<AssetPromise<void>>();
+    const materialShaderData = material.shaderData;
+    for (const key in shaderData) {
+      const { type, value } = shaderData[key];
 
-        switch (type) {
-          case MaterialLoaderType.Vector2:
-            materialShaderData.setVector2(key, new Vector2((<IVector2>value).x, (<IVector2>value).y));
-            break;
-          case MaterialLoaderType.Vector3:
-            materialShaderData.setVector3(
-              key,
-              new Vector3((<IVector3>value).x, (<IVector3>value).y, (<IVector3>value).z)
-            );
-            break;
-          case MaterialLoaderType.Vector4:
-            materialShaderData.setVector4(
-              key,
-              new Vector4((<IVector4>value).x, (<IVector4>value).y, (<IVector4>value).z, (<IVector4>value).w)
-            );
-            break;
-          case MaterialLoaderType.Color:
-            materialShaderData.setColor(
-              key,
-              new Color((<IColor>value).r, (<IColor>value).g, (<IColor>value).b, (<IColor>value).a)
-            );
-            break;
-          case MaterialLoaderType.Float:
-            materialShaderData.setFloat(key, <number>value);
-            break;
-          case MaterialLoaderType.Texture:
-            texturePromises.push(
-              // @ts-expect-error getResourceByRef is @internal
-              engine.resourceManager.getResourceByRef<Texture>(<RefItem>value).then((texture) => {
-                if (!(texture instanceof Texture)) {
-                  throw new Error(
-                    `MaterialLoader: texture reference "${(<RefItem>value).url}" did not resolve to a Texture.`
-                  );
-                }
-                materialShaderData.setTexture(key, texture);
-              })
-            );
-            break;
-          case MaterialLoaderType.Boolean:
-            materialShaderData.setInt(key, value ? 1 : 0);
-            break;
-          case MaterialLoaderType.Integer:
-            materialShaderData.setInt(key, Number(value));
-            break;
-          default:
-            throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
-        }
+      switch (type) {
+        case MaterialLoaderType.Vector2:
+          materialShaderData.setVector2(key, new Vector2((<IVector2>value).x, (<IVector2>value).y));
+          break;
+        case MaterialLoaderType.Vector3:
+          materialShaderData.setVector3(
+            key,
+            new Vector3((<IVector3>value).x, (<IVector3>value).y, (<IVector3>value).z)
+          );
+          break;
+        case MaterialLoaderType.Vector4:
+          materialShaderData.setVector4(
+            key,
+            new Vector4((<IVector4>value).x, (<IVector4>value).y, (<IVector4>value).z, (<IVector4>value).w)
+          );
+          break;
+        case MaterialLoaderType.Color:
+          materialShaderData.setColor(
+            key,
+            new Color((<IColor>value).r, (<IColor>value).g, (<IColor>value).b, (<IColor>value).a)
+          );
+          break;
+        case MaterialLoaderType.Float:
+          materialShaderData.setFloat(key, <number>value);
+          break;
+        case MaterialLoaderType.Texture:
+          texturePromises.push(
+            // @ts-expect-error getResourceByRef is @internal
+            engine.resourceManager.getResourceByRef<Texture>(<RefItem>value).then((texture) => {
+              if (!(texture instanceof Texture)) {
+                throw new Error(
+                  `MaterialLoader: texture reference "${(<RefItem>value).url}" did not resolve to a Texture.`
+                );
+              }
+              materialShaderData.setTexture(key, texture);
+            })
+          );
+          break;
+        case MaterialLoaderType.Boolean:
+          materialShaderData.setInt(key, value ? 1 : 0);
+          break;
+        case MaterialLoaderType.Integer:
+          materialShaderData.setInt(key, Number(value));
+          break;
+        default:
+          throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
       }
-
-      for (let i = 0, length = macros.length; i < length; i++) {
-        const { name, value } = macros[i];
-        if (value == undefined) {
-          materialShaderData.enableMacro(name);
-        } else {
-          materialShaderData.enableMacro(name, value);
-        }
-      }
-
-      await Promise.all(texturePromises);
-      return material;
-    } catch (error) {
-      material.destroy();
-      throw error;
     }
+
+    for (let i = 0, length = macros.length; i < length; i++) {
+      const { name, value } = macros[i];
+      if (value == undefined) {
+        materialShaderData.enableMacro(name);
+      } else {
+        materialShaderData.enableMacro(name, value);
+      }
+    }
+
+    return Promise.all(texturePromises).then(
+      () => material,
+      (error) => {
+        material.destroy();
+        throw error;
+      }
+    );
   }
 }

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -54,75 +54,85 @@ class MaterialLoader extends Loader<Material> {
     });
   }
 
-  private _getMaterialByShader(materialSchema: IMaterialSchema, shader: Shader, engine: Engine): Promise<Material> {
+  private async _getMaterialByShader(
+    materialSchema: IMaterialSchema,
+    shader: Shader,
+    engine: Engine
+  ): Promise<Material> {
     const { name, shaderData, macros } = materialSchema;
 
     const material = new Material(engine, shader);
-    material.name = name;
+    try {
+      material.name = name;
 
-    const texturePromises = new Array<AssetPromise<void>>();
-    const materialShaderData = material.shaderData;
-    for (const key in shaderData) {
-      const { type, value } = shaderData[key];
+      const texturePromises = new Array<AssetPromise<void>>();
+      const materialShaderData = material.shaderData;
+      for (const key in shaderData) {
+        const { type, value } = shaderData[key];
 
-      switch (type) {
-        case MaterialLoaderType.Vector2:
-          materialShaderData.setVector2(key, new Vector2((<IVector2>value).x, (<IVector2>value).y));
-          break;
-        case MaterialLoaderType.Vector3:
-          materialShaderData.setVector3(
-            key,
-            new Vector3((<IVector3>value).x, (<IVector3>value).y, (<IVector3>value).z)
-          );
-          break;
-        case MaterialLoaderType.Vector4:
-          materialShaderData.setVector4(
-            key,
-            new Vector4((<IVector4>value).x, (<IVector4>value).y, (<IVector4>value).z, (<IVector4>value).w)
-          );
-          break;
-        case MaterialLoaderType.Color:
-          materialShaderData.setColor(
-            key,
-            new Color((<IColor>value).r, (<IColor>value).g, (<IColor>value).b, (<IColor>value).a)
-          );
-          break;
-        case MaterialLoaderType.Float:
-          materialShaderData.setFloat(key, <number>value);
-          break;
-        case MaterialLoaderType.Texture:
-          texturePromises.push(
-            // @ts-expect-error getResourceByRef is @internal
-            engine.resourceManager.getResourceByRef<Texture>(<RefItem>value).then((texture) => {
-              if (!(texture instanceof Texture)) {
-                throw new Error(
-                  `MaterialLoader: texture reference "${(<RefItem>value).url}" did not resolve to a Texture.`
-                );
-              }
-              materialShaderData.setTexture(key, texture);
-            })
-          );
-          break;
-        case MaterialLoaderType.Boolean:
-          materialShaderData.setInt(key, value ? 1 : 0);
-          break;
-        case MaterialLoaderType.Integer:
-          materialShaderData.setInt(key, Number(value));
-          break;
-        default:
-          throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
+        switch (type) {
+          case MaterialLoaderType.Vector2:
+            materialShaderData.setVector2(key, new Vector2((<IVector2>value).x, (<IVector2>value).y));
+            break;
+          case MaterialLoaderType.Vector3:
+            materialShaderData.setVector3(
+              key,
+              new Vector3((<IVector3>value).x, (<IVector3>value).y, (<IVector3>value).z)
+            );
+            break;
+          case MaterialLoaderType.Vector4:
+            materialShaderData.setVector4(
+              key,
+              new Vector4((<IVector4>value).x, (<IVector4>value).y, (<IVector4>value).z, (<IVector4>value).w)
+            );
+            break;
+          case MaterialLoaderType.Color:
+            materialShaderData.setColor(
+              key,
+              new Color((<IColor>value).r, (<IColor>value).g, (<IColor>value).b, (<IColor>value).a)
+            );
+            break;
+          case MaterialLoaderType.Float:
+            materialShaderData.setFloat(key, <number>value);
+            break;
+          case MaterialLoaderType.Texture:
+            texturePromises.push(
+              // @ts-expect-error getResourceByRef is @internal
+              engine.resourceManager.getResourceByRef<Texture>(<RefItem>value).then((texture) => {
+                if (!(texture instanceof Texture)) {
+                  throw new Error(
+                    `MaterialLoader: texture reference "${(<RefItem>value).url}" did not resolve to a Texture.`
+                  );
+                }
+                materialShaderData.setTexture(key, texture);
+              })
+            );
+            break;
+          case MaterialLoaderType.Boolean:
+            materialShaderData.setInt(key, value ? 1 : 0);
+            break;
+          case MaterialLoaderType.Integer:
+            materialShaderData.setInt(key, Number(value));
+            break;
+          default:
+            throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
+        }
       }
-    }
 
-    for (let i = 0, length = macros.length; i < length; i++) {
-      const { name, value } = macros[i];
-      if (value == undefined) {
-        materialShaderData.enableMacro(name);
-      } else {
-        materialShaderData.enableMacro(name, value);
+      for (let i = 0, length = macros.length; i < length; i++) {
+        const { name, value } = macros[i];
+        if (value == undefined) {
+          materialShaderData.enableMacro(name);
+        } else {
+          materialShaderData.enableMacro(name, value);
+        }
       }
-    }
 
-    return Promise.all(texturePromises).then(() => material);
+      await Promise.all(texturePromises);
+      return material;
+    } catch (error) {
+      material.destroy();
+      throw error;
+    }
   }
 }

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -26,6 +26,12 @@ class MaterialLoader extends Loader<Material> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Material> {
     // @ts-ignore
     return resourceManager._request(item.url, { ...item, type: "json" }).then((materialSchema: IMaterialSchema) => {
+      for (const key in materialSchema.shaderData) {
+        if (!Object.values(MaterialLoaderType).includes(materialSchema.shaderData[key].type)) {
+          throw new Error(`MaterialLoader: unsupported shader data type "${materialSchema.shaderData[key].type}".`);
+        }
+      }
+
       const engine = resourceManager.engine;
       const { shaderRef, shader: shaderName } = materialSchema;
       const shader = Shader.find(shaderName);
@@ -51,22 +57,6 @@ class MaterialLoader extends Loader<Material> {
 
   private _getMaterialByShader(materialSchema: IMaterialSchema, shader: Shader, engine: Engine): Promise<Material> {
     const { name, shaderData, macros } = materialSchema;
-
-    for (let key in shaderData) {
-      switch (shaderData[key].type) {
-        case MaterialLoaderType.Vector2:
-        case MaterialLoaderType.Vector3:
-        case MaterialLoaderType.Vector4:
-        case MaterialLoaderType.Color:
-        case MaterialLoaderType.Float:
-        case MaterialLoaderType.Texture:
-        case MaterialLoaderType.Boolean:
-        case MaterialLoaderType.Integer:
-          break;
-        default:
-          throw new Error(`MaterialLoader: unsupported shader data type "${shaderData[key].type}".`);
-      }
-    }
 
     const material = new Material(engine, shader);
     material.name = name;

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -24,29 +24,28 @@ import {
 @resourceLoader(AssetType.Material, ["mat"])
 class MaterialLoader extends Loader<Material> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Material> {
-    return new AssetPromise((resolve, reject) => {
-      resourceManager
-        // @ts-ignore
-        ._request(item.url, {
-          ...item,
-          type: "json"
-        })
-        .then((materialSchema: IMaterialSchema) => {
-          const engine = resourceManager.engine;
-          const { shaderRef, shader: shaderName } = materialSchema;
-          const shader = Shader.find(shaderName);
-          if (shader) {
-            resolve(this._getMaterialByShader(materialSchema, shader, engine));
-          } else if (shaderRef) {
-            resolve(
-              resourceManager
-                // @ts-ignore
-                .getResourceByRef<Shader>(<RefItem>shaderRef)
-                .then((shader) => this._getMaterialByShader(materialSchema, shader, engine))
-            );
-          }
-        })
-        .catch(reject);
+    // @ts-ignore
+    return resourceManager._request(item.url, { ...item, type: "json" }).then((materialSchema: IMaterialSchema) => {
+      const engine = resourceManager.engine;
+      const { shaderRef, shader: shaderName } = materialSchema;
+      const shader = Shader.find(shaderName);
+      if (shader) {
+        return this._getMaterialByShader(materialSchema, shader, engine);
+      }
+      if (!shaderRef) {
+        throw new Error(`MaterialLoader: shader "${shaderName}" not found.`);
+      }
+      return (
+        resourceManager
+          // @ts-ignore
+          .getResourceByRef<Shader>(<RefItem>shaderRef)
+          .then((shader) => {
+            if (!(shader instanceof Shader)) {
+              throw new Error(`MaterialLoader: shader reference "${shaderRef.url}" did not resolve to a Shader.`);
+            }
+            return this._getMaterialByShader(materialSchema, shader, engine);
+          })
+      );
     });
   }
 
@@ -100,6 +99,8 @@ class MaterialLoader extends Loader<Material> {
         case MaterialLoaderType.Integer:
           materialShaderData.setInt(key, Number(value));
           break;
+        default:
+          throw new Error(`MaterialLoader: unsupported shader data type "${type}".`);
       }
     }
 

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -7,7 +7,7 @@ import {
   Material,
   ResourceManager,
   Shader,
-  Texture2D,
+  Texture,
   resourceLoader
 } from "@galacean/engine-core";
 import { Color, Vector2, Vector3, Vector4 } from "@galacean/engine-math";
@@ -60,7 +60,7 @@ class MaterialLoader extends Loader<Material> {
     const material = new Material(engine, shader);
     material.name = name;
 
-    const texturePromises = new Array<Promise<Texture2D>>();
+    const texturePromises = new Array<AssetPromise<void>>();
     const materialShaderData = material.shaderData;
     for (const key in shaderData) {
       const { type, value } = shaderData[key];
@@ -93,7 +93,12 @@ class MaterialLoader extends Loader<Material> {
         case MaterialLoaderType.Texture:
           texturePromises.push(
             // @ts-expect-error getResourceByRef is @internal
-            engine.resourceManager.getResourceByRef<Texture2D>(<RefItem>value).then((texture) => {
+            engine.resourceManager.getResourceByRef<Texture>(<RefItem>value).then((texture) => {
+              if (!(texture instanceof Texture)) {
+                throw new Error(
+                  `MaterialLoader: texture reference "${(<RefItem>value).url}" did not resolve to a Texture.`
+                );
+              }
               materialShaderData.setTexture(key, texture);
             })
           );

--- a/packages/loader/src/ShaderLoader.ts
+++ b/packages/loader/src/ShaderLoader.ts
@@ -15,12 +15,15 @@ class ShaderLoader extends Loader<Shader> {
     // @ts-expect-error _request is @internal
     return resourceManager._request<string>(url, { ...item, type: "text" }).then((code) => {
       const source = code.trimStart();
-      if (source.startsWith("{")) {
-        // @ts-expect-error _createFromPrecompiled is @internal
-        return Shader._createFromPrecompiled(JSON.parse(source));
-      }
+      const shader = source.startsWith("{")
+        ? // @ts-expect-error _createFromPrecompiled is @internal
+          Shader._createFromPrecompiled(JSON.parse(source))
+        : Shader.create(code, undefined, url);
 
-      return Shader.create(code, undefined, url);
+      if (!shader) {
+        throw new Error(`ShaderLoader: failed to create shader "${url}".`);
+      }
+      return shader;
     });
   }
 }

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -21,6 +21,10 @@ function registerShaderResource(shaderName: string): string {
   return shaderPath;
 }
 
+function loadMaterial(data: unknown) {
+  return engine.resourceManager.load<Material>({ url: createBlobURL(data, "mat"), type: AssetType.Material });
+}
+
 beforeAll(async () => {
   engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
   materialShaderName = `MaterialLoaderTestShader-${Math.random()}`;
@@ -47,17 +51,11 @@ describe("ShaderLoader", () => {
 
 describe("MaterialLoader", () => {
   it("loads a material with a registered shader", async () => {
-    const material = await engine.resourceManager.load<Material>({
-      url: createBlobURL(
-        {
-          name: "registered-shader",
-          shader: materialShaderName,
-          shaderData: { value: { type: "Float", value: 1 } },
-          macros: []
-        },
-        "mat"
-      ),
-      type: AssetType.Material
+    const material = await loadMaterial({
+      name: "registered-shader",
+      shader: materialShaderName,
+      shaderData: { value: { type: "Float", value: 1 } },
+      macros: []
     });
 
     expect(material.shader).toBe(Shader.find(materialShaderName));
@@ -67,18 +65,12 @@ describe("MaterialLoader", () => {
   it("loads a material from a valid shader reference", async () => {
     const shaderName = `MaterialLoaderRef-${Math.random()}`;
     const shaderPath = registerShaderResource(shaderName);
-    const material = await engine.resourceManager.load<Material>({
-      url: createBlobURL(
-        {
-          name: "shader-ref",
-          shader: shaderName,
-          shaderRef: { url: shaderPath },
-          shaderData: {},
-          macros: []
-        },
-        "mat"
-      ),
-      type: AssetType.Material
+    const material = await loadMaterial({
+      name: "shader-ref",
+      shader: shaderName,
+      shaderRef: { url: shaderPath },
+      shaderData: {},
+      macros: []
     });
 
     expect(material.shader).toBe(Shader.find(shaderName));
@@ -86,10 +78,7 @@ describe("MaterialLoader", () => {
 
   it("rejects a material without a resolvable shader", async () => {
     await expect(
-      engine.resourceManager.load({
-        url: createBlobURL({ name: "missing-shader", shader: "missing", shaderData: {}, macros: [] }, "mat"),
-        type: AssetType.Material
-      })
+      loadMaterial({ name: "missing-shader", shader: "missing", shaderData: {}, macros: [] })
     ).rejects.toBeDefined();
   });
 
@@ -100,12 +89,12 @@ describe("MaterialLoader", () => {
     ]);
 
     await expect(
-      engine.resourceManager.load({
-        url: createBlobURL(
-          { name: "wrong-shader-ref", shader: "missing", shaderRef: { url: textPath }, shaderData: {}, macros: [] },
-          "mat"
-        ),
-        type: AssetType.Material
+      loadMaterial({
+        name: "wrong-shader-ref",
+        shader: "missing",
+        shaderRef: { url: textPath },
+        shaderData: {},
+        macros: []
       })
     ).rejects.toBeDefined();
   });
@@ -113,17 +102,11 @@ describe("MaterialLoader", () => {
   it.each(["Matrix", "TextureArray"])("rejects unsupported %s shader data", async (type) => {
     const materialCount = engine.resourceManager.findResourcesByType(Material).length;
     await expect(
-      engine.resourceManager.load({
-        url: createBlobURL(
-          {
-            name: "unsupported-shader-data",
-            shader: materialShaderName,
-            shaderData: { supported: { type: "Float", value: 1 }, value: { type, value: [] } },
-            macros: []
-          },
-          "mat"
-        ),
-        type: AssetType.Material
+      loadMaterial({
+        name: "unsupported-shader-data",
+        shader: materialShaderName,
+        shaderData: { supported: { type: "Float", value: 1 }, value: { type, value: [] } },
+        macros: []
       })
     ).rejects.toBeDefined();
     expect(engine.resourceManager.findResourcesByType(Material)).toHaveLength(materialCount);
@@ -136,18 +119,12 @@ describe("MaterialLoader", () => {
     expect(engine.resourceManager.getFromCache(shaderPath)).toBeNull();
 
     await expect(
-      engine.resourceManager.load({
-        url: createBlobURL(
-          {
-            name: "unsupported-shader-ref",
-            shader: shaderName,
-            shaderRef: { url: shaderPath },
-            shaderData: { value: { type: "Matrix", value: [] } },
-            macros: []
-          },
-          "mat"
-        ),
-        type: AssetType.Material
+      loadMaterial({
+        name: "unsupported-shader-ref",
+        shader: shaderName,
+        shaderRef: { url: shaderPath },
+        shaderData: { value: { type: "Matrix", value: [] } },
+        macros: []
       })
     ).rejects.toBeDefined();
 

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -1,0 +1,80 @@
+import { AssetType, Shader } from "@galacean/engine";
+import "@galacean/engine-loader";
+import { WebGLEngine } from "@galacean/engine";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let engine: WebGLEngine;
+let materialShaderName: string;
+
+function createBlobURL(data: unknown, extension: string): string {
+  return URL.createObjectURL(new Blob([JSON.stringify(data)], { type: "application/json" })) + `#.${extension}`;
+}
+
+beforeAll(async () => {
+  engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+  materialShaderName = `MaterialLoaderTestShader-${Math.random()}`;
+  Shader._createFromPrecompiled({ name: materialShaderName, platformTarget: 0, subShaders: [] });
+});
+
+afterAll(() => {
+  engine.destroy();
+});
+
+describe("ShaderLoader", () => {
+  it("rejects duplicate shader creation", async () => {
+    const name = `ShaderLoaderDuplicate-${Math.random()}`;
+    const source = { name, platformTarget: 0, subShaders: [] };
+
+    expect(
+      await engine.resourceManager.load<Shader>({ url: createBlobURL(source, "shader"), type: AssetType.Shader })
+    ).toBeInstanceOf(Shader);
+    await expect(
+      engine.resourceManager.load<Shader>({ url: createBlobURL(source, "shader"), type: AssetType.Shader })
+    ).rejects.toBeDefined();
+  });
+});
+
+describe("MaterialLoader", () => {
+  it("rejects a material without a resolvable shader", async () => {
+    await expect(
+      engine.resourceManager.load({
+        url: createBlobURL({ name: "missing-shader", shader: "missing", shaderData: {}, macros: [] }, "mat"),
+        type: AssetType.Material
+      })
+    ).rejects.toBeDefined();
+  });
+
+  it("rejects a shader reference that resolves to another resource type", async () => {
+    const textPath = "MaterialLoaderTest/not-a-shader";
+    engine.resourceManager.registerVirtualResources([
+      { virtualPath: textPath, path: createBlobURL("not a shader", "txt"), type: AssetType.Text }
+    ]);
+
+    await expect(
+      engine.resourceManager.load({
+        url: createBlobURL(
+          { name: "wrong-shader-ref", shader: "missing", shaderRef: { url: textPath }, shaderData: {}, macros: [] },
+          "mat"
+        ),
+        type: AssetType.Material
+      })
+    ).rejects.toBeDefined();
+  });
+
+  it.each(["Matrix", "TextureArray"])("rejects unsupported %s shader data", async (type) => {
+    await expect(
+      engine.resourceManager.load({
+        url: createBlobURL(
+          {
+            name: "unsupported-shader-data",
+            shader: materialShaderName,
+            shaderData: { value: { type, value: [] } },
+            macros: []
+          },
+          "mat"
+        ),
+        type: AssetType.Material
+      })
+    ).rejects.toBeDefined();
+  });
+});

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -79,4 +79,37 @@ describe("MaterialLoader", () => {
     ).rejects.toBeDefined();
     expect(engine.resourceManager.findResourcesByType(Material)).toHaveLength(materialCount);
   });
+
+  it("rejects unsupported shader data before loading a shaderRef", async () => {
+    const shaderName = `MaterialLoaderUnsupportedRef-${Math.random()}`;
+    const shaderPath = `MaterialLoaderTest/${shaderName}`;
+    engine.resourceManager.registerVirtualResources([
+      {
+        virtualPath: shaderPath,
+        path: createBlobURL({ name: shaderName, platformTarget: 0, subShaders: [] }, "shader"),
+        type: AssetType.Shader
+      }
+    ]);
+    expect(Shader.find(shaderName)).toBeUndefined();
+    expect(engine.resourceManager.getFromCache(shaderPath)).toBeNull();
+
+    await expect(
+      engine.resourceManager.load({
+        url: createBlobURL(
+          {
+            name: "unsupported-shader-ref",
+            shader: shaderName,
+            shaderRef: { url: shaderPath },
+            shaderData: { value: { type: "Matrix", value: [] } },
+            macros: []
+          },
+          "mat"
+        ),
+        type: AssetType.Material
+      })
+    ).rejects.toBeDefined();
+
+    expect(Shader.find(shaderName)).toBeUndefined();
+    expect(engine.resourceManager.getFromCache(shaderPath)).toBeNull();
+  });
 });

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -1,4 +1,4 @@
-import { AssetType, Shader } from "@galacean/engine";
+import { AssetType, Material, Shader } from "@galacean/engine";
 import "@galacean/engine-loader";
 import { WebGLEngine } from "@galacean/engine";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -62,13 +62,14 @@ describe("MaterialLoader", () => {
   });
 
   it.each(["Matrix", "TextureArray"])("rejects unsupported %s shader data", async (type) => {
+    const materialCount = engine.resourceManager.findResourcesByType(Material).length;
     await expect(
       engine.resourceManager.load({
         url: createBlobURL(
           {
             name: "unsupported-shader-data",
             shader: materialShaderName,
-            shaderData: { value: { type, value: [] } },
+            shaderData: { supported: { type: "Float", value: 1 }, value: { type, value: [] } },
             macros: []
           },
           "mat"
@@ -76,5 +77,6 @@ describe("MaterialLoader", () => {
         type: AssetType.Material
       })
     ).rejects.toBeDefined();
+    expect(engine.resourceManager.findResourcesByType(Material)).toHaveLength(materialCount);
   });
 });

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -106,6 +106,7 @@ describe("MaterialLoader", () => {
       { virtualPath: textPath, path: createBlobURL("not a texture", "txt"), type: AssetType.Text }
     ]);
 
+    const materialCount = engine.resourceManager.findResourcesByType(Material).length;
     await expect(
       loadMaterial({
         name: "wrong-texture-ref",
@@ -114,6 +115,7 @@ describe("MaterialLoader", () => {
         macros: []
       })
     ).rejects.toBeDefined();
+    expect(engine.resourceManager.findResourcesByType(Material)).toHaveLength(materialCount);
   });
 
   it.each(["Matrix", "TextureArray"])("rejects unsupported %s shader data", async (type) => {

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -99,6 +99,23 @@ describe("MaterialLoader", () => {
     ).rejects.toBeDefined();
   });
 
+  it("rejects a texture reference that resolves to another resource type", async () => {
+    const textPath = "MaterialLoaderTest/not-a-texture";
+    const textureProperty = `MaterialLoaderTexture-${Math.random()}`;
+    engine.resourceManager.registerVirtualResources([
+      { virtualPath: textPath, path: createBlobURL("not a texture", "txt"), type: AssetType.Text }
+    ]);
+
+    await expect(
+      loadMaterial({
+        name: "wrong-texture-ref",
+        shader: materialShaderName,
+        shaderData: { [textureProperty]: { type: "Texture", value: { url: textPath } } },
+        macros: []
+      })
+    ).rejects.toBeDefined();
+  });
+
   it.each(["Matrix", "TextureArray"])("rejects unsupported %s shader data", async (type) => {
     const materialCount = engine.resourceManager.findResourcesByType(Material).length;
     await expect(

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -1,6 +1,5 @@
-import { AssetType, Material, Shader } from "@galacean/engine";
+import { AssetType, Material, Shader, WebGLEngine } from "@galacean/engine";
 import "@galacean/engine-loader";
-import { WebGLEngine } from "@galacean/engine";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 let engine: WebGLEngine;

--- a/tests/src/loader/MaterialLoader.test.ts
+++ b/tests/src/loader/MaterialLoader.test.ts
@@ -9,6 +9,18 @@ function createBlobURL(data: unknown, extension: string): string {
   return URL.createObjectURL(new Blob([JSON.stringify(data)], { type: "application/json" })) + `#.${extension}`;
 }
 
+function registerShaderResource(shaderName: string): string {
+  const shaderPath = `MaterialLoaderTest/${shaderName}`;
+  engine.resourceManager.registerVirtualResources([
+    {
+      virtualPath: shaderPath,
+      path: createBlobURL({ name: shaderName, platformTarget: 0, subShaders: [] }, "shader"),
+      type: AssetType.Shader
+    }
+  ]);
+  return shaderPath;
+}
+
 beforeAll(async () => {
   engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
   materialShaderName = `MaterialLoaderTestShader-${Math.random()}`;
@@ -34,6 +46,44 @@ describe("ShaderLoader", () => {
 });
 
 describe("MaterialLoader", () => {
+  it("loads a material with a registered shader", async () => {
+    const material = await engine.resourceManager.load<Material>({
+      url: createBlobURL(
+        {
+          name: "registered-shader",
+          shader: materialShaderName,
+          shaderData: { value: { type: "Float", value: 1 } },
+          macros: []
+        },
+        "mat"
+      ),
+      type: AssetType.Material
+    });
+
+    expect(material.shader).toBe(Shader.find(materialShaderName));
+    expect(material.shaderData.getFloat("value")).toBe(1);
+  });
+
+  it("loads a material from a valid shader reference", async () => {
+    const shaderName = `MaterialLoaderRef-${Math.random()}`;
+    const shaderPath = registerShaderResource(shaderName);
+    const material = await engine.resourceManager.load<Material>({
+      url: createBlobURL(
+        {
+          name: "shader-ref",
+          shader: shaderName,
+          shaderRef: { url: shaderPath },
+          shaderData: {},
+          macros: []
+        },
+        "mat"
+      ),
+      type: AssetType.Material
+    });
+
+    expect(material.shader).toBe(Shader.find(shaderName));
+  });
+
   it("rejects a material without a resolvable shader", async () => {
     await expect(
       engine.resourceManager.load({
@@ -81,14 +131,7 @@ describe("MaterialLoader", () => {
 
   it("rejects unsupported shader data before loading a shaderRef", async () => {
     const shaderName = `MaterialLoaderUnsupportedRef-${Math.random()}`;
-    const shaderPath = `MaterialLoaderTest/${shaderName}`;
-    engine.resourceManager.registerVirtualResources([
-      {
-        virtualPath: shaderPath,
-        path: createBlobURL({ name: shaderName, platformTarget: 0, subShaders: [] }, "shader"),
-        type: AssetType.Shader
-      }
-    ]);
+    const shaderPath = registerShaderResource(shaderName);
     expect(Shader.find(shaderName)).toBeUndefined();
     expect(engine.resourceManager.getFromCache(shaderPath)).toBeNull();
 


### PR DESCRIPTION
## Summary

- reject Shader loads when duplicate creation returns no Shader
- reject Material loads that have no resolvable Shader or resolve a non-Shader reference
- validate every Material shader-data type immediately after reading JSON, before Shader lookup, Shader/Texture dependency loading, or Material allocation
- reject Material texture references that resolve to `null` or a non-`Texture` before writing ShaderData
- destroy a partially allocated Material when any Texture dependency rejects
- derive the supported Material type set once instead of allocating an enum-value array for every shader-data field

## Why

`ShaderLoader` previously fulfilled with `undefined` on duplicate names. `MaterialLoader` could remain pending forever when a Shader was missing, silently drop unsupported properties such as `Matrix` or `TextureArray`, accept a non-Texture resource as a Texture reference, or retain a partially allocated Material after a Texture dependency rejected. Consumers therefore could not treat a fulfilled resource-package commit as terminal, correct success.

The fix stays in the Engine loader owner. It does not add timeouts, fallbacks, schema mirrors, or change the public duplicate behavior of `Shader.create`.

## Validation

- `HEADLESS=true pnpm exec vitest run tests/src/loader/MaterialLoader.test.ts` — 9/9
  - registered Shader and valid `shaderRef` success paths
  - duplicate Shader rejects
  - missing Shader rejects instead of pending
  - non-Shader references reject
  - non-Texture resource used as a Texture reference rejects without retaining a Material
  - `Matrix` / `TextureArray` reject without orphan Materials
  - unsupported Material data with an unloaded `shaderRef` rejects without registering or caching that Shader
- `HEADLESS=true pnpm exec vitest run tests/src/core/resource/ResourceManager.test.ts` — 27/27
- `pnpm b:module`
- `pnpm b:types`
- `pnpm format:check`
- `pnpm lint` — 0 errors; existing warnings only
- independent full-diff Ultra review — no P0/P1/P2
- latest-head CI: lint, three-platform build, Codecov upload, `codecov/patch`, `codecov/project`, all four E2E shards, and labeler passed

## Follow-up consumer gate

After this lands and is released as an exact 2.0 alpha, galacean/editor#3880 will pin that version and rerun the real Cosmic Flame package in a fresh browser realm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved material loading errors for missing, invalid, or unsupported shader data.
  * Prevented failed material loads from leaving behind cached resources.
  * Improved shader loading failures when shader creation does not succeed.
  * Ensured duplicate or unresolved shader references are reported clearly.

* **Tests**
  * Added coverage for successful material loading, valid shader references, and failure scenarios involving invalid resources and unsupported shader data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
