### PR TITLE
fix(particle): support mixed ForceOverLifetime axis modes

### DIFF
--- a/packages/core/src/particle/modules/ForceOverLifetimeModule.ts
+++ b/packages/core/src/particle/modules/ForceOverLifetimeModule.ts
@@ -35,6 +35,18 @@ export class ForceOverLifetimeModule extends ParticleGeneratorModule {
   @ignoreClone
   private _forceMaxConstant = new Vector3();
   @ignoreClone
+  private _forceMinGradientX = new Float32Array(8);
+  @ignoreClone
+  private _forceMinGradientY = new Float32Array(8);
+  @ignoreClone
+  private _forceMinGradientZ = new Float32Array(8);
+  @ignoreClone
+  private _forceMaxGradientX = new Float32Array(8);
+  @ignoreClone
+  private _forceMaxGradientY = new Float32Array(8);
+  @ignoreClone
+  private _forceMaxGradientZ = new Float32Array(8);
+  @ignoreClone
   private _forceMacro: ShaderMacro;
   @ignoreClone
   private _randomModeMacro: ShaderMacro;
@@ -123,25 +135,36 @@ export class ForceOverLifetimeModule extends ParticleGeneratorModule {
       const forceY = this._forceY;
       const forceZ = this._forceZ;
 
-      const isRandomCurveMode =
-        forceX.mode === ParticleCurveMode.TwoCurves &&
-        forceY.mode === ParticleCurveMode.TwoCurves &&
-        forceZ.mode === ParticleCurveMode.TwoCurves;
+      const isCurveMode = forceX._isCurveMode() || forceY._isCurveMode() || forceZ._isCurveMode();
+      const isRandomMode = forceX._isRandomMode() || forceY._isRandomMode() || forceZ._isRandomMode();
 
-      if (
-        isRandomCurveMode ||
-        (forceX.mode === ParticleCurveMode.Curve &&
-          forceY.mode === ParticleCurveMode.Curve &&
-          forceZ.mode === ParticleCurveMode.Curve)
-      ) {
-        shaderData.setFloatArray(ForceOverLifetimeModule._maxGradientXProperty, forceX.curveMax._getTypeArray());
-        shaderData.setFloatArray(ForceOverLifetimeModule._maxGradientYProperty, forceY.curveMax._getTypeArray());
-        shaderData.setFloatArray(ForceOverLifetimeModule._maxGradientZProperty, forceZ.curveMax._getTypeArray());
+      if (isCurveMode) {
+        shaderData.setFloatArray(
+          ForceOverLifetimeModule._maxGradientXProperty,
+          this._getCurveData(forceX, this._forceMaxGradientX, false)
+        );
+        shaderData.setFloatArray(
+          ForceOverLifetimeModule._maxGradientYProperty,
+          this._getCurveData(forceY, this._forceMaxGradientY, false)
+        );
+        shaderData.setFloatArray(
+          ForceOverLifetimeModule._maxGradientZProperty,
+          this._getCurveData(forceZ, this._forceMaxGradientZ, false)
+        );
         forceModeMacro = ForceOverLifetimeModule._curveModeMacro;
-        if (isRandomCurveMode) {
-          shaderData.setFloatArray(ForceOverLifetimeModule._minGradientXProperty, forceX.curveMin._getTypeArray());
-          shaderData.setFloatArray(ForceOverLifetimeModule._minGradientYProperty, forceY.curveMin._getTypeArray());
-          shaderData.setFloatArray(ForceOverLifetimeModule._minGradientZProperty, forceZ.curveMin._getTypeArray());
+        if (isRandomMode) {
+          shaderData.setFloatArray(
+            ForceOverLifetimeModule._minGradientXProperty,
+            this._getCurveData(forceX, this._forceMinGradientX, true)
+          );
+          shaderData.setFloatArray(
+            ForceOverLifetimeModule._minGradientYProperty,
+            this._getCurveData(forceY, this._forceMinGradientY, true)
+          );
+          shaderData.setFloatArray(
+            ForceOverLifetimeModule._minGradientZProperty,
+            this._getCurveData(forceZ, this._forceMinGradientZ, true)
+          );
           isRandomModeMacro = ForceOverLifetimeModule._isRandomMacro;
         }
       } else {
@@ -149,13 +172,13 @@ export class ForceOverLifetimeModule extends ParticleGeneratorModule {
         constantMax.set(forceX.constantMax, forceY.constantMax, forceZ.constantMax);
         shaderData.setVector3(ForceOverLifetimeModule._maxConstantProperty, constantMax);
         forceModeMacro = ForceOverLifetimeModule._constantModeMacro;
-        if (
-          forceX.mode === ParticleCurveMode.TwoConstants &&
-          forceY.mode === ParticleCurveMode.TwoConstants &&
-          forceZ.mode === ParticleCurveMode.TwoConstants
-        ) {
+        if (isRandomMode) {
           const constantMin = this._forceMinConstant;
-          constantMin.set(forceX.constantMin, forceY.constantMin, forceZ.constantMin);
+          constantMin.set(
+            forceX.mode === ParticleCurveMode.TwoConstants ? forceX.constantMin : forceX.constantMax,
+            forceY.mode === ParticleCurveMode.TwoConstants ? forceY.constantMin : forceY.constantMax,
+            forceZ.mode === ParticleCurveMode.TwoConstants ? forceZ.constantMin : forceZ.constantMax
+          );
           shaderData.setVector3(ForceOverLifetimeModule._minConstantProperty, constantMin);
           isRandomModeMacro = ForceOverLifetimeModule._isRandomMacro;
         }
@@ -178,16 +201,27 @@ export class ForceOverLifetimeModule extends ParticleGeneratorModule {
    * @internal
    */
   _isRandomMode(): boolean {
-    const modeX = this.forceX.mode;
-    const modeY = this.forceY.mode;
-    const modeZ = this.forceZ.mode;
-    return (
-      (modeX === ParticleCurveMode.TwoCurves &&
-        modeY === ParticleCurveMode.TwoCurves &&
-        modeZ === ParticleCurveMode.TwoCurves) ||
-      (modeX === ParticleCurveMode.TwoConstants &&
-        modeY === ParticleCurveMode.TwoConstants &&
-        modeZ === ParticleCurveMode.TwoConstants)
-    );
+    return this.forceX._isRandomMode() || this.forceY._isRandomMode() || this.forceZ._isRandomMode();
+  }
+
+  private _getCurveData(curve: ParticleCompositeCurve, out: Float32Array, useMin: boolean): Float32Array {
+    switch (curve.mode) {
+      case ParticleCurveMode.TwoCurves:
+        return (useMin ? curve.curveMin : curve.curveMax)._getTypeArray();
+      case ParticleCurveMode.Curve:
+        return curve.curveMax._getTypeArray();
+      default: {
+        const value = useMin && curve.mode === ParticleCurveMode.TwoConstants ? curve.constantMin : curve.constantMax;
+        out[0] = 0;
+        out[1] = value;
+        out[2] = 1 / 3;
+        out[3] = value;
+        out[4] = 2 / 3;
+        out[5] = value;
+        out[6] = 1;
+        out[7] = value;
+        return out;
+      }
+    }
   }
 }

--- a/packages/core/src/particle/modules/ForceOverLifetimeModule.ts
+++ b/packages/core/src/particle/modules/ForceOverLifetimeModule.ts
@@ -136,7 +136,7 @@ export class ForceOverLifetimeModule extends ParticleGeneratorModule {
       const forceZ = this._forceZ;
 
       const isCurveMode = forceX._isCurveMode() || forceY._isCurveMode() || forceZ._isCurveMode();
-      const isRandomMode = forceX._isRandomMode() || forceY._isRandomMode() || forceZ._isRandomMode();
+      const isRandomMode = this._isRandomMode();
 
       if (isCurveMode) {
         shaderData.setFloatArray(

--- a/tests/src/core/particle/ForceOverLifetime.test.ts
+++ b/tests/src/core/particle/ForceOverLifetime.test.ts
@@ -1,0 +1,75 @@
+import {
+  Camera,
+  CurveKey,
+  Engine,
+  ParticleCompositeCurve,
+  ParticleCurve,
+  ParticleMaterial,
+  ParticleRenderer,
+  ShaderMacro,
+  ShaderProperty,
+  WebGLEngine
+} from "@galacean/engine";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const FOL_CONSTANT_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_CONSTANT_MODE");
+const FOL_CURVE_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_CURVE_MODE");
+const FOL_RANDOM_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_IS_RANDOM_TWO");
+const FOL_MIN_CONST = ShaderProperty.getByName("renderer_FOLMinConst");
+const FOL_MAX_CONST = ShaderProperty.getByName("renderer_FOLMaxConst");
+
+function createParticleRenderer(engine: Engine): ParticleRenderer {
+  const scene = engine.sceneManager.activeScene;
+  const entity = scene.getRootEntity().createChild("FOL_MixedAxis");
+  const renderer = entity.addComponent(ParticleRenderer);
+  renderer.setMaterial(new ParticleMaterial(engine));
+  return renderer;
+}
+
+describe("ForceOverLifetime", () => {
+  let engine: Engine;
+
+  beforeAll(async () => {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+    const root = engine.sceneManager.activeScene.createRootEntity("root");
+    root.createChild("Camera").addComponent(Camera);
+  });
+
+  it("keeps constant axes fixed when another axis is random", () => {
+    const renderer = createParticleRenderer(engine);
+    const { forceOverLifetime } = renderer.generator;
+    forceOverLifetime.enabled = true;
+    forceOverLifetime.forceX = new ParticleCompositeCurve(-1, 1);
+    forceOverLifetime.forceY.constant = 2;
+    forceOverLifetime.forceZ.constant = -3;
+
+    renderer.generator._updateShaderData(renderer.shaderData);
+
+    const macros = renderer.shaderData["_macroCollection"];
+    expect(macros.isEnable(FOL_CONSTANT_MODE_MACRO)).to.eq(true);
+    expect(macros.isEnable(FOL_CURVE_MODE_MACRO)).to.eq(false);
+    expect(macros.isEnable(FOL_RANDOM_MODE_MACRO)).to.eq(true);
+    const minConstant = renderer.shaderData.getVector3(FOL_MIN_CONST);
+    const maxConstant = renderer.shaderData.getVector3(FOL_MAX_CONST);
+    expect([minConstant.x, minConstant.y, minConstant.z]).to.deep.eq([-1, 2, -3]);
+    expect([maxConstant.x, maxConstant.y, maxConstant.z]).to.deep.eq([1, 2, -3]);
+
+    forceOverLifetime.forceX = new ParticleCompositeCurve(
+      new ParticleCurve(new CurveKey(0, -1), new CurveKey(1, -1)),
+      new ParticleCurve(new CurveKey(0, 1), new CurveKey(1, 1))
+    );
+    renderer.generator._updateShaderData(renderer.shaderData);
+
+    expect(macros.isEnable(FOL_CONSTANT_MODE_MACRO)).to.eq(false);
+    expect(macros.isEnable(FOL_CURVE_MODE_MACRO)).to.eq(true);
+    expect(macros.isEnable(FOL_RANDOM_MODE_MACRO)).to.eq(true);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMinGradientX")[1]).to.eq(-1);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMaxGradientX")[1]).to.eq(1);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMinGradientY")[1]).to.eq(2);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMaxGradientY")[1]).to.eq(2);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMinGradientZ")[1]).to.eq(-3);
+    expect(renderer.shaderData.getFloatArray("renderer_FOLMaxGradientZ")[1]).to.eq(-3);
+
+    renderer.entity.destroy();
+  });
+});

--- a/tests/src/core/particle/ForceOverLifetime.test.ts
+++ b/tests/src/core/particle/ForceOverLifetime.test.ts
@@ -12,7 +12,7 @@ import {
   ShaderProperty,
   WebGLEngine
 } from "@galacean/engine";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const FOL_CONSTANT_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_CONSTANT_MODE");
 const FOL_CURVE_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_CURVE_MODE");
@@ -28,12 +28,13 @@ function updateEngine(engine: Engine, frames: number, deltaTime = 100) {
   //@ts-ignore
   engine._time._lastSystemTime = 0;
   let times = 0;
-  performance.now = function () {
-    times++;
-    return times * deltaTime;
-  };
-  for (let i = 0; i < frames; i++) {
-    engine.update();
+  const now = vi.spyOn(performance, "now").mockImplementation(() => ++times * deltaTime);
+  try {
+    for (let i = 0; i < frames; i++) {
+      engine.update();
+    }
+  } finally {
+    now.mockRestore();
   }
 }
 

--- a/tests/src/core/particle/ForceOverLifetime.test.ts
+++ b/tests/src/core/particle/ForceOverLifetime.test.ts
@@ -54,10 +54,31 @@ describe("ForceOverLifetime", () => {
     expect([minConstant.x, minConstant.y, minConstant.z]).to.deep.eq([-1, 2, -3]);
     expect([maxConstant.x, maxConstant.y, maxConstant.z]).to.deep.eq([1, 2, -3]);
 
+    forceOverLifetime.forceX = new ParticleCompositeCurve(new ParticleCurve(new CurveKey(0, -1), new CurveKey(1, 1)));
+    forceOverLifetime.forceY = new ParticleCompositeCurve(-2, 3);
+    renderer.generator._updateShaderData(renderer.shaderData);
+
+    expect(macros.isEnable(FOL_CONSTANT_MODE_MACRO)).to.eq(false);
+    expect(macros.isEnable(FOL_CURVE_MODE_MACRO)).to.eq(true);
+    expect(macros.isEnable(FOL_RANDOM_MODE_MACRO)).to.eq(true);
+    const curveMin = renderer.shaderData.getFloatArray("renderer_FOLMinGradientX");
+    const curveMax = renderer.shaderData.getFloatArray("renderer_FOLMaxGradientX");
+    expect(Array.from(curveMin)).to.deep.eq(Array.from(curveMax));
+    const twoConstantsMin = renderer.shaderData.getFloatArray("renderer_FOLMinGradientY");
+    const twoConstantsMax = renderer.shaderData.getFloatArray("renderer_FOLMaxGradientY");
+    expect([twoConstantsMin[1], twoConstantsMin[3], twoConstantsMin[5], twoConstantsMin[7]]).to.deep.eq([
+      -2, -2, -2, -2
+    ]);
+    expect([twoConstantsMax[1], twoConstantsMax[3], twoConstantsMax[5], twoConstantsMax[7]]).to.deep.eq([3, 3, 3, 3]);
+    const constantMin = renderer.shaderData.getFloatArray("renderer_FOLMinGradientZ");
+    const constantMax = renderer.shaderData.getFloatArray("renderer_FOLMaxGradientZ");
+    expect(Array.from(constantMin)).to.deep.eq(Array.from(constantMax));
+
     forceOverLifetime.forceX = new ParticleCompositeCurve(
       new ParticleCurve(new CurveKey(0, -1), new CurveKey(1, -1)),
       new ParticleCurve(new CurveKey(0, 1), new CurveKey(1, 1))
     );
+    forceOverLifetime.forceY = new ParticleCompositeCurve(2);
     renderer.generator._updateShaderData(renderer.shaderData);
 
     expect(macros.isEnable(FOL_CONSTANT_MODE_MACRO)).to.eq(false);

--- a/tests/src/core/particle/ForceOverLifetime.test.ts
+++ b/tests/src/core/particle/ForceOverLifetime.test.ts
@@ -1,4 +1,5 @@
 import {
+  Burst,
   Camera,
   CurveKey,
   Engine,
@@ -6,6 +7,7 @@ import {
   ParticleCurve,
   ParticleMaterial,
   ParticleRenderer,
+  ParticleStopMode,
   ShaderMacro,
   ShaderProperty,
   WebGLEngine
@@ -17,12 +19,37 @@ const FOL_CURVE_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_CURVE_MODE");
 const FOL_RANDOM_MODE_MACRO = ShaderMacro.getByName("RENDERER_FOL_IS_RANDOM_TWO");
 const FOL_MIN_CONST = ShaderProperty.getByName("renderer_FOLMinConst");
 const FOL_MAX_CONST = ShaderProperty.getByName("renderer_FOLMaxConst");
+// ParticleBufferUtils.instanceVertexFloatStride
+const FLOAT_STRIDE = 42;
+
+function updateEngine(engine: Engine, frames: number, deltaTime = 100) {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  //@ts-ignore
+  engine._time._lastSystemTime = 0;
+  let times = 0;
+  performance.now = function () {
+    times++;
+    return times * deltaTime;
+  };
+  for (let i = 0; i < frames; i++) {
+    engine.update();
+  }
+}
 
 function createParticleRenderer(engine: Engine): ParticleRenderer {
   const scene = engine.sceneManager.activeScene;
   const entity = scene.getRootEntity().createChild("FOL_MixedAxis");
   const renderer = entity.addComponent(ParticleRenderer);
   renderer.setMaterial(new ParticleMaterial(engine));
+
+  const generator = renderer.generator;
+  generator.useAutoRandomSeed = false;
+  generator.main.duration = 5;
+  generator.main.isLoop = false;
+  generator.main.maxParticles = 1000;
+  generator.main.startLifetime.constant = 10;
+  generator.emission.rateOverTime.constant = 0;
   return renderer;
 }
 
@@ -33,6 +60,7 @@ describe("ForceOverLifetime", () => {
     engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
     const root = engine.sceneManager.activeScene.createRootEntity("root");
     root.createChild("Camera").addComponent(Camera);
+    engine.run();
   });
 
   it("keeps constant axes fixed when another axis is random", () => {
@@ -90,6 +118,31 @@ describe("ForceOverLifetime", () => {
     expect(renderer.shaderData.getFloatArray("renderer_FOLMaxGradientY")[1]).to.eq(2);
     expect(renderer.shaderData.getFloatArray("renderer_FOLMinGradientZ")[1]).to.eq(-3);
     expect(renderer.shaderData.getFloatArray("renderer_FOLMaxGradientZ")[1]).to.eq(-3);
+
+    renderer.entity.destroy();
+  });
+
+  it("writes random factors for particles when only one force axis is random", () => {
+    const renderer = createParticleRenderer(engine);
+    const generator = renderer.generator;
+    const { forceOverLifetime } = generator;
+    forceOverLifetime.enabled = true;
+    forceOverLifetime.forceX = new ParticleCompositeCurve(-1, 1);
+    forceOverLifetime.forceY.constant = 2;
+    forceOverLifetime.forceZ.constant = -3;
+
+    generator.emission.addBurst(new Burst(0, new ParticleCompositeCurve(2), 1, 0.01));
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    updateEngine(engine, 3);
+
+    expect(generator._getAliveParticleCount()).to.eq(2);
+    const vertices = (generator as any)._instanceVertices as Float32Array;
+    const first = Array.from(vertices.slice(38, 41));
+    const second = Array.from(vertices.slice(FLOAT_STRIDE + 38, FLOAT_STRIDE + 41));
+    expect(first.every((value) => value > 0 && value < 1)).to.eq(true);
+    expect(second.every((value) => value > 0 && value < 1)).to.eq(true);
+    expect(first).to.not.deep.eq(second);
 
     renderer.entity.destroy();
   });


### PR DESCRIPTION
## Summary\n\nFixes #2796\n\n## Root cause\n\nForceOverLifetimeModule required all three axes to use the same curve or random mode. A mixed setup such as X=TwoConstants and Y/Z=Constant therefore fell back to the constant max-only path, and ParticleGenerator did not allocate the per-particle random values.\n\n## Minimal fix\n\n- Select curve mode when any axis uses Curve or TwoCurves, and random mode when any axis uses TwoConstants or TwoCurves.\n- Encode constant and TwoConstants axes as cached flat min/max curves when the shared curve path is active.\n- Upload identical min and max values for non-random axes, preserving their constant direction while other axes vary.\n- Keep the existing shader macro and uniform contract for both the regular particle vertex path and transform-feedback path.\n\n## Validation\n\n- Chromium focused test: tests/src/core/particle/ForceOverLifetime.test.ts, 2/2 passed, including real per-particle a_Random2.xyz slot writes for mixed-axis random mode.\n- Chromium particle suite: 16 files, 173 tests passed.\n- pnpm b:module passed.\n- pnpm b:types passed.\n- pnpm --filter @galacean/engine-core run b:types passed.\n- pnpm lint passed with 0 errors; only existing repository warnings remain.\n- Prettier check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Particle forces now support independent settings on the X, Y, and Z axes.
  * Mixed constant, curve-based, and randomized force configurations are supported.
  * Curve data is correctly applied to shader-driven particle effects.

* **Bug Fixes**
  * Fixed particle behavior when only selected axes use randomized or curve-based values.
  * Improved handling of constant and varying force ranges in mixed-axis configurations.
  * Randomized force values now apply correctly during particle rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->