### PR TITLE
fix(audio): allow gesture resume after blocked autoplay

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -7,7 +7,6 @@ export class AudioManager {
 
   private static _context: AudioContext;
   private static _gainNode: GainNode;
-  private static _resumePromise: Promise<void> = null;
   private static _needsUserGestureResume = false;
   private static _suspendedByCaller = false;
   private static _recovering = false;
@@ -34,14 +33,13 @@ export class AudioManager {
    */
   static resume(): Promise<void> {
     AudioManager._suspendedByCaller = false;
-    return (AudioManager._resumePromise ??= AudioManager.getContext()
+    // A blocked resume may remain pending until a later user gesture. Every explicit
+    // attempt must reach the browser in that gesture; reusing its promise loses activation.
+    return AudioManager.getContext()
       .resume()
       .then(() => {
         AudioManager._needsUserGestureResume = false;
-      })
-      .finally(() => {
-        AudioManager._resumePromise = null;
-      }));
+      });
   }
 
   /**
@@ -117,8 +115,6 @@ export class AudioManager {
       if (document.hidden || AudioManager._suspendedByCaller) {
         return;
       }
-      // Go through AudioManager.resume() so _resumePromise coalesces any gesture-resume racing us during
-      // the slow iOS interrupted->running transition; a bare context.resume() here wouldn't dedupe
       AudioManager.resume().catch(() => {});
     }, 100);
   }

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -101,7 +101,6 @@ function resetAudioManagerState(): void {
 
   (AudioManager as any)._context = null;
   (AudioManager as any)._gainNode = null;
-  (AudioManager as any)._resumePromise = null;
   (AudioManager as any)._needsUserGestureResume = false;
   (AudioManager as any)._suspendedByCaller = false;
   (AudioManager as any)._recovering = false;
@@ -378,7 +377,7 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._needsUserGestureResume).to.be.false;
   });
 
-  it("coalesces overlapping resume() calls and re-issues a later resume", async () => {
+  it("retries native resume while an earlier autoplay attempt remains pending", async () => {
     createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "suspended";
@@ -393,13 +392,15 @@ describe("AudioSource playback lifecycle", () => {
 
     AudioManager.resume().catch(() => {});
     AudioManager.resume().catch(() => {});
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    await flushAsync();
+    expect(context.state).to.equal("running");
 
     resolveFirst!();
     await flushAsync();
 
     await AudioManager.resume();
-    expect(resumeSpy).toHaveBeenCalledTimes(2);
+    expect(resumeSpy).toHaveBeenCalledTimes(3);
   });
 
   it("does not auto-resume a caller-controlled suspend on a later gesture", async () => {
@@ -617,9 +618,7 @@ describe("AudioSource playback lifecycle", () => {
     expect(context.state).to.equal("running");
   });
 
-  // a storm of clicks AFTER the 100ms guard window but BEFORE the resume settles must coalesce via
-  // _resumePromise into the timer's resume (the timer goes through AudioManager.resume() now)
-  it("coalesces a click-storm during the slow iOS resume settle into a single context.resume()", async () => {
+  it("allows gesture retries while a foreground recovery resume remains pending", async () => {
     vi.useFakeTimers();
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;
@@ -640,19 +639,18 @@ describe("AudioSource playback lifecycle", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     const resumeSpy = vi.spyOn(context, "resume");
 
-    // 100ms timer fires -> timer calls AudioManager.resume() which sets _resumePromise
+    // The automatic recovery attempt has not settled yet.
     vi.advanceTimersByTime(100);
     await flushAsync();
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     expect((AudioManager as any)._recovering).to.be.false;
-    expect((AudioManager as any)._resumePromise).to.not.be.null;
 
-    // storm of clicks while the resume is still pending -> _resumePromise coalesces them
+    // Each gesture must reach the browser while automatic recovery is pending.
     for (let i = 0; i < 10; i++) {
       document.dispatchEvent(new Event("click"));
     }
     await flushAsync();
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(11);
 
     releaseResume!();
     await flushAsync();


### PR DESCRIPTION
## 背景与实际影响

在 Cocos → Galacean 的「跳跃英雄漫威皮肤」中，用户在正常 Chrome 页面多次点击后，背景音乐和音效仍全部无声。独立无头浏览器先前报告播放成功，未能覆盖严格 autoplay 策略。

直接检查用户受影响页面确认：音乐/音效开关均为 1，AudioClip 已加载、volume=1，但多个 AudioSource 的 pendingPlay=true；AudioContext.state=suspended、currentTime=0、playingCount=0，AudioManager 缓存的恢复 Promise 长期未结束。

## 根因

AudioManager.resume() 使用 `_resumePromise ??=` 合并恢复请求。浏览器可以让缺少用户激活的 AudioContext.resume() 一直 pending，而不是 reject。后续可信点击虽然再次调用 AudioManager.resume()，却只获得旧 Promise，原生 resume() 没有在新的手势调用栈中执行，因而无法利用新的激活机会。

在同一受影响标签页，下一次真实点击直接调用原生 resume() 后，context 恢复 running、currentTime 开始推进，旧等待中的播放也恢复。这确认问题位于恢复请求去重，而不是资源、音量或渲染。

## 修复

- 删除 `_resumePromise` 缓存，每次显式 resume() 都调用原生 AudioContext.resume()。
- 保留返回 Promise、caller-suspend 和中断恢复的现有语义。
- 不添加重试计时器、不重建上下文、不改业务音量与资源。
- 保留已有前后台恢复延迟与恢复期间的保护，本 PR 不扩大到其他生命周期策略。

## 验证

- `pnpm b:module` 通过。
- `pnpm exec vitest run --browser.enabled=true --browser.headless=true tests/src/core/audio`：2 文件、36 项通过。
- 更新原先强制 Promise 合并的测试，覆盖首次恢复仍 pending 时第二次恢复必须触达原生 API，以及前台恢复 pending 时后续手势仍可重试。
- 严格 `--autoplay-policy=document-user-activation-required` 浏览器复现：先用无 userGesture 的 CDP 调用发起 resume，再真实鼠标点击。旧缓存逻辑仍 suspended/time=0/pendingPlay=true；修复后 running、BGM 播放，输出 RMS=0.00555，页面错误为 0。

## 边界

- iOS/Safari 真机、电话中断与真人听感未在本次验证中覆盖，不宣称全设备 PASS。
- 游戏的实验版依赖接入与游戏侧临时解锁逻辑不属于这个 Engine PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Audio resume attempts can now be retried while an earlier recovery attempt is still pending.
  - Gesture-triggered retries proceed independently instead of being merged with pending automatic recovery attempts.
  - Playback blocked by autoplay restrictions is correctly dropped during the audio lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->