### PR TITLE
fix(core): load fresh runtime scene on same-url reload

### DIFF
--- a/packages/core/src/SceneManager.ts
+++ b/packages/core/src/SceneManager.ts
@@ -94,7 +94,7 @@ export class SceneManager {
     const scenePromise = this.engine.resourceManager.load<Scene>({ url, type: AssetType.Scene });
     scenePromise.then((scene: Scene) => {
       if (destroyOldScene) {
-        const scenes = this._scenes.getArray();
+        const scenes = this._scenes.getLoopArray();
         for (let i = 0, n = scenes.length; i < n; i++) {
           scenes[i].destroy();
         }

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -39,7 +39,7 @@ export class ResourceManager {
   /** Base url for loading assets. */
   baseUrl: string | null = null;
 
-  private _loadingPromises: Record<string, AssetPromise<any>> = {};
+  private _loadingPromises: Record<string, AssetPromise<any>[]> = {};
 
   /** Asset path pool, key is the `instanceID` of resource, value is asset path. */
   private _assetPool: Record<number, string> = Object.create(null);
@@ -152,14 +152,14 @@ export class ResourceManager {
 
   cancelNotLoaded(url?: string | string[]): void {
     if (!url) {
-      Utils.objectValues(this._loadingPromises).forEach((promise) => {
-        promise.cancel();
+      Utils.objectValues(this._loadingPromises).forEach((promises) => {
+        promises.forEach((promise) => promise.cancel());
       });
     } else if (typeof url === "string") {
-      this._loadingPromises[this._getLoadingKey(url)]?.cancel();
+      this._loadingPromises[this._getLoadingKey(url)]?.forEach((promise) => promise.cancel());
     } else {
       for (let i = 0, n = url.length; i < n; i++) {
-        this._loadingPromises[this._getLoadingKey(url[i])]?.cancel();
+        this._loadingPromises[this._getLoadingKey(url[i])]?.forEach((promise) => promise.cancel());
       }
     }
   }
@@ -348,8 +348,14 @@ export class ResourceManager {
     const remoteAssetBaseURL = this._getRemoteUrl(assetBaseURL);
     item.url = assetBaseURL;
 
+    // Check loader
+    const loader = <Loader<T>>ResourceManager._loaders[item.type];
+    if (!loader) {
+      throw `loader not found: ${item.type}`;
+    }
+
     // Check cache
-    const cacheObject = this._assetUrlPool[remoteAssetBaseURL];
+    const cacheObject = loader.useCache && this._assetUrlPool[remoteAssetBaseURL];
     if (cacheObject) {
       return new AssetPromise((resolve) => {
         resolve(this._getResolveResource(cacheObject, paths) as T);
@@ -360,7 +366,7 @@ export class ResourceManager {
 
     // Check is loading
     const loadingPromises = this._loadingPromises;
-    const loadingPromise = loadingPromises[remoteAssetURL];
+    const loadingPromise = loader.useCache && loadingPromises[remoteAssetURL]?.[0];
     if (loadingPromise) {
       return new AssetPromise((resolve, reject, setTaskCompleteProgress, setTaskDetailProgress) => {
         loadingPromise
@@ -374,19 +380,13 @@ export class ResourceManager {
       });
     }
 
-    // Check loader
-    const loader = <Loader<T>>ResourceManager._loaders[item.type];
-    if (!loader) {
-      throw `loader not found: ${item.type}`;
-    }
-
     const subpackageName = virtualResourceEntry?.subpackageName;
 
     // Check sub asset
     if (queryPath) {
       // Check whether load main asset
       const mainPromise =
-        loadingPromises[remoteAssetBaseURL] ||
+        (loader.useCache && loadingPromises[remoteAssetBaseURL]?.[0]) ||
         this._loadSubpackageAndMainAsset(loader, item, remoteAssetBaseURL, subpackageName);
 
       return this._createSubAssetPromiseCallback<T>(remoteAssetBaseURL, remoteAssetURL, queryPath, mainPromise);
@@ -408,18 +408,18 @@ export class ResourceManager {
   private _loadMainAsset<T>(loader: Loader<T>, item: LoadItem, remoteAssetBaseURL: string): AssetPromise<T> {
     const loadingPromises = this._loadingPromises;
     const promise = loader.load(item, this);
-    loadingPromises[remoteAssetBaseURL] = promise;
+    (loadingPromises[remoteAssetBaseURL] ||= []).push(promise);
 
     promise.then(
       (resource: T) => {
         if (loader.useCache) {
           this._addAsset(remoteAssetBaseURL, resource as EngineObject);
         }
-        delete loadingPromises[remoteAssetBaseURL];
+        this._removeLoadingPromise(loadingPromises, remoteAssetBaseURL, promise);
         this._releaseSubAssetPromiseCallback(remoteAssetBaseURL);
       },
       () => {
-        delete loadingPromises[remoteAssetBaseURL];
+        this._removeLoadingPromise(loadingPromises, remoteAssetBaseURL, promise);
         this._releaseSubAssetPromiseCallback(remoteAssetBaseURL);
       }
     );
@@ -461,16 +461,31 @@ export class ResourceManager {
       }, reject);
     });
 
-    loadingPromises[remoteAssetURL] = promise;
+    (loadingPromises[remoteAssetURL] ||= []).push(promise);
 
     promise.then(
       () => {
-        delete loadingPromises[remoteAssetURL];
+        this._removeLoadingPromise(loadingPromises, remoteAssetURL, promise);
       },
-      () => delete loadingPromises[remoteAssetURL]
+      () => this._removeLoadingPromise(loadingPromises, remoteAssetURL, promise)
     );
 
     return promise;
+  }
+
+  private _removeLoadingPromise(
+    loadingPromises: Record<string, AssetPromise<any>[]>,
+    url: string,
+    promise: AssetPromise<any>
+  ): void {
+    const promises = loadingPromises[url];
+    const index = promises?.indexOf(promise) ?? -1;
+    if (index !== -1) {
+      promises.splice(index, 1);
+      if (promises.length === 0) {
+        delete loadingPromises[url];
+      }
+    }
   }
 
   private _gc(forceDestroy: boolean): void {

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -167,7 +167,7 @@ export function applySceneData(
   return Promise.all(promises).then(() => {});
 }
 
-@resourceLoader(AssetType.Scene, ["scene"], true)
+@resourceLoader(AssetType.Scene, ["scene"], false)
 class SceneLoader extends Loader<Scene> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Scene> {
     const { engine } = resourceManager;

--- a/tests/src/core/SceneManagerLoadScene.test.ts
+++ b/tests/src/core/SceneManagerLoadScene.test.ts
@@ -27,14 +27,22 @@ describe("SceneManager.loadScene", () => {
     engine.destroy();
   });
 
-  it("reloads the same URL into a fresh usable runtime scene", async () => {
+  it("loads overlapping same-URL requests into independent scenes", async () => {
+    const resolves: ((value: SceneFile) => void)[] = [];
     const request = vi
       .spyOn(engine.resourceManager as any, "_request")
-      .mockReturnValue(AssetPromise.resolve(sceneFile) as any);
+      .mockImplementation(
+        () => new AssetPromise((resolve) => resolves.push(resolve as (value: SceneFile) => void)) as any
+      );
 
     try {
-      const first = await engine.sceneManager.loadScene("main.scene");
-      const second = await engine.sceneManager.loadScene("main.scene");
+      const firstPromise = engine.sceneManager.loadScene("main.scene");
+      const secondPromise = engine.sceneManager.loadScene("main.scene");
+
+      resolves[0](sceneFile);
+      const first = await firstPromise;
+      resolves[1](sceneFile);
+      const second = await secondPromise;
 
       expect(first).not.toBe(second);
       expect(first.destroyed).toBe(true);
@@ -42,6 +50,34 @@ describe("SceneManager.loadScene", () => {
       expect(second.rootEntities).toHaveLength(1);
       expect(second.rootEntities[0].name).toBe("root");
       expect(engine.sceneManager.activeScene).toBe(second);
+    } finally {
+      request.mockRestore();
+    }
+  });
+
+  it("keeps overlapping same-URL requests independent when the second finishes first", async () => {
+    const resolves: ((value: SceneFile) => void)[] = [];
+    const request = vi
+      .spyOn(engine.resourceManager as any, "_request")
+      .mockImplementation(
+        () => new AssetPromise((resolve) => resolves.push(resolve as (value: SceneFile) => void)) as any
+      );
+
+    try {
+      const firstPromise = engine.sceneManager.loadScene("main.scene");
+      const secondPromise = engine.sceneManager.loadScene("main.scene");
+
+      resolves[1](sceneFile);
+      const second = await secondPromise;
+      resolves[0](sceneFile);
+      const first = await firstPromise;
+
+      expect(first).not.toBe(second);
+      expect(second.destroyed).toBe(true);
+      expect(first.destroyed).toBe(false);
+      expect(first.rootEntities).toHaveLength(1);
+      expect(first.rootEntities[0].name).toBe("root");
+      expect(engine.sceneManager.activeScene).toBe(first);
     } finally {
       request.mockRestore();
     }

--- a/tests/src/core/SceneManagerLoadScene.test.ts
+++ b/tests/src/core/SceneManagerLoadScene.test.ts
@@ -1,0 +1,70 @@
+import "@galacean/engine-loader";
+import { AssetPromise, BackgroundMode, Scene } from "@galacean/engine-core";
+import { WebGLEngine } from "@galacean/engine";
+import type { SceneFile } from "../../../packages/loader/src/schema/SceneSchema";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const sceneFile: SceneFile = {
+  version: "2.0",
+  refs: [],
+  entities: [{ name: "root" }],
+  components: [],
+  scene: {
+    name: "main",
+    rootEntities: [0],
+    background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] }
+  }
+};
+
+describe("SceneManager.loadScene", () => {
+  let engine: WebGLEngine;
+
+  beforeAll(async () => {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+  });
+
+  afterAll(() => {
+    engine.destroy();
+  });
+
+  it("reloads the same URL into a fresh usable runtime scene", async () => {
+    const request = vi
+      .spyOn(engine.resourceManager as any, "_request")
+      .mockReturnValue(AssetPromise.resolve(sceneFile) as any);
+
+    try {
+      const first = await engine.sceneManager.loadScene("main.scene");
+      const second = await engine.sceneManager.loadScene("main.scene");
+
+      expect(first).not.toBe(second);
+      expect(first.destroyed).toBe(true);
+      expect(second.destroyed).toBe(false);
+      expect(second.rootEntities).toHaveLength(1);
+      expect(second.rootEntities[0].name).toBe("root");
+      expect(engine.sceneManager.activeScene).toBe(second);
+    } finally {
+      request.mockRestore();
+    }
+  });
+
+  it("destroys every active scene while activating the fresh scene", async () => {
+    const request = vi
+      .spyOn(engine.resourceManager as any, "_request")
+      .mockReturnValue(AssetPromise.resolve(sceneFile) as any);
+
+    try {
+      const sceneManager = engine.sceneManager;
+      const extraScenes = [new Scene(engine, "extra-1"), new Scene(engine, "extra-2")];
+      extraScenes.forEach((scene) => sceneManager.addScene(scene));
+      const oldScenes = [...sceneManager.scenes];
+
+      const scene = await sceneManager.loadScene("main.scene");
+
+      oldScenes.forEach((oldScene) => expect(oldScene.destroyed).toBe(true));
+      expect(scene.destroyed).toBe(false);
+      expect(sceneManager.scenes).toEqual([scene]);
+    } finally {
+      request.mockRestore();
+    }
+  });
+});

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -118,6 +118,70 @@ describe("ResourceManager", () => {
   });
 
   describe("load asset", () => {
+    it("loads concurrent uncached requests independently", async () => {
+      const resourceManager = engine.resourceManager;
+      const url = "Assets/concurrent-primitive.mesh";
+      const resolves: ((value?: any) => void)[] = [];
+      const cachePool = (resourceManager as any)._assetUrlPool;
+      cachePool[url] = { instanceId: 987654329 };
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.PrimitiveMesh], "load")
+        .mockImplementation(() => new AssetPromise((resolve) => resolves.push(resolve)) as any);
+
+      try {
+        const firstPromise = resourceManager.load<any>({ type: AssetType.PrimitiveMesh, url });
+        const secondPromise = resourceManager.load<any>({ type: AssetType.PrimitiveMesh, url });
+
+        expect(loaderSpy).toHaveBeenCalledTimes(2);
+
+        const firstResource = { instanceId: 987654326 };
+        const secondResource = { instanceId: 987654327 };
+        resolves[0](firstResource);
+        resolves[1](secondResource);
+
+        await expect(firstPromise).resolves.toBe(firstResource);
+        await expect(secondPromise).resolves.toBe(secondResource);
+      } finally {
+        delete cachePool[url];
+        resourceManager.cancelNotLoaded(url);
+        loaderSpy.mockRestore();
+      }
+    });
+
+    it("cancels every pending uncached request for a URL", async () => {
+      const resourceManager = engine.resourceManager;
+      const url = "Assets/cancel-primitive.mesh";
+      const resolves: ((value?: any) => void)[] = [];
+      const cancelSpies = [vi.fn(), vi.fn(), vi.fn()];
+      let loadIndex = 0;
+      const loaderSpy = vi.spyOn(ResourceManager._loaders[AssetType.PrimitiveMesh], "load").mockImplementation(
+        () =>
+          new AssetPromise((resolve, _reject, _setComplete, _setDetail, onCancel) => {
+            resolves.push(resolve);
+            onCancel(cancelSpies[loadIndex++]);
+          }) as any
+      );
+
+      try {
+        const firstPromise = resourceManager.load<any>({ type: AssetType.PrimitiveMesh, url });
+        const secondPromise = resourceManager.load<any>({ type: AssetType.PrimitiveMesh, url });
+        resolves[0]({ instanceId: 987654328 });
+        await expect(firstPromise).resolves.toEqual({ instanceId: 987654328 });
+
+        const thirdPromise = resourceManager.load<any>({ type: AssetType.PrimitiveMesh, url });
+        resourceManager.cancelNotLoaded(url);
+
+        expect(cancelSpies[0]).not.toHaveBeenCalled();
+        expect(cancelSpies[1]).toHaveBeenCalledOnce();
+        expect(cancelSpies[2]).toHaveBeenCalledOnce();
+        await expect(secondPromise).rejects.toBe("canceled");
+        await expect(thirdPromise).rejects.toBe("canceled");
+      } finally {
+        resourceManager.cancelNotLoaded(url);
+        loaderSpy.mockRestore();
+      }
+    });
+
     it("resolves a relative baseUrl once at the request boundary", async () => {
       const resourceManager = engine.resourceManager;
       const requestSpy = vi


### PR DESCRIPTION
Fixes #2979

## Root cause

`SceneLoader` was changed to disable completed-result URL caching, but `ResourceManager` still reused one in-flight `_loadingPromises` entry for every loader. Two overlapping same-URL `SceneManager.loadScene` calls therefore received the same runtime `Scene`; the later lifecycle callback could destroy it and reattach the destroyed object.

## Solution

- Store in-flight requests as a collection per URL.
- `useCache=false` loaders neither read completed URL cache nor reuse an in-flight Promise, so each load materializes its own result.
- Cached loaders continue to share only the first in-flight Promise.
- Completion removes only its own Promise, preserving later requests; `cancelNotLoaded(url)` and `cancelNotLoaded()` cancel every request in each collection.
- Keep the existing loop-safe SceneManager destruction behavior. No Scene special case, identity guard, generation, compatibility path, or public protocol was added.

ProjectLoader and PrimitiveMeshLoader use the same generic `useCache=false` path; the ResourceManager test exercises the real PrimitiveMesh loader registration and verifies both completed-cache bypass and independent concurrent results.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/core/SceneManagerLoadScene.test.ts src/core/resource/ResourceManager.test.ts src/loader/SceneFormatV2.test.ts src/core/mesh/PrimitiveMesh.test.ts` from `tests`: 95/95 passed in Chromium.
- `pnpm b:module`: passed; existing circular-dependency and sourcemap warnings only.
- `pnpm b:types`: passed, including Engine knowledge validation.
- `pnpm lint`: passed with 0 errors and existing warnings only.
- Prettier check and `git diff --check`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scene reloading so previous scenes are reliably cleaned up before replacement scenes load.
  - Prevented stale active scenes from remaining after a new scene loads.
  - Improved handling of concurrent uncached asset requests.
  - Ensured all pending requests for an asset can be canceled consistently.

- **Tests**
  - Added coverage for scene replacement, cleanup, and active-scene tracking.
  - Added tests for concurrent asset loading and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->