### PR TITLE
docs(skill): clarify runtime resource load paths

### DIFF
--- a/packages/galacean/skills/engine-knowledge/SKILL.md
+++ b/packages/galacean/skills/engine-knowledge/SKILL.md
@@ -22,7 +22,7 @@ This Skill does not define how a host creates, serializes, builds, or publishes 
 - For Script activation and frame ordering, read [lifecycle-and-frame-order.md](references/lifecycle-and-frame-order.md).
 - For collider ownership, motion, fixed steps, and callbacks, read [physics-setup.md](references/physics-setup.md).
 - For built-in mesh dimensions and orientation, read [primitive-geometry.md](references/primitive-geometry.md).
-- For cloning, reference counts, garbage collection, and shared resources, read [resource-ownership.md](references/resource-ownership.md).
+- For runtime resource loading, cloning, reference counts, garbage collection, and shared resources, read [resource-ownership.md](references/resource-ownership.md).
 - For material sharing, color-space intent, multi-camera composition, SpriteMask targets, and final output, read [rendering-and-color.md](references/rendering-and-color.md).
 - For physics-backed picking, shadows, skyboxes, per-renderer normal maps, draw-ready custom meshes, or local post-process volumes, read [runtime-recipes.md](references/runtime-recipes.md).
 - For Spine runtime, instance, animation-state, and render ownership, read [spine.md](references/spine.md).

--- a/packages/galacean/skills/engine-knowledge/references/resource-ownership.md
+++ b/packages/galacean/skills/engine-knowledge/references/resource-ownership.md
@@ -2,6 +2,10 @@
 
 Use this reference when deciding whether an object should be shared, cloned, garbage-collected, or explicitly destroyed.
 
+## Runtime resource loading
+
+- `resourceManager.load()` resolves a browser URL or an exact `virtualPath` already registered with `ResourceManager`; it never reads a host filesystem path.
+
 ## Reference-counted resources
 
 - Engine resources derived from `ReferResource` participate in reference counting. Assigning them to owning Engine objects changes their retained lifetime through those owners.

--- a/packages/galacean/skills/engine-knowledge/references/resource-ownership.md
+++ b/packages/galacean/skills/engine-knowledge/references/resource-ownership.md
@@ -1,10 +1,11 @@
 # Resource Ownership
 
-Use this reference when deciding whether an object should be shared, cloned, garbage-collected, or explicitly destroyed.
+Use this reference when resolving a runtime resource load, or deciding whether an object should be shared, cloned, garbage-collected, or explicitly destroyed.
 
 ## Runtime resource loading
 
-- `resourceManager.load()` resolves a browser URL or an exact `virtualPath` already registered with `ResourceManager`; it never reads a host filesystem path.
+- `resourceManager.load()` resolves an exact `virtualPath` registered through `ResourceManager.registerVirtualResources()` to its backing URL. Every other input is fetched as a URL, with a relative one resolved against `resourceManager.baseUrl` when it is set.
+- Loading never reads a host filesystem path, so a disk or project path becomes an ordinary HTTP request instead of a local file read.
 
 ## Reference-counted resources
 


### PR DESCRIPTION
## Summary
- route runtime resource-loading questions to the existing resource ownership reference
- document that `resourceManager.load()` resolves an exact `virtualPath` registered through `ResourceManager.registerVirtualResources()`, and fetches every other input as a URL whose relative form is resolved against `resourceManager.baseUrl`
- record that a host filesystem path becomes an ordinary HTTP request, not a local file read
- keep the runtime API and Skill reference structure unchanged

## Validation
- traced `ResourceManager.load()` through virtual-path resolution and browser `XMLHttpRequest`
- `EngineKnowledgeSkill.test.ts` 5/5 PASS
- `git diff --check`

Closes #3104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded resource ownership guidance to cover runtime resource loading.
  * Clarified that runtime loading accepts registered exact virtual paths; other inputs are treated as URLs.
  * Clarified that relative URLs resolve against the configured base URL.
  * Documented that host filesystem paths are not read.
  * Explained that caching depends on the loader, while in-flight duplicate requests are always deduplicated.
  * Clarified that only uncached, non-pending loads reach the loader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->