### PR TITLE
docs(engine): clarify primitive orientation contracts

### DIFF
--- a/packages/core/src/mesh/PrimitiveMesh.ts
+++ b/packages/core/src/mesh/PrimitiveMesh.ts
@@ -113,11 +113,10 @@ export class PrimitiveMesh {
   }
 
   /**
-   * Create a plane mesh.
-   * U increases along local +X (width), and V along local +Z (height).
+   * Create a plane mesh with U mapped along local +X and V along local +Z.
    * @param engine - Engine
-   * @param width - Plane width
-   * @param height - Plane height
+   * @param width - Plane width along the local X axis
+   * @param height - Plane height along the local Z axis
    * @param horizontalSegments - Plane horizontal segments
    * @param verticalSegments - Plane vertical segments
    * @param noLongerAccessible - No longer access the vertices of the mesh after creation

--- a/packages/core/src/mesh/PrimitiveMesh.ts
+++ b/packages/core/src/mesh/PrimitiveMesh.ts
@@ -114,6 +114,7 @@ export class PrimitiveMesh {
 
   /**
    * Create a plane mesh.
+   * U increases along local +X (width), and V along local +Z (height).
    * @param engine - Engine
    * @param width - Plane width
    * @param height - Plane height

--- a/packages/galacean/skills/engine-knowledge/SKILL.md
+++ b/packages/galacean/skills/engine-knowledge/SKILL.md
@@ -21,7 +21,7 @@ This Skill does not define how a host creates, serializes, builds, or publishes 
 - For handedness, forward direction, transform composition, Euler order, and screen or viewport spaces, read [coordinates-and-space.md](references/coordinates-and-space.md).
 - For Script activation and frame ordering, read [lifecycle-and-frame-order.md](references/lifecycle-and-frame-order.md).
 - For collider ownership, motion, fixed steps, and callbacks, read [physics-setup.md](references/physics-setup.md).
-- For built-in mesh dimensions, orientation, and Plane UV basis, read [primitive-geometry.md](references/primitive-geometry.md).
+- For built-in mesh dimensions and orientation, read [primitive-geometry.md](references/primitive-geometry.md).
 - For cloning, reference counts, garbage collection, and shared resources, read [resource-ownership.md](references/resource-ownership.md).
 - For material sharing, color-space intent, multi-camera composition, SpriteMask targets, and final output, read [rendering-and-color.md](references/rendering-and-color.md).
 - For physics-backed picking, shadows, skyboxes, per-renderer normal maps, draw-ready custom meshes, or local post-process volumes, read [runtime-recipes.md](references/runtime-recipes.md).

--- a/packages/galacean/skills/engine-knowledge/SKILL.md
+++ b/packages/galacean/skills/engine-knowledge/SKILL.md
@@ -18,10 +18,10 @@ This Skill does not define how a host creates, serializes, builds, or publishes 
 
 ## References
 
-- For handedness, forward direction, and screen or viewport spaces, read [coordinates-and-space.md](references/coordinates-and-space.md).
+- For handedness, forward direction, Euler composition, hierarchy rotation, and screen or viewport spaces, read [coordinates-and-space.md](references/coordinates-and-space.md).
 - For Script activation and frame ordering, read [lifecycle-and-frame-order.md](references/lifecycle-and-frame-order.md).
 - For collider ownership, motion, fixed steps, and callbacks, read [physics-setup.md](references/physics-setup.md).
-- For built-in mesh dimensions and orientation, read [primitive-geometry.md](references/primitive-geometry.md).
+- For built-in mesh dimensions, orientation, and Plane UV basis, read [primitive-geometry.md](references/primitive-geometry.md).
 - For cloning, reference counts, garbage collection, and shared resources, read [resource-ownership.md](references/resource-ownership.md).
 - For material sharing, color-space intent, multi-camera composition, SpriteMask targets, and final output, read [rendering-and-color.md](references/rendering-and-color.md).
 - For physics-backed picking, shadows, skyboxes, per-renderer normal maps, draw-ready custom meshes, or local post-process volumes, read [runtime-recipes.md](references/runtime-recipes.md).

--- a/packages/galacean/skills/engine-knowledge/SKILL.md
+++ b/packages/galacean/skills/engine-knowledge/SKILL.md
@@ -18,7 +18,7 @@ This Skill does not define how a host creates, serializes, builds, or publishes 
 
 ## References
 
-- For handedness, forward direction, Euler composition, hierarchy rotation, and screen or viewport spaces, read [coordinates-and-space.md](references/coordinates-and-space.md).
+- For handedness, forward direction, transform composition, Euler order, and screen or viewport spaces, read [coordinates-and-space.md](references/coordinates-and-space.md).
 - For Script activation and frame ordering, read [lifecycle-and-frame-order.md](references/lifecycle-and-frame-order.md).
 - For collider ownership, motion, fixed steps, and callbacks, read [physics-setup.md](references/physics-setup.md).
 - For built-in mesh dimensions, orientation, and Plane UV basis, read [primitive-geometry.md](references/primitive-geometry.md).

--- a/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
+++ b/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
@@ -11,11 +11,8 @@ Use this reference when handedness, direction, or coordinate conversion changes 
 
 ## Transform rotation composition
 
-- Transform Euler properties and `setRotation(x, y, z)` use degrees. `Quaternion.rotationEuler(x, y, z)` uses radians.
-- Euler conversion composes the local quaternion as `Qy * Qx * Qz`, where the terms rotate around local Y, X, and Z respectively. With the Engine's quaternion-vector convention, the rightmost rotation acts first.
-- A child's world rotation is `QparentWorld * Qlocal`. Nested single-axis Transform nodes therefore provide an explicit alternative when a multi-axis orientation is easier to reason about as ordered steps.
-
-Use these contracts to derive orientation-sensitive placement. Do not create disposable runtime entities merely to probe Euler order or parent-child rotation that the Engine already defines.
+- Local Euler rotation composes as `Qy * Qx * Qz`; when applied to a vector, the rightmost axis rotation acts first.
+- A child's world rotation is `QparentWorld * Qlocal`.
 
 ## Screen and viewport spaces
 

--- a/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
+++ b/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
@@ -9,10 +9,12 @@ Use this reference when handedness, direction, or coordinate conversion changes 
 - Local space is relative to an Entity's parent. World space is the shared comparison space; convert values before comparing or combining positions and directions from different parents.
 - Positive rotation follows the Engine's right-handed convention. Do not copy signs from a left-handed `+Z`-forward engine without converting them.
 
-## Transform rotation composition
+## Transform composition conventions
 
-- Local Euler rotation composes as `Qy * Qx * Qz`; when applied to a vector, the rightmost axis rotation acts first.
-- A child's world rotation is `QparentWorld * Qlocal`.
+- Matrices use column vectors: `v' = M * v`.
+- Hierarchy composition is `world = parentWorld * local` for transform matrices and rotation quaternions.
+- Transform applies local rotation increments by post-multiplication (`Qlocal * deltaLocal`) and world rotation increments by pre-multiplication (`deltaWorld * Qworld`).
+- Euler rotation uses intrinsic Y-X-Z order (`Qy * Qx * Qz`).
 
 ## Screen and viewport spaces
 

--- a/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
+++ b/packages/galacean/skills/engine-knowledge/references/coordinates-and-space.md
@@ -9,6 +9,14 @@ Use this reference when handedness, direction, or coordinate conversion changes 
 - Local space is relative to an Entity's parent. World space is the shared comparison space; convert values before comparing or combining positions and directions from different parents.
 - Positive rotation follows the Engine's right-handed convention. Do not copy signs from a left-handed `+Z`-forward engine without converting them.
 
+## Transform rotation composition
+
+- Transform Euler properties and `setRotation(x, y, z)` use degrees. `Quaternion.rotationEuler(x, y, z)` uses radians.
+- Euler conversion composes the local quaternion as `Qy * Qx * Qz`, where the terms rotate around local Y, X, and Z respectively. With the Engine's quaternion-vector convention, the rightmost rotation acts first.
+- A child's world rotation is `QparentWorld * Qlocal`. Nested single-axis Transform nodes therefore provide an explicit alternative when a multi-axis orientation is easier to reason about as ordered steps.
+
+Use these contracts to derive orientation-sensitive placement. Do not create disposable runtime entities merely to probe Euler order or parent-child rotation that the Engine already defines.
+
 ## Screen and viewport spaces
 
 - Screen space uses canvas pixels with `(0, 0)` at the top-left. X increases rightward and Y increases downward.

--- a/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
+++ b/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
@@ -15,10 +15,20 @@ The table describes meshes created with omitted size arguments and an entity sca
 | Capsule            | radius 0.5, cylindrical height 2, total height 3 | centered on Y                |
 | Torus              | major radius 0.5, tube radius 0.1                | lies in XY around the Z axis |
 
+## Plane local basis and UVs
+
+`PrimitiveMesh.createPlane` emits positions in local XZ, normals along local `+Y`, and UVs over the same basis:
+
+- `width` spans local `-X` to `+X`; U increases toward local `+X`.
+- `height` spans local `-Z` to `+Z`; V increases toward local `+Z`.
+
+These directions describe the mesh data itself. Texture upload or asset-import settings remain responsible for any image-row flip; do not infer those settings from the Plane geometry.
+
 ## Placement consequences
 
 - A centered primitive rests on a horizontal surface when its center is raised by its scaled half-height.
 - A default Plane is already horizontal; rotating it as if it were an XY plane changes the intended ground orientation.
+- Derive orientation-sensitive Plane placement from the local normal and UV basis above. Do not create disposable runtime entities merely to rediscover these built-in mesh conventions.
 - Capsule `height` describes the cylindrical section between hemisphere centers. Total vertical extent also includes both hemispherical radii.
 - Non-uniform entity scale changes the rendered bounds after mesh construction. Do not assume one scalar radius still describes the world-space result.
 

--- a/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
+++ b/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
@@ -15,20 +15,16 @@ The table describes meshes created with omitted size arguments and an entity sca
 | Capsule            | radius 0.5, cylindrical height 2, total height 3 | centered on Y                |
 | Torus              | major radius 0.5, tube radius 0.1                | lies in XY around the Z axis |
 
-## Plane local basis and UVs
+## Plane UV basis
 
-`PrimitiveMesh.createPlane` emits positions in local XZ, normals along local `+Y`, and UVs over the same basis:
+`PrimitiveMesh.createPlane` maps U along local `+X` (`width`) and V along local `+Z` (`height`).
 
-- `width` spans local `-X` to `+X`; U increases toward local `+X`.
-- `height` spans local `-Z` to `+Z`; V increases toward local `+Z`.
-
-These directions describe the mesh data itself. Texture upload or asset-import settings remain responsible for any image-row flip; do not infer those settings from the Plane geometry.
+Texture upload or asset-import settings determine image-row flips independently of this mesh UV basis.
 
 ## Placement consequences
 
 - A centered primitive rests on a horizontal surface when its center is raised by its scaled half-height.
 - A default Plane is already horizontal; rotating it as if it were an XY plane changes the intended ground orientation.
-- Derive orientation-sensitive Plane placement from the local normal and UV basis above. Do not create disposable runtime entities merely to rediscover these built-in mesh conventions.
 - Capsule `height` describes the cylindrical section between hemisphere centers. Total vertical extent also includes both hemispherical radii.
 - Non-uniform entity scale changes the rendered bounds after mesh construction. Do not assume one scalar radius still describes the world-space result.
 

--- a/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
+++ b/packages/galacean/skills/engine-knowledge/references/primitive-geometry.md
@@ -15,12 +15,6 @@ The table describes meshes created with omitted size arguments and an entity sca
 | Capsule            | radius 0.5, cylindrical height 2, total height 3 | centered on Y                |
 | Torus              | major radius 0.5, tube radius 0.1                | lies in XY around the Z axis |
 
-## Plane UV basis
-
-`PrimitiveMesh.createPlane` maps U along local `+X` (`width`) and V along local `+Z` (`height`).
-
-Texture upload or asset-import settings determine image-row flips independently of this mesh UV basis.
-
 ## Placement consequences
 
 - A centered primitive rests on a horizontal surface when its center is raised by its scaled half-height.


### PR DESCRIPTION
## 结论

补齐 Engine 已确定的 Plane 局部坐标、UV 基准和 Transform 旋转组合合同，避免 Agent 为构造方向敏感的几何体重复查询 API、创建临时实体和运行矩阵探测。

真实 3D 骰子施工中，Worker 定向读取更新后的 Engine Skill 后，直接确认 Plane 位于 XZ、法线朝 `+Y`，推导六个数字面的旋转并进入 Prefab 施工；未再创建临时实体或运行额外矩阵探测。相关决策窗口由旧样本约 14 分钟收敛到新样本约 3 分半。该对比用于证明行为方向生效，不将全部时间差严格归因于本 PR。

## 问题

现有 Engine Skill 只说明右手坐标系、Y-up 和 Plane 位于 XZ 平面并朝 `+Y`，但缺少：

- Plane 的本地 U/V 方向；
- Transform Euler 与 Quaternion API 的角度单位差异；
- Euler 组合顺序；
- 父子 Transform 的世界旋转组合关系。

这些都是 Engine 已经确定的事实。缺失时，Agent 会把它们当作施工前阻塞事实，通过 Engine API、资产回读、临时实体和本地矩阵脚本反复验证。

## 改动

- 在 `primitive-geometry.md` 中补充 Plane 的局部法线与 UV 基准：U 沿 `+X`，V 沿 `+Z`。
- 在 `coordinates-and-space.md` 中补充 Euler/Quaternion 单位、`Qy * Qx * Qz` 组合及父子旋转合同。
- 更新 Engine Skill 的 reference 路由，使方向和 UV 问题能定向命中对应文档。
- 明确这些确定性合同不需要通过一次性运行时实体重新探测。

本 PR 只补充 Engine 权威知识，不规定 Editor 施工方案，也不加入具体游戏的 case-by-case 规则。

## 验证

- `git diff --check` 通过。
- 修改后真实运行：`5c714ea0-8d93-4325-ac0a-a4bb57ff76dd`。
- 对照运行：`61e7db30-2846-4f38-8a9b-34d7f6fcc0e0`。
- 通用 Skill 校验脚本因本机缺少 Python `yaml` 依赖未运行；本 PR 未新增脚本或 Schema。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded coordinate and space references to cover transform composition and Euler rotation order.
  - Clarified matrix, hierarchy, quaternion, and Euler rotation composition conventions.
  - Documented plane UV directions: U increases along local +X, and V along local +Z.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->