### PR TITLE
fix(ui): invalidate overlay canvas sorting when sortOrder changes

### DIFF
--- a/packages/ui/src/component/UICanvas.ts
+++ b/packages/ui/src/component/UICanvas.ts
@@ -214,7 +214,7 @@ export class UICanvas extends Component implements IElement, ICloneHook<UICanvas
       this._sortOrder = value;
       this._realRenderMode === CanvasRenderMode.ScreenSpaceOverlay &&
         // @ts-ignore
-        (this.scene._componentsManager._overlayCanvasesSortingFlag = true);
+        (this.scene._componentsManager._overlayCanvasesSortingDirty = true);
     }
   }
 

--- a/tests/src/ui/UICanvas.test.ts
+++ b/tests/src/ui/UICanvas.test.ts
@@ -70,6 +70,31 @@ describe("UICanvas", async () => {
     expect(rootCanvas.distance).to.eq(50);
   });
 
+  it("Resort overlay canvases after sort order changes", () => {
+    const lowerEntity = scene.createRootEntity("lowerCanvas");
+    const lowerCanvas = lowerEntity.addComponent(UICanvas);
+    lowerCanvas.renderMode = CanvasRenderMode.ScreenSpaceOverlay;
+    lowerCanvas.sortOrder = 1;
+
+    const upperEntity = scene.createRootEntity("upperCanvas");
+    const upperCanvas = upperEntity.addComponent(UICanvas);
+    upperCanvas.renderMode = CanvasRenderMode.ScreenSpaceOverlay;
+    upperCanvas.sortOrder = 2;
+
+    const componentsManager = scene._componentsManager;
+    componentsManager.sortOverlayUICanvases();
+    // @ts-ignore
+    expect(lowerCanvas._canvasIndex).to.be.lessThan(upperCanvas._canvasIndex);
+
+    lowerCanvas.sortOrder = 3;
+    componentsManager.sortOverlayUICanvases();
+    // @ts-ignore
+    expect(lowerCanvas._canvasIndex).to.be.greaterThan(upperCanvas._canvasIndex);
+
+    lowerEntity.destroy();
+    upperEntity.destroy();
+  });
+
   // Is Root Canvas
   it("Is root canvas", () => {
     // @ts-ignore


### PR DESCRIPTION
## 问题

`UICanvas.sortOrder` 的 setter 给一个**不存在的成员**赋值：

```ts
this._realRenderMode === CanvasRenderMode.ScreenSpaceOverlay &&
  // @ts-ignore
  (this.scene._componentsManager._overlayCanvasesSortingFlag = true);   // ← 该成员不存在
```

`ComponentsManager` 记录的脏标记实际叫 `_overlayCanvasesSortingDirty`（`packages/core/src/ComponentsManager.ts:23`），它由 `addUICanvas` / `removeUICanvas` 置位，并只在 `sortOverlayUICanvases()` 中消费与清除。那行 `@ts-ignore` 让拼写错误完全无声：内部成员被 `stripInternal` 从发布声明中剥离，所以类型检查本来也发现不了它（该问题正由 #3105 一并处理）。

## 影响

`Engine._render` 每帧在 `UIUtils.renderOverlay()` 之前调用 `sortOverlayUICanvases()`，但它只在脏标记为真时才真正重排。因此在**已处于 `ScreenSpaceOverlay` 模式**的画布上修改 `sortOrder`：

- 脏标记保持为假，重排被跳过；
- `_canvasIndex` 维持旧值，渲染顺序与 Overlay 命中顺序都继续使用过期顺序；
- 直到某个无关的画布增删（或引擎停机重建）才顺带纠正。

## 修复

仅改为给正确的成员赋值。`@ts-ignore` 暂时保留，因为 `_overlayCanvasesSortingDirty` 目前仍是 `@internal`、不在本分支编译所用的声明中；#3105 合并后可以删除（见下方说明）。

## 测试

新增用例创建两块 Overlay 画布（`sortOrder` 为 1 和 2），排序后断言索引递增，再把较低者的 `sortOrder` 改为 3 并重新排序，断言其索引变大。修复前该断言失败（`expected +0 to be above 1`），修复后通过。

## 验证

`tests/src/ui/UICanvas.test.ts`：

| 场景 | 结果 |
|---|---|
| 修复源码（`@galacean/engine-ui` 解析到 `packages/ui/src`） | **7 / 7 通过** |
| 未修复实现（同一用例，解析到修复前的产物） | **1 失败**：`expected +0 to be above 1` |

`tests/src/ui/` 全量：**69 / 69 通过**。

## 与 #3105 的关系

本 PR 是从 #3105 中拆出的**行为修复**部分；#3105 剩下的是声明契约修复（`stripInternal`）。两者可以独立合入，互不依赖：

- 本 PR 在 #3105 之前合入：可行，`@ts-ignore` 保留。
- 本 PR 在 #3105 之后合入：`UICanvas.ts` 与测试中的 `@ts-ignore` 可以一并删除，因为届时 `_overlayCanvasesSortingDirty` 与 `_canvasIndex` 都已出现在声明中。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed screen-space overlay canvases so their display order updates correctly after changing sort order.

- **Tests**
  - Added coverage verifying that overlay canvases are reordered when their sort order changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->